### PR TITLE
Fix rrule-generator state bug

### DIFF
--- a/packages/rrule-generator/package.json
+++ b/packages/rrule-generator/package.json
@@ -19,7 +19,8 @@
 		"rrule": "^2.6.4",
 		"date-fns": "^2.14.0",
 		"ramda": "^0.27.0",
-		"react-date-picker": "^8.0.1"
+		"react-date-picker": "^8.0.1",
+		"uuid": "^8.2.0"
 	},
 	"devDependencies": {
 		"@react-workspaces/react-scripts": "3.4.0-alpha-01",
@@ -31,6 +32,7 @@
 		"@types/node": "^14.0.13",
 		"@types/react": "^16.9.38",
 		"@types/react-dom": "^16.9.8",
+		"@types/uuid": "^8.0.0",
 		"@typescript-eslint/eslint-plugin": "^3.3.0",
 		"@typescript-eslint/parser": "^3.3.0",
 		"react-scripts": "3.4.1",

--- a/packages/rrule-generator/src/components/RRuleGenerator.tsx
+++ b/packages/rrule-generator/src/components/RRuleGenerator.tsx
@@ -1,40 +1,20 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
 import Start from './Start';
 import Repeat from './Repeat';
 import End from './End';
-import { computeRRuleFromString, computeRRuleToString } from '../utils';
 import '../styles/index.css';
 import { RRuleGeneratorProps } from './types';
-import { useRRuleConfig, useRRuleState } from '../hooks';
+import { useRRuleState, useStateListener } from '../hooks';
 import { withConfig, withState } from '../context';
 
-const RRuleGenerator: React.FC<RRuleGeneratorProps> = ({
-	hideEnd,
-	hideError,
-	hideStart,
-	id = 'rrule',
-	onChange,
-	value,
-}) => {
-	const { error, getData, setData } = useRRuleState();
-	const config = useRRuleConfig();
+const RRuleGenerator: React.FC<RRuleGeneratorProps> = (props) => {
+	// set up state listener
+	useStateListener(props);
 
-	// Update/Initiate the state from value if it changes
-	useEffect(() => {
-		if (value) {
-			const data = computeRRuleFromString(getData(), value);
-			setData(data);
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value]);
-
-	const rRuleString = computeRRuleToString(getData(), config, hideStart);
-	useEffect(() => {
-		onChange(rRuleString);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [rRuleString]);
+	const { hideEnd, hideError, hideStart, id = 'rrule' } = props;
+	const { error } = useRRuleState();
 
 	return (
 		<div>

--- a/packages/rrule-generator/src/hooks/index.ts
+++ b/packages/rrule-generator/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { default as useRRuleConfig } from './useRRuleConfig';
 
 export { default as useRRuleState } from './useRRuleState';
+
+export { default as useStateListener } from './useStateListener';

--- a/packages/rrule-generator/src/hooks/useStateListener.ts
+++ b/packages/rrule-generator/src/hooks/useStateListener.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+import { RRuleGeneratorProps } from '../components/types';
+import useRRuleState from './useRRuleState';
+import useRRuleConfig from './useRRuleConfig';
+import { computeRRuleFromString, computeRRuleToString } from '../utils';
+
+const useStateListener = ({ onChange, value, hideStart }: RRuleGeneratorProps): void => {
+	const { hash, getData, setData } = useRRuleState();
+	const config = useRRuleConfig();
+
+	// Update/Initiate the state from value if it changes
+	useEffect(() => {
+		if (value) {
+			const data = computeRRuleFromString(getData(), value);
+			setData(data);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [value]);
+
+	/**
+	 * When hash changes, it means state was changed as a result of user ation
+	 * So, we need to fire onChange
+	 */
+	useEffect(() => {
+		const rRuleString = computeRRuleToString(getData(), config, hideStart);
+		onChange(rRuleString);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [hash]);
+};
+
+export default useStateListener;

--- a/packages/rrule-generator/src/hooks/useStateListener.ts
+++ b/packages/rrule-generator/src/hooks/useStateListener.ts
@@ -19,7 +19,7 @@ const useStateListener = ({ onChange, value, hideStart }: RRuleGeneratorProps): 
 	}, [value]);
 
 	/**
-	 * When hash changes, it means state was changed as a result of user ation
+	 * When hash changes, it means state was changed as a result of user action
 	 * So, we need to fire onChange
 	 */
 	useEffect(() => {

--- a/packages/rrule-generator/src/state/types.ts
+++ b/packages/rrule-generator/src/state/types.ts
@@ -14,6 +14,8 @@ import {
 } from '../types';
 
 export interface RRuleState {
+	// string that determines if the state has changed as a result of user action
+	hash: string;
 	start: StartRule;
 	repeat: RepeatRule;
 	end: EndRule;

--- a/packages/rrule-generator/src/state/useInitialState.ts
+++ b/packages/rrule-generator/src/state/useInitialState.ts
@@ -1,4 +1,6 @@
 import { useCallback, useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
 import { RRuleConfig } from '../types';
 import { StateInitializer, RRuleState } from './types';
 
@@ -8,6 +10,7 @@ import { StateInitializer, RRuleState } from './types';
 const useInitialState = (config: RRuleConfig): StateInitializer => {
 	const state = useMemo<RRuleState>(
 		() => ({
+			hash: uuidv4(),
 			start: {
 				date: new Date(),
 			},

--- a/packages/rrule-generator/src/state/useRRuleStateReducer.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateReducer.ts
@@ -1,8 +1,10 @@
-import { RRuleStateReducer, StateInitializer } from './types';
 import { assocPath } from 'ramda';
+import { v4 as uuidv4 } from 'uuid';
+
+import { RRuleStateReducer, StateInitializer } from './types';
 
 const useRRuleStateReducer = (initializer: StateInitializer): RRuleStateReducer => {
-	const dataReducer: RRuleStateReducer = (state, action) => {
+	const dataReducer: RRuleStateReducer = (prevState, action) => {
 		const {
 			after,
 			data,
@@ -19,6 +21,10 @@ const useRRuleStateReducer = (initializer: StateInitializer): RRuleStateReducer 
 			type,
 			which,
 		} = action;
+
+		// dispatching 'SET_DATA' means the state didn't change
+		// it was set/reset, we won't update the hash in that case
+		const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuidv4() };
 
 		switch (type) {
 			case 'SET_START_DATE':

--- a/packages/rrule-generator/src/state/useRRuleStateReducer.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateReducer.ts
@@ -22,8 +22,8 @@ const useRRuleStateReducer = (initializer: StateInitializer): RRuleStateReducer 
 			which,
 		} = action;
 
-		// dispatching 'SET_DATA' means the state didn't change
-		// it was set/reset, we won't update the hash in that case
+		// dispatching 'SET_DATA' means the state didn't change as a result of user action
+		// it was set/reset, so, we won't update the hash in that case
 		const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuidv4() };
 
 		switch (type) {

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeEndDate.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeEndDate.ts
@@ -1,6 +1,6 @@
 import { ComputeRule } from './types';
 
-const computeEndOnDate: ComputeRule<Date> = (data, rruleObj) => {
+const computeEndDate: ComputeRule<Date> = (data, rruleObj) => {
 	if (!rruleObj.until) {
 		return data?.end?.date;
 	}
@@ -8,4 +8,4 @@ const computeEndOnDate: ComputeRule<Date> = (data, rruleObj) => {
 	return rruleObj.until;
 };
 
-export default computeEndOnDate;
+export default computeEndDate;

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeStartDate.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeStartDate.ts
@@ -1,10 +1,10 @@
 import { ComputeRule } from './types';
 
-const computeStartOnDate: ComputeRule<Date> = (data, rruleObj) => {
+const computeStartDate: ComputeRule<Date> = (data, rruleObj) => {
 	if (!rruleObj.dtstart) {
 		return data?.start?.date;
 	}
 
 	return rruleObj.dtstart;
 };
-export default computeStartOnDate;
+export default computeStartDate;


### PR DESCRIPTION
This PR fixes the bug in `rrule-generator` package caused by continuous state change when using the component as controlled.