### PR TITLE
Intial initial fetch before rehydration

### DIFF
--- a/domains/rem/src/services/apollo/initialization/useCacheRehydration.ts
+++ b/domains/rem/src/services/apollo/initialization/useCacheRehydration.ts
@@ -8,7 +8,10 @@ import { getGuids } from '@eventespresso/predicates';
 import { useDatetimes } from '@eventespresso/edtr-services';
 import { assocPath } from 'ramda';
 
-const useCacheRehydration = (): void => {
+/**
+ * Returns true if the cache has been rehydrated, false otherwise
+ */
+const useCacheRehydration = (): boolean => {
 	const { getData: getRelationalData, initialize, isInitialized } = useRelations();
 
 	const { recurrences: espressoRecurrences = DEFAULT_RECURRENCE_LIST_DATA, relations } = useCacheRehydrationData();
@@ -65,6 +68,8 @@ const useCacheRehydration = (): void => {
 		relations,
 		updateRecurrenceList,
 	]);
+
+	return initialized.current;
 };
 
 export default useCacheRehydration;

--- a/domains/rem/src/services/apollo/initialization/useInitQueries.ts
+++ b/domains/rem/src/services/apollo/initialization/useInitQueries.ts
@@ -2,10 +2,10 @@ import { useFetchRecurrences } from '../queries';
 import useCacheRehydration from './useCacheRehydration';
 
 const useInitQueries = (): void => {
-	useCacheRehydration();
+	const rehydrated = useCacheRehydration();
 
 	// initiate datetime fetching.
-	useFetchRecurrences();
+	useFetchRecurrences({ skip: !rehydrated }); // skip until the cache has not been rehydrated
 };
 
 export default useInitQueries;

--- a/domains/rem/src/services/apollo/queries/recurrences/useFetchRecurrences.ts
+++ b/domains/rem/src/services/apollo/queries/recurrences/useFetchRecurrences.ts
@@ -2,11 +2,11 @@ import { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { useSystemNotifications } from '@eventespresso/toaster';
-import useRecurrenceQueryOptions from './useRecurrenceQueryOptions';
+import useRecurrenceQueryOptions, { RecurrencesQueryOptions } from './useRecurrenceQueryOptions';
 import { FetchQueryResult, useQuery } from '@eventespresso/data';
 import type { RecurrencesList } from '../../types';
 
-const useFetchRecurrences = (): FetchQueryResult<RecurrencesList> => {
+const useFetchRecurrences = (queryOptions?: Partial<RecurrencesQueryOptions>): FetchQueryResult<RecurrencesList> => {
 	const { query, ...options } = useRecurrenceQueryOptions();
 
 	const toaster = useSystemNotifications();
@@ -16,6 +16,7 @@ const useFetchRecurrences = (): FetchQueryResult<RecurrencesList> => {
 
 	const { loading, ...result } = useQuery<RecurrencesList>(query, {
 		...options,
+		...queryOptions, // priority to passed options
 		onCompleted: (): void => {
 			dismissLoading();
 			toastId.current = toaster.success({ message: __('recurrences initialized') });

--- a/domains/rem/src/services/apollo/queries/recurrences/useRecurrenceQueryOptions.ts
+++ b/domains/rem/src/services/apollo/queries/recurrences/useRecurrenceQueryOptions.ts
@@ -6,7 +6,7 @@ import { RecurrenceEdge } from '../../types';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { useDatetimeIds } from '@eventespresso/edtr-services';
 
-type RecurrencesQueryOptions = ReadQueryOptions<RecurrencesList<RecurrenceEdge>, RecurrencesQueryArgs>;
+export type RecurrencesQueryOptions = ReadQueryOptions<RecurrencesList<RecurrenceEdge>, RecurrencesQueryArgs>;
 
 const useRecurrenceQueryOptions = (datetimeIn: EntityId[] = []): RecurrencesQueryOptions => {
 	const datetimeIds = useDatetimeIds();


### PR DESCRIPTION
This PR fixes the issue of initial fetch queries getting called before the store is rehydrated.