### PR TITLE
REM Editor fixes

### DIFF
--- a/domains/rem/src/ui/recurrence/PatternEditor.tsx
+++ b/domains/rem/src/ui/recurrence/PatternEditor.tsx
@@ -20,6 +20,10 @@ const PatternEditor: React.FC = () => {
 		onClose();
 	}, [onClose, setExRule]);
 
+	// We need to show rRule even after coming back from next steps
+	// isOpen is reset on each mount (step), exRule still remains in REM state
+	const showExRule = exRule || isOpen;
+
 	return (
 		<>
 			{!rRule ? (
@@ -37,7 +41,7 @@ const PatternEditor: React.FC = () => {
 				type='recurrence'
 			/>
 			<Divider type='dotted' />
-			{isOpen && (
+			{showExRule && (
 				<RRuleEditor
 					desc={__('defines a rule or repeating pattern that will remove dates from those generated above')}
 					icon={CloseCircleOutlined}
@@ -50,8 +54,8 @@ const PatternEditor: React.FC = () => {
 			)}
 			<ButtonRow>
 				<Button
-					buttonText={isOpen ? __('Remove exclusion pattern') : __('Add exclusion pattern')}
-					onClick={isOpen ? onRemoveClick : onOpen}
+					buttonText={showExRule ? __('Remove exclusion pattern') : __('Add exclusion pattern')}
+					onClick={showExRule ? onRemoveClick : onOpen}
 				/>
 				<DebugInfo data={{ rRule, exRule }} />
 			</ButtonRow>

--- a/packages/rrule-generator/src/components/Repeat/Weekly/index.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Weekly/index.tsx
@@ -52,7 +52,7 @@ const Weekly: React.FC<BaseProps> = ({ id }) => {
 					const dayId = `${id}-${dayName}`;
 
 					return (
-						<label htmlFor={dayId} key={dayName} className={isDayActive && 'active'}>
+						<label htmlFor={dayId} key={dayName} className={isDayActive ? 'active' : ''}>
 							<input
 								className='rrule-generator__form-control rrule-generator__input'
 								type='checkbox'

--- a/packages/rrule-generator/src/components/types.ts
+++ b/packages/rrule-generator/src/components/types.ts
@@ -1,11 +1,10 @@
-import { ConfigProviderProps } from '../context';
+import { ConfigProviderProps, StateProviderProps } from '../context';
 
 export interface BaseProps {
 	id?: string;
 }
 
-export interface RRuleGeneratorProps extends BaseProps, ConfigProviderProps {
-	value?: string;
+export interface RRuleGeneratorProps extends BaseProps, ConfigProviderProps, StateProviderProps {
 	onChange: (rRuleString: string) => void;
 	hideStart?: boolean;
 	hideEnd?: boolean;

--- a/packages/rrule-generator/src/context/StateProvider.tsx
+++ b/packages/rrule-generator/src/context/StateProvider.tsx
@@ -7,9 +7,13 @@ const StateContext = createContext<RRuleStateManager>(null);
 
 const { Provider, Consumer: StateConsumer } = StateContext;
 
-const StateProvider: React.FC = ({ children }) => {
+export interface StateProviderProps {
+	value?: string; // rRule String
+}
+
+const StateProvider: React.FC<StateProviderProps> = ({ children, value }) => {
 	const config = useRRuleConfig();
-	const stateManager = useRRuleStateManager(config);
+	const stateManager = useRRuleStateManager(config, value);
 	return <Provider value={stateManager}>{children}</Provider>;
 };
 

--- a/packages/rrule-generator/src/context/withState.tsx
+++ b/packages/rrule-generator/src/context/withState.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { StateProvider } from './StateProvider';
+import { StateProvider, StateProviderProps } from './StateProvider';
 
-const withState = <P extends any>(Component: React.ComponentType<P>): React.ComponentType<P> => {
+const withState = <P extends StateProviderProps>(Component: React.ComponentType<P>): React.ComponentType<P> => {
 	const WrappedComponent: React.ComponentType<P> = (props) => {
 		return (
-			<StateProvider>
+			<StateProvider value={props.value}>
 				<Component {...props} />
 			</StateProvider>
 		);

--- a/packages/rrule-generator/src/state/useInitialState.ts
+++ b/packages/rrule-generator/src/state/useInitialState.ts
@@ -3,11 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { RRuleConfig } from '../types';
 import { StateInitializer, RRuleState } from './types';
+import { computeRRuleFromString } from '../utils';
 
 /**
  * Initializes the state dynamically by using the config.
  */
-const useInitialState = (config: RRuleConfig): StateInitializer => {
+const useInitialState = (config: RRuleConfig, rRuleString?: string): StateInitializer => {
 	const state = useMemo<RRuleState>(
 		() => ({
 			hash: uuidv4(),
@@ -69,9 +70,12 @@ const useInitialState = (config: RRuleConfig): StateInitializer => {
 
 	return useCallback<StateInitializer>(
 		(initialState) => {
-			return { ...initialState, ...state };
+			// if rRule string is provided, use it to generate initial state
+			const data = rRuleString ? computeRRuleFromString(state, rRuleString) : state;
+
+			return { ...initialState, ...data };
 		},
-		[state]
+		[rRuleString, state]
 	);
 };
 

--- a/packages/rrule-generator/src/state/useRRuleStateManager.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateManager.ts
@@ -7,8 +7,8 @@ import { RRuleConfig } from '../types';
 
 type RSM = RRuleStateManager;
 
-const useRRuleStateManager = (config: RRuleConfig): RSM => {
-	const initializer = useInitialState(config);
+const useRRuleStateManager = (config: RRuleConfig, rRuleString?: string): RSM => {
+	const initializer = useInitialState(config, rRuleString);
 	const dataReducer = useRRuleStateReducer(initializer);
 	const [state, dispatch] = useReducer(dataReducer, null, initializer);
 


### PR DESCRIPTION
This PR fixes the issue of rRule and exRule being reset when moving back from other REM steps.
- Fixes `rrule-generator` to generate initial state from supplied rrule string 
- Fixes React warning for boolean attribute in `packages/rrule-generator/src/components/Repeat/Weekly/index.tsx`
- Preserves visible state of exRule between REM steps
See #152 