### PR TITLE
Update rRuleGenerator & Forms Packages

### DIFF
--- a/packages/form/src/FormSectionSidebar.tsx
+++ b/packages/form/src/FormSectionSidebar.tsx
@@ -5,8 +5,8 @@ import type { SectionProps } from './types';
 const NoIcon: SectionProps['icon'] = () => null;
 
 interface Props {
-	desc?: string | React.ReactNode;
-	title?: string | React.ReactNode;
+	desc?: React.ReactNode;
+	title?: React.ReactNode;
 	Icon?: React.ComponentType<{ className: string }>;
 }
 

--- a/packages/form/src/FormSectionSidebar.tsx
+++ b/packages/form/src/FormSectionSidebar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import type { SectionProps } from './types';
+
+const NoIcon: SectionProps['icon'] = () => null;
+
+interface Props {
+	desc?: string | React.ReactNode;
+	title?: string | React.ReactNode;
+	Icon?: React.ComponentType<{ className: string }>;
+}
+
+const FormSectionSidebar: React.FC<Props> = ({ desc, Icon = NoIcon, title }) => {
+	return (
+		<div className='ee-form-section__sidebar'>
+			<Icon className='ee-form-section__sidebar-icon' />
+			<h3 className='ee-form-section__sidebar-heading'>{title}</h3>
+			{desc && <div className='ee-form-section__sidebar-desc'>{desc}</div>}
+		</div>
+	);
+};
+
+export default FormSectionSidebar;

--- a/packages/form/src/RenderSection.tsx
+++ b/packages/form/src/RenderSection.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 
 import type { SectionProps } from './types';
+import FormSectionSidebar from './FormSectionSidebar';
 import RenderFields from './RenderFields';
 
 const NoIcon: SectionProps['icon'] = () => null;
 
-const RenderSection: React.FC<SectionProps> = ({
-	name,
-	title,
-	icon: Icon = NoIcon,
-	fields,
-	addSectionToFieldNames,
-}) => {
+const RenderSection: React.FC<SectionProps> = ({ name, title, icon = NoIcon, fields, addSectionToFieldNames }) => {
 	return (
 		<div className='section-wrapper'>
-			<div className='section-heading'>
-				{<Icon className='section-heading-icon' />}
-				<h3>{title}</h3>
-			</div>
+			<FormSectionSidebar title={title} Icon={icon} />
 			<div className='section-body'>
 				<RenderFields fields={fields} namespace={addSectionToFieldNames ? name : null} />
 			</div>

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,9 +1,11 @@
 export { default as EspressoForm } from './EspressoForm';
 
-export * from './types';
+export { default as FormSectionSidebar } from './FormSectionSidebar';
 
-export * from './utils';
+export { FormSpy, useForm, useFormState } from 'react-final-form';
 
 export { default as TestForm } from './TestForm';
 
-export { FormSpy, useForm, useFormState } from 'react-final-form';
+export * from './types';
+
+export * from './utils';

--- a/packages/form/src/styles.scss
+++ b/packages/form/src/styles.scss
@@ -2,9 +2,10 @@
 
 .ee-form {
 	.form-wrapper {
+		margin: 0 auto;
 		max-width: 900px;
 		padding: 0;
-		margin: 0 auto;
+
 		.ee-debug-info-btn {
 			@include max782px {
 				display: block;
@@ -13,98 +14,135 @@
 			}
 		}
 	}
+
 	.sections-wrapper {
 		padding: 0 0 var(--ee-padding-big);
 		& > div:first-child {
-			padding: 1em 0;
-		}
-	}
-	.section-wrapper {
-		padding: 2.5em 0 1rem;
-		display: flex;
-		flex-wrap: wrap;
-	}
-	.section-wrapper + .section-wrapper {
-		border-top: 3px solid var(--ee-color-grey-14);
-	}
-	.section-heading {
-		position: relative;
-		h3 {
-			color: var(--ee-default-text-color);
-			font-size: 1.4rem;
-			font-weight: bold;
-			color: var(--ee-default-text-color);
-			font-size: 1.4rem;
-			margin: 0;
+			padding: var(--ee-padding-small) 0;
 		}
 	}
 
-	.section-heading-icon {
-		color: var(--ee-color-grey-13);
-		display: inline-block;
-		font-size: var(--ee-font-size-extreme);
-		position: absolute;
-		top: 2rem;
-		left: 0.25rem;
+	.section {
+		&-wrapper {
+			padding: var(--ee-padding-bigger) 0 var(--ee-padding-small);
+			display: flex;
+			flex-wrap: wrap;
+		}
+
+		&-wrapper + &-wrapper {
+			border-top: 3px solid var(--ee-color-grey-14);
+		}
+
+		&-body {
+			padding: var(--ee-padding-smaller) 0;
+			.ee-form-item {
+				padding: var(--ee-padding-smaller) 0;
+
+				&-switch {
+					padding: var(--ee-padding-small) 0;
+				}
+				&-pair {
+					box-sizing: border-box;
+					display: inline-flex;
+					margin: var(--ee-margin-default) 0;
+					padding-right: var(--ee-padding-default);
+					width: 50%;
+					label {
+						display: flex;
+						align-items: center;
+					}
+				}
+				.ee-icon--info-circle-outlined {
+					color: var(--ee-color-primary-low-contrast);
+					margin: 0 var(--ee-margin-tiny);
+				}
+			}
+		}
 	}
+
+	&-section {
+		&__sidebar {
+			flex: 0 1 25%;
+			position: relative;
+
+			&-heading {
+				color: var(--ee-default-text-color);
+				font-size: var(--ee-font-size-bigger);
+				font-weight: bold;
+				margin: 0;
+			}
+
+			&-icon.ee-svg.ee-svg {
+				color: var(--ee-color-grey-13);
+				display: inline-block;
+				font-size: var(--ee-font-size-extreme);
+				height: var(--ee-font-size-extreme);
+				margin: 0 0 var(--ee-margin-small);
+				width: var(--ee-font-size-extreme);
+			}
+
+			&-desc {
+				color: var(--ee-default-text-color-low-contrast);
+				margin: var(--ee-margin-small) 0;
+			}
+		}
+	}
+
 	.field-group-items {
 		display: flex;
 		flex-wrap: wrap;
 		width: 100%;
 	}
+
 	.repeatable-wrap {
-		margin-bottom: 1em;
+		margin-bottom: var(--ee-margin-small);
 	}
+
 	.repeatable-item {
 		.remove-item {
 			float: right;
-			margin-left: 0.5em;
+			margin-left: var(--ee-margin-tiny);
 		}
 	}
+
 	.submit-wrapper {
 		display: flex;
 		justify-content: flex-end;
 
 		> div {
-			padding: 0 0.5em;
+			padding: 0 var(--ee-padding-tiny);
 		}
 	}
-	.section-body {
-		padding: var(--ee-padding-smaller) 0;
-		.ee-form-item {
-			padding: var(--ee-padding-smaller) 0;
 
-			&-switch {
-				padding: var(--ee-padding-small) 0;
-			}
-			&-pair {
-				width: 50%;
-				display: inline-flex;
-				padding-right: var(--ee-margin-default);
-				margin: var(--ee-margin-default) 0;
-				label {
-					display: flex;
-					align-items: center;
-				}
-			}
-			.ee-icon--info-circle-outlined {
-				color: var(--ee-color-primary-low-contrast);
-				margin: 0 var(--ee-margin-tiny);
+	@media only screen and (min-width: 782px) {
+		.ee-form-section-sidebar {
+			flex: 0 25%;
+		}
+
+		.section-body {
+			flex: 0 75%;
+			position: relative;
+			.field-group-item {
+				flex: 0 50%;
+				padding: 0 var(--ee-padding-tiny);
 			}
 		}
 	}
+
 	@media only screen and (max-width: 782px) {
-		.section-heading {
+		.ee-form-section-sidebar {
 			flex: 0 100%;
 			h3 {
-				margin: 0 0 1.5rem;
+				margin: 0 0 var(--ee-margin-default);
 			}
-			.section-heading-icon {
+			&-icon {
 				left: unset;
+				position: absolute;
 				right: 0.25rem;
 				top: -0.75rem;
 			}
 		}
+
 		.section-body {
 			flex: 0 100%;
 
@@ -116,20 +154,8 @@
 			}
 		}
 	}
-	@media only screen and (min-width: 782px) {
-		.section-heading {
-			flex: 0 20%;
-		}
-		.section-body {
-			flex: 0 80%;
-			position: relative;
-			.field-group-item {
-				flex: 0 50%;
-				padding: 0 0.5em;
-			}
-		}
-	}
+
 	.tooltip {
-		margin-left: 0.5em;
+		margin-left: var(--ee-margin-tiny);
 	}
 }

--- a/packages/rrule-generator/src/components/RRuleGenerator/RRuleText.tsx
+++ b/packages/rrule-generator/src/components/RRuleGenerator/RRuleText.tsx
@@ -3,13 +3,20 @@ import { RRule } from 'rrule';
 import format from 'date-fns/format';
 import { __, sprintf } from '@wordpress/i18n';
 
+import { LOCALIZED_DATE_FULL_FORMAT } from '@eventespresso/constants';
+
 export interface RRuleTextProps {
 	rRuleString?: string;
 }
 
 const RRuleText: React.FC<RRuleTextProps> = ({ rRuleString }) => {
 	const rRule = RRule.fromString(rRuleString);
-	const ruleText = sprintf(__('%s,%sstarting %s'), rRule.toText(), '\n', format(rRule.options.dtstart, 'PPPP'));
+	const ruleText = sprintf(
+		__('%s,%sstarting %s'),
+		rRule.toText(),
+		'\n',
+		format(rRule.options.dtstart, LOCALIZED_DATE_FULL_FORMAT)
+	);
 
 	return (
 		ruleText && (

--- a/packages/rrule-generator/src/components/RRuleGenerator/RRuleText.tsx
+++ b/packages/rrule-generator/src/components/RRuleGenerator/RRuleText.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { RRule } from 'rrule';
+import format from 'date-fns/format';
+import { __, sprintf } from '@wordpress/i18n';
+
+export interface RRuleTextProps {
+	rRuleString?: string;
+}
+
+const RRuleText: React.FC<RRuleTextProps> = ({ rRuleString }) => {
+	const rRule = RRule.fromString(rRuleString);
+	const ruleText = sprintf(__('%s,%sstarting %s'), rRule.toText(), '\n', format(rRule.options.dtstart, 'PPPP'));
+
+	return (
+		ruleText && (
+			<div className='rrule-generator__form-group-row'>
+				<div className='rrule-text'>{ruleText}</div>
+			</div>
+		)
+	);
+};
+
+export default RRuleText;

--- a/packages/rrule-generator/src/components/RRuleGenerator/index.tsx
+++ b/packages/rrule-generator/src/components/RRuleGenerator/index.tsx
@@ -4,6 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import Start from '../Start';
 import Repeat from '../Repeat';
 import End from '../End';
+import RRuleText from './RRuleText';
 import { RRuleGeneratorProps } from '../types';
 import { useRRuleState, useStateListener } from '../../hooks';
 import { withConfig, withState } from '../../context';
@@ -11,7 +12,7 @@ import { withConfig, withState } from '../../context';
 import '../../styles/index.css';
 import './styles.scss';
 
-const RRuleGenerator: React.FC<RRuleGeneratorProps> = (props) => {
+const RRuleGenerator: React.FC<RRuleGeneratorProps> = ({ showReadable = true, ...props }) => {
 	// set up state listener
 	useStateListener(props);
 
@@ -28,6 +29,8 @@ const RRuleGenerator: React.FC<RRuleGeneratorProps> = (props) => {
 					)}
 				</div>
 			)}
+
+			{showReadable && <RRuleText rRuleString={props.value} />}
 
 			{!hideStart && <Start id={`${id}-start`} />}
 

--- a/packages/rrule-generator/src/components/RRuleGenerator/styles.scss
+++ b/packages/rrule-generator/src/components/RRuleGenerator/styles.scss
@@ -1,6 +1,4 @@
 .rrule-generator {
-	padding-bottom: 0.75rem;
-
 	&__alert-danger {
 		background-color: rgb(254, 215, 215);
 		margin-bottom: 0.75rem;
@@ -8,5 +6,38 @@
 		padding-right: 1rem;
 		padding-bottom: 0.75rem;
 		padding-top: 0.75rem;
+	}
+
+	&__form-group-row:first-child {
+		margin: 3rem 0 1rem;
+	}
+
+	.rrule-text {
+		border-radius: 3px;
+		color: white;
+		font-size: 1rem;
+		line-height: 1.5rem;
+		margin-left: 20%;
+		min-height: 2.625rem;
+		outline: none;
+		padding: 0.5rem 1rem;
+		white-space: pre;
+
+		&-label {
+			color: white;
+		}
+	}
+
+	&-wrapper {
+		&-recurrence {
+			.rrule-text {
+				background: #7ab540;
+			}
+		}
+		&-exclusion {
+			.rrule-text {
+				background: #e65983;
+			}
+		}
 	}
 }

--- a/packages/rrule-generator/src/components/Repeat/styles.scss
+++ b/packages/rrule-generator/src/components/Repeat/styles.scss
@@ -1,5 +1,7 @@
 .rrule-generator {
 	&__frequency {
+		flex: 0 1 80%;
+
 		> select.rrule-generator__form-control {
 			width: 220px;
 		}

--- a/packages/rrule-generator/src/components/styles.scss
+++ b/packages/rrule-generator/src/components/styles.scss
@@ -1,12 +1,14 @@
 .rrule-generator {
-	padding-bottom: 0.75rem;
-
 	&__form-group {
 		&-row {
 			align-items: center;
 			display: flex;
 			flex-wrap: wrap;
 			margin-bottom: 1rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 
 			&--align-items-start {
 				align-items: flex-start;
@@ -19,12 +21,15 @@
 			label {
 				flex: 0 1 20%;
 				font-size: var(--ee-font-size-default);
-				max-width: 15%;
 				padding-left: 1rem;
 				padding-right: 1rem;
 				text-align: right;
 			}
 		}
+	}
+
+	&__frequency {
+		flex: 0 1 80%;
 	}
 
 	&__on,
@@ -90,7 +95,7 @@
 	&__form-control {
 		.rrule-generator & {
 			margin-right: 1rem;
-			min-width: 40px;
+			min-width: 140px;
 			width: 100%;
 		}
 
@@ -113,12 +118,12 @@
 
 			&__month {
 				min-width: 60px;
-				width: 135px;
+				width: 140px;
 			}
 
 			&__input {
 				border-radius: 4px;
-				border: 1px solid #7e8993;
+				border: 1px solid #c1c1c1;
 				min-width: unset;
 				padding: 6px 8px;
 				text-align: center;

--- a/packages/rrule-generator/src/components/types.ts
+++ b/packages/rrule-generator/src/components/types.ts
@@ -10,6 +10,7 @@ export interface RRuleGeneratorProps extends BaseProps, ConfigProviderProps {
 	hideStart?: boolean;
 	hideEnd?: boolean;
 	hideError?: boolean;
+	showReadable?: boolean;
 }
 
 export type OnChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => void;


### PR DESCRIPTION
this PR:

- adds a new FormSectionSidebar component to the forms package that handles form section titles, icons, and descriptions, that looks like:
![ScreenShot_20200811155106](https://user-images.githubusercontent.com/1751030/89956678-7c274500-dbea-11ea-9ef2-c89d6d3592a4.png)

- tweaks a bunch of other form related styles

- adds a new RRuleText component to the rRuleGenerator package that adds a human readable output for the rRule at the top of the pattern generator that looks like:
![ScreenShot_20200811155436](https://user-images.githubusercontent.com/1751030/89956910-f9eb5080-dbea-11ea-8879-12c4b62ea80e.png)
for recurrence patterns and 
![ScreenShot_20200811155513](https://user-images.githubusercontent.com/1751030/89956934-0e2f4d80-dbeb-11ea-887a-5cdaa0384de5.png)
for exclusion patterns

- tweaks a bunch of other rRuleGenerator related styles so that they match up better with the forms