### PR TITLE
Fix remaining tests

### DIFF
--- a/packages/data/src/queries/currentUser/test/useCurrentUser.test.ts
+++ b/packages/data/src/queries/currentUser/test/useCurrentUser.test.ts
@@ -2,40 +2,39 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useCurrentUser } from '..';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
-import { useCacheRehydration } from '@eventespresso/edtr-services';
-import { currentUser } from './data';
+import { currentUser, successMocks } from './data';
+import useInitCurrentUserTestCache from './useInitCurrentUserTestCache';
 
-const timeout = 5000; // milliseconds
 describe('useCurrentUser', () => {
-	const wrapper = ApolloMockedProvider();
 	it('checks for the current user when the cache is empty', async () => {
+		const wrapper = ApolloMockedProvider([], false);
 		const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
 		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for the current user when the cache is NOT empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const wrapper = ApolloMockedProvider(successMocks, false);
+		const { result } = renderHook(
 			() => {
-				useCacheRehydration();
+				useInitCurrentUserTestCache();
 				return useCurrentUser();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
 
 		expect(result.current).toBeDefined();
 	});
 
 	it('checks for current user props', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const wrapper = ApolloMockedProvider(successMocks, false);
+		const { result } = renderHook(
 			() => {
-				useCacheRehydration();
+				useInitCurrentUserTestCache();
 				return useCurrentUser();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
 
 		const { current: cachedUser } = result;
 

--- a/packages/data/src/queries/currentUser/test/useFetchCurrentUser.test.ts
+++ b/packages/data/src/queries/currentUser/test/useFetchCurrentUser.test.ts
@@ -7,7 +7,7 @@ import { successMocks, errorMocks, currentUser } from './data';
 const timeout = 5000; // milliseconds
 describe('useFetchCurrentUser', () => {
 	it('checks for the error state', async () => {
-		const wrapper = ApolloMockedProvider(errorMocks);
+		const wrapper = ApolloMockedProvider(errorMocks, false);
 
 		const { result, waitForNextUpdate } = renderHook(() => useFetchCurrentUser(), {
 			wrapper,
@@ -23,7 +23,7 @@ describe('useFetchCurrentUser', () => {
 	});
 
 	it('checks for the loading state', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
 		const { result, waitForNextUpdate } = renderHook(() => useFetchCurrentUser(), {
 			wrapper,
@@ -37,16 +37,11 @@ describe('useFetchCurrentUser', () => {
 	});
 
 	it('checks for the response data', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
-		const { result, waitForNextUpdate } = renderHook(() => useFetchCurrentUser(), {
+		const { result } = renderHook(() => useFetchCurrentUser(), {
 			wrapper,
 		});
-
-		expect(result.current.error).toBeUndefined();
-		expect(result.current.data).toBeUndefined();
-
-		await waitForNextUpdate({ timeout }); // wait for response
 
 		// Data is already written above
 		expect(result.current.data).toBeDefined();
@@ -54,13 +49,11 @@ describe('useFetchCurrentUser', () => {
 	});
 
 	it('checks for the entries in response data', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
-		const { result, waitForNextUpdate } = renderHook(() => useFetchCurrentUser(), {
+		const { result } = renderHook(() => useFetchCurrentUser(), {
 			wrapper,
 		});
-
-		await waitForNextUpdate({ timeout }); // wait for response
 
 		expect(result.current.data).toHaveProperty('viewer');
 

--- a/packages/data/src/queries/currentUser/test/useInitCurrentUserTestCache.ts
+++ b/packages/data/src/queries/currentUser/test/useInitCurrentUserTestCache.ts
@@ -1,0 +1,25 @@
+import { WriteQueryOptions, useApolloClient } from '@eventespresso/data';
+import type { Viewer } from '@eventespresso/services';
+
+import useCurrentUserQueryOptions from '../useCurrentUserQueryOptions';
+import { currentUser } from './data';
+
+const useInitCurrentUserTestCache = (viewer = currentUser): void => {
+	// init hooks
+	const client = useApolloClient();
+	const queryOptions = useCurrentUserQueryOptions();
+
+	const writeQueryOptions: WriteQueryOptions<Viewer> = {
+		...queryOptions,
+		data: {
+			viewer,
+		},
+	};
+	try {
+		// write the test data to cache
+		client.writeQuery(writeQueryOptions);
+	} catch (error) {
+		console.error(error);
+	}
+};
+export default useInitCurrentUserTestCache;

--- a/packages/data/src/queries/currentUser/useCurrentUser.ts
+++ b/packages/data/src/queries/currentUser/useCurrentUser.ts
@@ -1,17 +1,15 @@
-import { GET_CURRENT_USER } from '.';
-import { useCacheQuery, ReadQueryOptions } from '../';
+import { useCacheQuery } from '../';
 import type { CurrentUserProps, Viewer } from '@eventespresso/services';
+import useCurrentUserQueryOptions from './useCurrentUserQueryOptions';
 
 /**
  * A custom react hook for retrieving CurrentUser
  */
 const useCurrentUser = (): CurrentUserProps => {
-  const options: ReadQueryOptions = {
-    query: GET_CURRENT_USER,
-  };
-  const { data } = useCacheQuery<Viewer>(options);
+	const options = useCurrentUserQueryOptions();
+	const { data } = useCacheQuery<Viewer>(options);
 
-  return data?.viewer;
+	return data?.viewer;
 };
 
 export default useCurrentUser;

--- a/packages/data/src/queries/generalSettings/test/useFetchGeneralSettings.test.ts
+++ b/packages/data/src/queries/generalSettings/test/useFetchGeneralSettings.test.ts
@@ -7,7 +7,7 @@ import { successMocks, errorMocks, generalSettings } from './data';
 const timeout = 5000; // milliseconds
 describe('useFetchGeneralSettings', () => {
 	it('checks for the error state', async () => {
-		const wrapper = ApolloMockedProvider(errorMocks);
+		const wrapper = ApolloMockedProvider(errorMocks, false);
 
 		const { result, waitForNextUpdate } = renderHook(() => useFetchGeneralSettings(), {
 			wrapper,
@@ -23,7 +23,7 @@ describe('useFetchGeneralSettings', () => {
 	});
 
 	it('checks for the loading state', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
 		const { result, waitForNextUpdate } = renderHook(() => useFetchGeneralSettings(), {
 			wrapper,
@@ -37,16 +37,11 @@ describe('useFetchGeneralSettings', () => {
 	});
 
 	it('checks for the response data', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
-		const { result, waitForNextUpdate } = renderHook(() => useFetchGeneralSettings(), {
+		const { result } = renderHook(() => useFetchGeneralSettings(), {
 			wrapper,
 		});
-
-		expect(result.current.error).toBeUndefined();
-		expect(result.current.data).toBeUndefined();
-
-		await waitForNextUpdate({ timeout }); // wait for response
 
 		// Data is already written above
 		expect(result.current.data).toBeDefined();
@@ -54,13 +49,11 @@ describe('useFetchGeneralSettings', () => {
 	});
 
 	it('checks for the entries in response data', async () => {
-		const wrapper = ApolloMockedProvider(successMocks);
+		const wrapper = ApolloMockedProvider(successMocks, false);
 
-		const { result, waitForNextUpdate } = renderHook(() => useFetchGeneralSettings(), {
+		const { result } = renderHook(() => useFetchGeneralSettings(), {
 			wrapper,
 		});
-
-		await waitForNextUpdate({ timeout }); // wait for response
 
 		expect(result.current.data).toHaveProperty('generalSettings');
 

--- a/packages/data/src/queries/generalSettings/test/useGeneralSettings.test.ts
+++ b/packages/data/src/queries/generalSettings/test/useGeneralSettings.test.ts
@@ -2,40 +2,39 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useGeneralSettings } from '..';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
-import { useCacheRehydration } from '@eventespresso/edtr-services';
-import { generalSettings } from './data';
+import { generalSettings, successMocks } from './data';
+import useInitGeneralSettingsTestCache from './useInitGeneralSettingsTestCache';
 
-const timeout = 5000; // milliseconds
 describe('useGeneralSettings', () => {
-	const wrapper = ApolloMockedProvider();
-	it('checks for the current user when the cache is empty', () => {
+	it('checks for the general settings when the cache is empty', () => {
+		const wrapper = ApolloMockedProvider([], false);
 		const { result } = renderHook(() => useGeneralSettings(), { wrapper });
 
 		expect(result.current).toBe(undefined);
 	});
 
-	it('checks for the current user when the cache is NOT empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+	it('checks for the general settings when the cache is NOT empty', async () => {
+		const wrapper = ApolloMockedProvider(successMocks, false);
+		const { result } = renderHook(
 			() => {
-				useCacheRehydration();
+				useInitGeneralSettingsTestCache();
 				return useGeneralSettings();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
 
 		expect(result.current).toBeDefined();
 	});
 
-	it('checks for current user props', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+	it('checks for general settings props', async () => {
+		const wrapper = ApolloMockedProvider(successMocks, false);
+		const { result } = renderHook(
 			() => {
-				useCacheRehydration();
+				useInitGeneralSettingsTestCache();
 				return useGeneralSettings();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
 
 		const { current: cachedSettings } = result;
 

--- a/packages/data/src/queries/generalSettings/test/useInitGeneralSettingsTestCache.ts
+++ b/packages/data/src/queries/generalSettings/test/useInitGeneralSettingsTestCache.ts
@@ -1,0 +1,25 @@
+import { WriteQueryOptions, useApolloClient } from '@eventespresso/data';
+import type { GeneralSettingsData } from '@eventespresso/services';
+
+import useGeneralSettingsQueryOptions from '../useGeneralSettingsQueryOptions';
+import { generalSettings as mockedGeneralSettings } from './data';
+
+const useInitGeneralSettingsTestCache = (generalSettings = mockedGeneralSettings): void => {
+	// init hooks
+	const client = useApolloClient();
+	const queryOptions = useGeneralSettingsQueryOptions();
+
+	const writeQueryOptions: WriteQueryOptions<GeneralSettingsData> = {
+		...queryOptions,
+		data: {
+			generalSettings,
+		},
+	};
+	try {
+		// write the test data to cache
+		client.writeQuery(writeQueryOptions);
+	} catch (error) {
+		console.error(error);
+	}
+};
+export default useInitGeneralSettingsTestCache;

--- a/packages/data/src/queries/generalSettings/useGeneralSettings.ts
+++ b/packages/data/src/queries/generalSettings/useGeneralSettings.ts
@@ -1,16 +1,14 @@
-import { GET_GENERAL_SETTINGS } from '.';
-import { useCacheQuery, ReadQueryOptions } from '../';
+import { useCacheQuery } from '../';
 import { GeneralSettings, GeneralSettingsData } from '@eventespresso/services';
+import useGeneralSettingsQueryOptions from './useGeneralSettingsQueryOptions';
 /**
  * A custom react hook for retrieving GeneralSettings
  */
 const useGeneralSettings = (): GeneralSettings => {
-  const options: ReadQueryOptions = {
-    query: GET_GENERAL_SETTINGS,
-  };
-  const { data } = useCacheQuery<GeneralSettingsData>(options);
+	const options = useGeneralSettingsQueryOptions();
+	const { data } = useCacheQuery<GeneralSettingsData>(options);
 
-  return data?.generalSettings;
+	return data?.generalSettings;
 };
 
 export default useGeneralSettings;

--- a/packages/edtr-services/src/context/test/TestContextProviders.tsx
+++ b/packages/edtr-services/src/context/test/TestContextProviders.tsx
@@ -3,21 +3,25 @@ import { MockedProvider } from '@apollo/react-testing';
 
 import { cache } from '@eventespresso/data';
 
-import { ServiceProvider as CommonProviders } from '../ContextProvider';
+import { ServiceProvider } from '../ContextProvider';
 import { useDomTestData, useResetApolloCache, useSetGlobalStatusFlags, useSetRelationalData } from './';
 import type { MockedResponse } from './types';
 
 /**
  * A top level provider wrapped by Apollo MockedProvider.
  *
- * @param {ReactElement} children The element that should be wrapped.
- * @returns {ReactElement} The wrapped element.
+ * @param {mocks} The mocked responses for Apollo
+ * @param {addServiceProviders} Whether to add service contexts. Pass false to test in isolation
+ * @returns {React.FC} The provider component
  */
-export const ApolloMockedProvider = (mocks: ReadonlyArray<MockedResponse> = []): React.FC => {
+export const ApolloMockedProvider = (
+	mocks: ReadonlyArray<MockedResponse> = [],
+	addServiceProviders = true
+): React.FC => {
 	const Provider: React.FC = ({ children }) => {
 		return (
 			<MockedProvider mocks={mocks} cache={cache}>
-				<ApolloAwareWrapper>{children}</ApolloAwareWrapper>
+				{addServiceProviders ? <ApolloAwareWrapper>{children}</ApolloAwareWrapper> : <>{children}</>}
 			</MockedProvider>
 		);
 	};
@@ -25,7 +29,7 @@ export const ApolloMockedProvider = (mocks: ReadonlyArray<MockedResponse> = []):
 };
 
 /**
- * A mid level provider wrapped by CommonProviders.
+ * A mid level provider wrapped by ServiceProvider.
  * It sets the DOM data and handles Apollo cache reset.
  *
  * @param {ReactElement} children The element that should be wrapped.
@@ -37,9 +41,9 @@ export const ApolloAwareWrapper: React.FC = ({ children }) => {
 	// clear Apollo cache on unmount
 	useResetApolloCache();
 	return (
-		<CommonProviders>
+		<ServiceProvider>
 			<ContextAwareWrapper>{children}</ContextAwareWrapper>
-		</CommonProviders>
+		</ServiceProvider>
 	);
 };
 


### PR DESCRIPTION
This PR:
- Updates `useCurrentUser` and `useGeneralSettings` hooks to use query option hooks
- Creates test cache init hooks for tests
- Updates `TestContextProviders` to allow tests in isolation
- Fixes tests for current user and general settings

Closes #39 