### PR TITLE
Wire up TPC for REM

### DIFF
--- a/domains/rem/src/data/types.ts
+++ b/domains/rem/src/data/types.ts
@@ -1,8 +1,13 @@
 import type { Reducer, ReducerState } from 'react';
 
 import type { DatetimeBaseInput, Ticket } from '@eventespresso/edtr-services';
-import { AnyObject } from '@eventespresso/services';
-import { EntityId } from '@eventespresso/data';
+import type { AnyObject } from '@eventespresso/services';
+import type { EntityId } from '@eventespresso/data';
+import type { TpcPriceModifier } from '@eventespresso/tpc';
+
+export interface RemTicket extends Omit<Ticket, 'prices'> {
+	prices?: Array<TpcPriceModifier>;
+}
 
 export interface FormState {
 	dateDetails: DatetimeBaseInput;
@@ -13,7 +18,7 @@ export interface FormState {
 	rRule: string;
 	salesEndOffset?: string;
 	salesStartOffset?: string;
-	tickets: AnyObject<Ticket>;
+	tickets: AnyObject<RemTicket>;
 }
 
 export type DataActionType =
@@ -28,7 +33,7 @@ export type DataActionType =
 export interface DataAction extends Partial<FormState> {
 	type: DataActionType;
 	id?: EntityId;
-	ticket?: Ticket;
+	ticket?: RemTicket;
 }
 
 export type FormStateManagerHook = () => FormStateManager;

--- a/domains/rem/src/ui/Tickets/TicketTemplate.tsx
+++ b/domains/rem/src/ui/Tickets/TicketTemplate.tsx
@@ -18,7 +18,7 @@ interface Props {
 const TicketTemplate: React.FC<Props> = ({ addTicketTemplate, ticketTemplates }) => {
 	const [selectedTicketId, setSelectedTicketId] = useState('');
 
-	// conver Apollo tickets to REM tickets
+	// convert Apollo tickets to REM tickets
 	// This is nothing but o make fool of TS ¯\_(ツ)_/¯
 	const tickets = useTickets().map<RemTicket>(assoc('prices', []));
 

--- a/domains/rem/src/ui/Tickets/TicketTemplate.tsx
+++ b/domains/rem/src/ui/Tickets/TicketTemplate.tsx
@@ -19,7 +19,7 @@ const TicketTemplate: React.FC<Props> = ({ addTicketTemplate, ticketTemplates })
 	const [selectedTicketId, setSelectedTicketId] = useState('');
 
 	// convert Apollo tickets to REM tickets
-	// This is nothing but to make fool of TS ¯\_(ツ)_/¯
+	// This is nothing but to make a fool of TS ¯\_(ツ)_/¯
 	const tickets = useTickets().map<RemTicket>(assoc('prices', []));
 
 	const filteredTickets = ticketTemplates.length

--- a/domains/rem/src/ui/Tickets/TicketTemplate.tsx
+++ b/domains/rem/src/ui/Tickets/TicketTemplate.tsx
@@ -19,7 +19,7 @@ const TicketTemplate: React.FC<Props> = ({ addTicketTemplate, ticketTemplates })
 	const [selectedTicketId, setSelectedTicketId] = useState('');
 
 	// convert Apollo tickets to REM tickets
-	// This is nothing but o make fool of TS ¯\_(ツ)_/¯
+	// This is nothing but to make fool of TS ¯\_(ツ)_/¯
 	const tickets = useTickets().map<RemTicket>(assoc('prices', []));
 
 	const filteredTickets = ticketTemplates.length

--- a/domains/rem/src/ui/Tickets/TicketTemplate.tsx
+++ b/domains/rem/src/ui/Tickets/TicketTemplate.tsx
@@ -1,22 +1,26 @@
 import React, { useState, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
+import { assoc } from 'ramda';
 
-import { Ticket, useTickets } from '@eventespresso/edtr-services';
+import { useTickets } from '@eventespresso/edtr-services';
 import { Button, SelectInput } from '@eventespresso/components';
 import { getGuids, entitiesWithGuIdNotInArray, entitiesWithGuIdInArray } from '@eventespresso/predicates';
 import { entityListToSelectOptions } from '@eventespresso/services';
+import { RemTicket } from '../../data';
 
 import './style.scss';
 
 interface Props {
-	ticketTemplates: Ticket[];
-	addTicketTemplate: (ticket: Ticket) => void;
+	ticketTemplates: RemTicket[];
+	addTicketTemplate: (ticket: RemTicket) => void;
 }
 
 const TicketTemplate: React.FC<Props> = ({ addTicketTemplate, ticketTemplates }) => {
 	const [selectedTicketId, setSelectedTicketId] = useState('');
 
-	const tickets = useTickets();
+	// conver Apollo tickets to REM tickets
+	// This is nothing but o make fool of TS ¯\_(ツ)_/¯
+	const tickets = useTickets().map<RemTicket>(assoc('prices', []));
 
 	const filteredTickets = ticketTemplates.length
 		? entitiesWithGuIdNotInArray(tickets, getGuids(ticketTemplates))

--- a/domains/rem/src/ui/Tickets/multiStep/ContentBody.tsx
+++ b/domains/rem/src/ui/Tickets/multiStep/ContentBody.tsx
@@ -43,11 +43,10 @@ const ContentBody: React.FC = ({ children }) => {
 										isDisabled={isSaveDisabled}
 										onClick={next}
 									/>
-									<Next
+									<Submit
 										buttonText={__('Skip prices - Save')}
 										isDisabled={isSaveDisabled}
 										onClick={form.submit}
-										skippable
 									/>
 								</ButtonRow>
 							</>
@@ -57,7 +56,7 @@ const ContentBody: React.FC = ({ children }) => {
 							<>
 								<TicketPriceCalculator context='editTicketForm' />
 								<ButtonRow rightAligned>
-									<Previous onClick={prev} />
+									<Previous onClick={prev} buttonText={__('Ticket details')} />
 									<Submit
 										onClick={form.submit}
 										isDisabled={isTPCSubmitDisabled}

--- a/domains/rem/src/ui/Tickets/multiStep/types.ts
+++ b/domains/rem/src/ui/Tickets/multiStep/types.ts
@@ -1,12 +1,12 @@
 import type { Disclosure } from '@eventespresso/services';
-import type { Ticket } from '@eventespresso/edtr-services';
 import type { FormRenderProps } from 'react-final-form';
 import type { TicketFormShape } from '../types';
+import { RemTicket } from '../../../data';
 
 export interface ContainerProps extends ContentProps, Omit<Disclosure, 'onOpen'> {}
 
 export interface ContentProps {
-	entity?: Ticket;
+	entity?: RemTicket;
 	onClose: VoidFunction;
 }
 

--- a/domains/rem/src/ui/Tickets/multiStep/useDataListener.ts
+++ b/domains/rem/src/ui/Tickets/multiStep/useDataListener.ts
@@ -3,20 +3,20 @@ import { useForm } from '@eventespresso/form';
 import { pick } from 'ramda';
 
 import { useDataState as useTPCDataState } from '@eventespresso/tpc';
-import { Ticket } from '@eventespresso/edtr-services';
+import { useFormState, RemTicket } from '../../../data';
 
 // The fields that need to be synced from TPC to ticket edit form
 // This is to avoid ticket.name being synced
-const TPC_TICKET_FIELDS_TO_SYNC: Array<keyof Ticket> = ['isTaxable', 'price', 'reverseCalculate'];
+const TPC_TICKET_FIELDS_TO_SYNC: Array<keyof RemTicket> = ['isTaxable', 'price', 'reverseCalculate'];
 
 /**
  * A custom hook which subscribes to TAM and TPC data and updates
  * RFF data when needed.
  */
 const useDataListener: VoidFunction = () => {
-	const { mutators } = useForm();
+	const { mutators, getState } = useForm();
 
-	const { deletedPrices, prices, ticket } = useTPCDataState();
+	const { deletedPrices, prices, ticket, setPrices } = useTPCDataState();
 	useEffect(() => {
 		const fieldsToSync = pick(TPC_TICKET_FIELDS_TO_SYNC, ticket);
 		Object.entries(fieldsToSync).forEach(([key, value]) => {
@@ -26,6 +26,24 @@ const useDataListener: VoidFunction = () => {
 		// duplicate prices in RFF state
 		mutators.updateFieldValue('prices', prices);
 	}, [deletedPrices, mutators, prices, ticket]);
+
+	const { tickets: remTickets } = useFormState();
+	// This effect on mount, feeds prices to TPC from REM form state
+	useEffect(() => {
+		// get the ticket id from RFF form state
+		const ticketId = getState()?.values?.id;
+		// get the ticket from REM form state using the above id
+		const currentTicket = remTickets?.[ticketId];
+		// extract prices already saved in REM form state
+		const prices = currentTicket?.prices;
+
+		// If we are lucky
+		if (currentTicket && prices) {
+			// feed TPC the best peanut butter
+			setPrices(prices);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 };
 
 export default useDataListener;

--- a/domains/rem/src/ui/Tickets/multiStep/useDataListener.ts
+++ b/domains/rem/src/ui/Tickets/multiStep/useDataListener.ts
@@ -38,7 +38,7 @@ const useDataListener: VoidFunction = () => {
 		const prices = currentTicket?.prices;
 
 		// If we are lucky
-		if (currentTicket && prices) {
+		if (prices) {
 			// feed TPC the best peanut butter
 			setPrices(prices);
 		}

--- a/domains/rem/src/ui/Tickets/types.ts
+++ b/domains/rem/src/ui/Tickets/types.ts
@@ -1,8 +1,9 @@
 import type { DateAndTime } from '@eventespresso/edtr-services';
-import type { UpdateTicketInput, Datetime, Ticket } from '@eventespresso/edtr-services';
+import type { UpdateTicketInput, Datetime } from '@eventespresso/edtr-services';
+import { RemTicket } from '../../data';
 
 export interface BaseProps {
-	ticket: Ticket;
+	ticket: RemTicket;
 }
 
 export interface TicketFormShape extends Omit<UpdateTicketInput, 'prices'> {
@@ -17,12 +18,12 @@ export interface TicketFormShape extends Omit<UpdateTicketInput, 'prices'> {
 export interface TicketCardProps {
 	onCopy?: VoidFunction;
 	onTrash?: VoidFunction;
-	ticket: Ticket;
+	ticket: RemTicket;
 }
 
 export interface OffsetProps {
 	datetime: Datetime;
-	ticket: Ticket;
+	ticket: RemTicket;
 }
 
 export interface Offset {

--- a/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
+++ b/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
@@ -4,18 +4,18 @@ import { pick } from 'ramda';
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import type { EspressoFormProps } from '@eventespresso/form';
 import { useMemoStringify } from '@eventespresso/hooks';
-import { Ticket } from '@eventespresso/edtr-services';
 
 import { validate } from './formValidation';
 import { TicketFormShape } from './types';
 import { TICKET_FIELDS_TO_USE } from '../../constants';
+import { RemTicket } from '../../data';
 
 type TicketFormConfig = EspressoFormProps<TicketFormShape>;
 
-const useTicketFormConfig = (ticket?: Ticket, config?: Partial<TicketFormConfig>): TicketFormConfig => {
+const useTicketFormConfig = (ticket?: RemTicket, config?: Partial<TicketFormConfig>): TicketFormConfig => {
 	const initialValues: TicketFormShape = {
 		...config?.initialValues,
-		...pick<Partial<Ticket>, keyof Ticket>(TICKET_FIELDS_TO_USE, ticket || {}),
+		...pick<Partial<RemTicket>, keyof RemTicket>(TICKET_FIELDS_TO_USE, ticket || {}),
 	};
 	const adjacentFormItemProps = useMemoStringify({
 		className: 'ee-form-item-pair',

--- a/packages/tpc/src/hooks/useTicketPriceCalculator.tsx
+++ b/packages/tpc/src/hooks/useTicketPriceCalculator.tsx
@@ -1,9 +1,9 @@
 import { useDisclosure } from '@chakra-ui/hooks';
 
-import { TicketPriceCalculator } from '../types';
+import { TicketPriceCalculatorHook } from '../types';
 import ModalContainer from '../components/ModalContainer';
 
-const useTicketPriceCalculator = (): TicketPriceCalculator => {
+const useTicketPriceCalculator = (): TicketPriceCalculatorHook => {
 	const disclosure = useDisclosure();
 
 	return {

--- a/packages/tpc/src/index.ts
+++ b/packages/tpc/src/index.ts
@@ -4,3 +4,4 @@ export * from './context';
 export * from './data';
 export * from './hooks';
 export * from './utils';
+export * from './types';

--- a/packages/tpc/src/types.ts
+++ b/packages/tpc/src/types.ts
@@ -14,7 +14,7 @@ export interface Disclosure {
 	onClose: VoidFunction;
 }
 
-export interface TicketPriceCalculator extends Disclosure {
+export interface TicketPriceCalculatorHook extends Disclosure {
 	ModalContainer: React.FC<ModalContainerProps>;
 }
 


### PR DESCRIPTION
This PR averts a huge disaster of code changes to TPC and uses the REM context to feed prices to TPC on mount without the need to modify TPC.

Closes #115