### PR TITLE
Change Default Values for Start and End Dates

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -5,10 +5,10 @@ import { parseISO } from 'date-fns';
 
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import { useDatetimeItem, processDateAndTime } from '@eventespresso/edtr-services';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
+import { PLUS_ONE_MONTH } from '@eventespresso/constants';
+import { useTimeZoneTime, setDefaultTime } from '@eventespresso/services';
 import type { EspressoFormProps } from '@eventespresso/form';
 import type { Datetime } from '@eventespresso/edtr-services';
-import { useTimeZoneTime } from '@eventespresso/services';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { EntityId } from '@eventespresso/data';
 
@@ -25,9 +25,11 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 	const { siteTimeToUtc, utcToSiteTime } = useTimeZoneTime();
 
 	const startDate = useMemoStringify(
-		datetime?.startDate ? utcToSiteTime(parseISO(datetime?.startDate)) : PLUS_ONE_MONTH
+		datetime?.startDate ? utcToSiteTime(parseISO(datetime?.startDate)) : setDefaultTime(PLUS_ONE_MONTH, 'start')
 	);
-	const endDate = useMemoStringify(datetime?.endDate ? utcToSiteTime(parseISO(datetime?.endDate)) : PLUS_TWO_MONTHS);
+	const endDate = useMemoStringify(
+		datetime?.endDate ? utcToSiteTime(parseISO(datetime?.endDate)) : setDefaultTime(PLUS_ONE_MONTH, 'end')
+	);
 
 	const { onSubmit } = config;
 

--- a/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -5,10 +5,10 @@ import { pick } from 'ramda';
 
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import { useTicketItem, processDateAndTime } from '@eventespresso/edtr-services';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
+import { PLUS_ONE_MONTH } from '@eventespresso/constants';
 import type { EspressoFormProps } from '@eventespresso/form';
 import type { Ticket } from '@eventespresso/edtr-services';
-import { useTimeZoneTime } from '@eventespresso/services';
+import { useTimeZoneTime, setDefaultTime } from '@eventespresso/services';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { EntityId } from '@eventespresso/data';
 import { validate } from './formValidation';
@@ -36,8 +36,12 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 
 	const { siteTimeToUtc, utcToSiteTime } = useTimeZoneTime();
 
-	const startDate = useMemoStringify(ticket?.startDate ? utcToSiteTime(parseISO(ticket?.startDate)) : PLUS_ONE_MONTH);
-	const endDate = useMemoStringify(ticket?.endDate ? utcToSiteTime(parseISO(ticket?.endDate)) : PLUS_TWO_MONTHS);
+	const startDate = useMemoStringify(
+		ticket?.startDate ? utcToSiteTime(parseISO(ticket?.startDate)) : setDefaultTime(PLUS_ONE_MONTH, 'start')
+	);
+	const endDate = useMemoStringify(
+		ticket?.endDate ? utcToSiteTime(parseISO(ticket?.endDate)) : setDefaultTime(PLUS_ONE_MONTH, 'end')
+	);
 
 	const { onSubmit } = config;
 

--- a/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
+++ b/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
@@ -1,9 +1,16 @@
+import { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { pick } from 'ramda';
 
+import {
+	intervalsToOptions,
+	Intervals,
+	DATE_INTERVALS,
+	useTimeZoneTime,
+	setDefaultTime,
+} from '@eventespresso/services';
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
-import { intervalsToOptions, Intervals, DATE_INTERVALS } from '@eventespresso/services';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
+import { PLUS_ONE_MONTH } from '@eventespresso/constants';
 import type { EspressoFormProps, FieldProps } from '@eventespresso/form';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { Ticket } from '@eventespresso/edtr-services';
@@ -11,33 +18,8 @@ import { Ticket } from '@eventespresso/edtr-services';
 import { validate } from './formValidation';
 import { TICKET_FIELDS_TO_USE } from '../../constants';
 import { RemTicket } from '../../data';
-import { useMemo } from 'react';
 
 type TicketFormConfig = EspressoFormProps<RemTicket>;
-
-const TICKET_DEFAULTS: Partial<RemTicket> = {
-	ticketSalesStart: {
-		position: 'before',
-		startOrEnd: 'start',
-		unit: 'months',
-		unitValue: 1,
-	},
-	ticketSalesEnd: {
-		position: 'before',
-		startOrEnd: 'start',
-		unit: 'days',
-		unitValue: 1,
-	},
-	dateTimeStart: {
-		date: PLUS_ONE_MONTH,
-		time: PLUS_ONE_MONTH,
-	},
-	dateTimeEnd: {
-		date: PLUS_TWO_MONTHS,
-		time: PLUS_TWO_MONTHS,
-	},
-	isShared: false,
-};
 
 const dateTimeFields: Array<FieldProps> = [
 	{
@@ -108,6 +90,38 @@ const ticketSalesFields: Array<FieldProps> = [
 ];
 
 const useTicketFormConfig = (ticket?: RemTicket | Ticket, config?: Partial<TicketFormConfig>): TicketFormConfig => {
+	const { utcToSiteTime } = useTimeZoneTime();
+
+	const startDate = useMemoStringify(setDefaultTime(utcToSiteTime(PLUS_ONE_MONTH), 'start'));
+	const endDate = useMemoStringify(setDefaultTime(utcToSiteTime(PLUS_ONE_MONTH), 'end'));
+
+	const TICKET_DEFAULTS: Partial<RemTicket> = useMemo(
+		() => ({
+			ticketSalesStart: {
+				position: 'before',
+				startOrEnd: 'start',
+				unit: 'months',
+				unitValue: 1,
+			},
+			ticketSalesEnd: {
+				position: 'before',
+				startOrEnd: 'start',
+				unit: 'days',
+				unitValue: 1,
+			},
+			dateTimeStart: {
+				date: startDate,
+				time: startDate,
+			},
+			dateTimeEnd: {
+				date: endDate,
+				time: endDate,
+			},
+			isShared: false,
+		}),
+		[endDate, startDate]
+	);
+
 	const initialValues = useMemoStringify<Partial<RemTicket>>({
 		...TICKET_DEFAULTS,
 		...config?.initialValues,

--- a/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
+++ b/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { parseISO } from 'date-fns';
 import { __ } from '@wordpress/i18n';
 
+import { switchTenseForDate } from '@eventespresso/services';
+import { DisplayStartOrEndDate } from '@eventespresso/edtr-services';
+import { useMemoStringify } from '@eventespresso/hooks';
 import { BiggieCalendarDate, CalendarDateRange } from '../../';
 import type { CalendarDateSwitcherProps } from './types';
-import { DisplayStartOrEndDate } from '@eventespresso/edtr-services';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
-import { switchTenseForDate } from '@eventespresso/services';
 
 const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = React.memo(
 	({ className, displayDate = DisplayStartOrEndDate.start, labels, ...props }) => {
-		const startDate = parseISO(props.startDate) || PLUS_ONE_MONTH;
-		const endDate = parseISO(props.endDate) || PLUS_TWO_MONTHS;
+		const startDate = useMemoStringify(parseISO(props.startDate), [props.startDate]);
+		const endDate = useMemoStringify(parseISO(props.endDate), [props.endDate]);
 
 		let headerText = '';
 		let footerText = '';

--- a/packages/services/src/utilities/date/misc.ts
+++ b/packages/services/src/utilities/date/misc.ts
@@ -54,3 +54,12 @@ export const shiftDate = (args: ShiftDateArgs) => (date: Date | string): Date =>
 	}
 	return parsedDate;
 };
+
+/**
+ * Sets the default time for a date based on `type`
+ * Default time: 'start' => 8 am, 'end' => 5 pm
+ */
+export const setDefaultTime = (date: Date, type: 'start' | 'end' = 'start'): Date => {
+	const hours = type === 'start' ? 8 : 17;
+	return pipe(setHours(hours), setMinutes(0), setSeconds(0))(date);
+};


### PR DESCRIPTION
This PR changes the default values for start and end dates for dates and tickets as mentioned in [core/issues/3089](https://github.com/eventespresso/event-espresso-core/issues/3089)