### PR TITLE
Disable bulk edit for production

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/tableView/Checkbox.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/tableView/Checkbox.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
 import { ActionCheckbox, ActionCheckboxProps } from '@eventespresso/components';
-
 import { useEdtrState } from '@eventespresso/edtr-services';
+import { checkFeatureFlag } from '@eventespresso/config';
+
+const isBulkEditEnabled = checkFeatureFlag('bulkEdit');
 
 const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
 	const { visibleDatetimeIds } = useEdtrState();
+	if (!isBulkEditEnabled) {
+		return null;
+	}
 
 	return <ActionCheckbox {...props} visibleEntityIds={visibleDatetimeIds} />;
 };

--- a/domains/eventEditor/src/ui/datetimes/datesList/tableView/TableView.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/tableView/TableView.tsx
@@ -6,10 +6,13 @@ import useHeaderRowGenerator from './useHeaderRowGenerator';
 import useBodyRowGenerator from './useBodyRowGenerator';
 import { useDatesListContext } from '@edtrServices/context/EntityListContext';
 import { useReorderDatetimes } from '@eventespresso/edtr-services';
+import { checkFeatureFlag } from '@eventespresso/config';
 import { withBulkEdit } from '@eventespresso/services';
 import { Actions } from '../bulkEdit';
 
 import './styles.scss';
+
+const isBulkEditEnabled = checkFeatureFlag('bulkEdit');
 
 /**
  * Displays event date details in a standard list table like view
@@ -24,7 +27,7 @@ const TableView: React.FC = () => {
 
 	return (
 		<>
-			<Actions />
+			{isBulkEditEnabled && <Actions />}
 			<EntityTable
 				entities={filteredEntities}
 				filterState={filterState}

--- a/domains/eventEditor/src/ui/tickets/ticketsList/tableView/Checkbox.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/tableView/Checkbox.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
 import { ActionCheckbox, ActionCheckboxProps } from '@eventespresso/components';
-
 import { useEdtrState } from '@eventespresso/edtr-services';
+import { checkFeatureFlag } from '@eventespresso/config';
+
+const isBulkEditEnabled = checkFeatureFlag('bulkEdit');
 
 const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
 	const { visibleTicketIds } = useEdtrState();
+	if (!isBulkEditEnabled) {
+		return null;
+	}
 
 	return <ActionCheckbox {...props} visibleEntityIds={visibleTicketIds} />;
 };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/tableView/TableView.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/tableView/TableView.tsx
@@ -6,9 +6,11 @@ import useHeaderRowGenerator from './useHeaderRowGenerator';
 import useBodyRowGenerator from './useBodyRowGenerator';
 import { useTicketsListContext } from '@edtrServices/context/EntityListContext';
 import { useReorderTickets } from '@eventespresso/edtr-services';
+import { checkFeatureFlag } from '@eventespresso/config';
 import { withBulkEdit } from '@eventespresso/services';
 import { Actions } from '../bulkEdit';
 
+const isBulkEditEnabled = checkFeatureFlag('bulkEdit');
 /**
  * Displays tickets in a standard list table like view
  */
@@ -22,7 +24,7 @@ const TableView: React.FC = () => {
 
 	return (
 		<>
-			<Actions />
+			{isBulkEditEnabled && <Actions />}
 			<EntityTable
 				entities={filteredEntities}
 				filterState={filterState}

--- a/packages/config/src/checkFeatureFlag.ts
+++ b/packages/config/src/checkFeatureFlag.ts
@@ -1,4 +1,4 @@
-// avoid package dependecy upon `services`
+// avoid package dependency upon `services`
 import toBoolean from '../../services/src/utilities/converters/toBoolean';
 
 export const FEATURE_FLAGS = {

--- a/packages/config/src/checkFeatureFlag.ts
+++ b/packages/config/src/checkFeatureFlag.ts
@@ -1,9 +1,12 @@
-export const featureFlags = {
+// avoid package dependecy upon `services`
+import toBoolean from '../../services/src/utilities/converters/toBoolean';
+
+export const FEATURE_FLAGS = {
 	bulkEdit: process.env.FF_BULK_EDIT,
 };
 
-type Feature = 'bulkEdit' | '';
+type Feature = keyof typeof FEATURE_FLAGS;
 
 export const checkFeatureFlag = (feature: Feature): boolean => {
-	return featureFlags[feature];
+	return toBoolean(FEATURE_FLAGS?.[feature]);
 };

--- a/packages/services/src/bulkEdit/BulkEditProvider.tsx
+++ b/packages/services/src/bulkEdit/BulkEditProvider.tsx
@@ -60,6 +60,4 @@ const BulkEditProvider: React.FC = ({ children }) => {
 
 export { BulkEditProvider, BulkEditConsumer, BulkEditContext };
 
-export default BulkEditProvider;
-
 export type { BulkEdit };

--- a/packages/services/src/bulkEdit/withBulkEdit.tsx
+++ b/packages/services/src/bulkEdit/withBulkEdit.tsx
@@ -1,21 +1,14 @@
-import React, { lazy } from 'react';
-
-import { checkFeatureFlag } from '@eventespresso/config';
+import React from 'react';
 
 import type { AnyObject } from '../';
-
-const BulkEditProvider = lazy(() => import(/* webpackChunkName: "bulk-edit-provider" */ './BulkEditProvider'));
-
-const isBulkEditEnabled = checkFeatureFlag('bulkEdit');
+import { BulkEditProvider } from './BulkEditProvider';
 
 export const withBulkEdit = <P extends AnyObject>(Component: React.ComponentType<P>): React.FC<P> => {
 	const WrappedComponent: React.FC<P> = (props) => {
-		return isBulkEditEnabled ? (
+		return (
 			<BulkEditProvider>
 				<Component {...props} />
 			</BulkEditProvider>
-		) : (
-			<Component {...props} />
 		);
 	};
 


### PR DESCRIPTION
This PR in continuation with #201, disables bulk edit for production builds.