### PR TITLE
Modal registry

### DIFF
--- a/domains/eventEditor/src/services/index.ts
+++ b/domains/eventEditor/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from './context';
 export * from './filterState';
+export * from './utils';

--- a/domains/eventEditor/src/services/registry.tsx
+++ b/domains/eventEditor/src/services/registry.tsx
@@ -1,7 +1,8 @@
 import { ModalSubscription, ModalSubscriptionCb } from '@eventespresso/registry';
-import { domain } from '@eventespresso/edtr-services';
+import { domain, EdtrGlobalModals } from '@eventespresso/edtr-services';
 import { NewDatePopover } from '@edtrUI/datetimes/datesList/newDateOptions';
-import { Container } from '@edtrUI/datetimes/dateForm/multiStep';
+import { Container as EditDateContainer } from '@edtrUI/datetimes/dateForm/multiStep';
+import { Container as EditTicketContainer } from '@edtrUI/tickets/ticketForm/multiStep';
 
 const modalSubscription = new ModalSubscription(domain);
 
@@ -9,8 +10,10 @@ const modalRegistrationHandler: ModalSubscriptionCb<any> = ({ registry }) => {
 	const { registerContainer } = registry;
 
 	// Register new date popover
-	registerContainer('newDatePopover', NewDatePopover);
+	registerContainer(EdtrGlobalModals.NEW_DATE_POPOVER, NewDatePopover);
 	// Register edit date modal
-	registerContainer('editDate', Container);
+	registerContainer(EdtrGlobalModals.EDIT_DATE, EditDateContainer);
+	// Register edit ticket modal
+	registerContainer(EdtrGlobalModals.EDIT_TICKET, EditTicketContainer);
 };
 modalSubscription.subscribe(modalRegistrationHandler);

--- a/domains/eventEditor/src/services/registry.tsx
+++ b/domains/eventEditor/src/services/registry.tsx
@@ -1,0 +1,12 @@
+import { ModalSubscription, ModalSubscriptionCb } from '@eventespresso/registry';
+import { domain } from '@eventespresso/edtr-services';
+import { NewDatePopover } from '@edtrUI/datetimes/datesList/newDateOptions';
+
+// Register new date popover
+const modalSubscription = new ModalSubscription(domain);
+const modalRegistrationHandler: ModalSubscriptionCb<'rem'> = ({ registry }) => {
+	const { registerContainer } = registry;
+
+	registerContainer('newDatePopover', NewDatePopover);
+};
+modalSubscription.subscribe(modalRegistrationHandler);

--- a/domains/eventEditor/src/services/registry.tsx
+++ b/domains/eventEditor/src/services/registry.tsx
@@ -1,12 +1,16 @@
 import { ModalSubscription, ModalSubscriptionCb } from '@eventespresso/registry';
 import { domain } from '@eventespresso/edtr-services';
 import { NewDatePopover } from '@edtrUI/datetimes/datesList/newDateOptions';
+import { Container } from '@edtrUI/datetimes/dateForm/multiStep';
 
-// Register new date popover
 const modalSubscription = new ModalSubscription(domain);
-const modalRegistrationHandler: ModalSubscriptionCb<'rem'> = ({ registry }) => {
+
+const modalRegistrationHandler: ModalSubscriptionCb<any> = ({ registry }) => {
 	const { registerContainer } = registry;
 
+	// Register new date popover
 	registerContainer('newDatePopover', NewDatePopover);
+	// Register edit date modal
+	registerContainer('editDate', Container);
 };
 modalSubscription.subscribe(modalRegistrationHandler);

--- a/domains/eventEditor/src/services/utils.ts
+++ b/domains/eventEditor/src/services/utils.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { ModalSubscription, ModalRegistry } from '@eventespresso/registry';
+import { domain } from '@eventespresso/edtr-services';
+
+const { getSubscriptions } = new ModalSubscription(domain);
+const registry = new ModalRegistry({ domain });
+
+export const getRegisteredContainers = (): Array<React.ReactNode> => {
+	const { generateElements } = registry;
+
+	const subscriptions = getSubscriptions();
+
+	Object.values(subscriptions).forEach(({ callback }) => {
+		callback({ registry });
+	});
+
+	return generateElements();
+};

--- a/domains/eventEditor/src/ui/EventEditor.tsx
+++ b/domains/eventEditor/src/ui/EventEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { DatesList } from './datetimes/datesList';
 import { TicketsList } from './tickets/ticketsList';
+// fire up the UI element registry
 import '@edtrServices/registry';
 
 import { initToaster } from '@eventespresso/toaster';

--- a/domains/eventEditor/src/ui/EventEditor.tsx
+++ b/domains/eventEditor/src/ui/EventEditor.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 
 import { DatesList } from './datetimes/datesList';
 import { TicketsList } from './tickets/ticketsList';
+import '@edtrServices/registry';
 
 import { initToaster } from '@eventespresso/toaster';
 import { useEditorInitialization } from '../hooks';
+import { getRegisteredContainers } from '@edtrServices/utils';
 
 import './styles.scss';
+
+const containers = getRegisteredContainers();
 
 const EventEditor: React.FC = () => {
 	useEditorInitialization();
@@ -17,6 +21,7 @@ const EventEditor: React.FC = () => {
 		<>
 			<DatesList />
 			<TicketsList />
+			{containers}
 		</>
 	);
 };

--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Container.tsx
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Container.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { Container as EditModalContainer } from '@eventespresso/components';
-import { useEvent, useDatetimeItem } from '@eventespresso/edtr-services';
-import type { ContainerProps } from './types';
-import Content from './Content';
+import { useEvent, useDatetimeItem, EdtrGlobalModals } from '@eventespresso/edtr-services';
+import { useGlobalModal } from '@eventespresso/registry';
 
-const Container: React.FC<ContainerProps> = ({ datetimeId, ...props }) => {
-	const datetime = useDatetimeItem({ id: datetimeId });
+import Content from './Content';
+import { EntityEditModalData } from '@edtrUI/types';
+
+const Container: React.FC = () => {
+	const { getData, isOpen, close: closeModal } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_DATE);
+	const { close: closePopover } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
+	const datetime = useDatetimeItem({ id: getData()?.entityId });
 	const event = useEvent();
 
 	let title = datetime?.dbId ? sprintf(__('Edit datetime %s'), `#${datetime.dbId}`) : __('New Datetime');
@@ -15,7 +19,12 @@ const Container: React.FC<ContainerProps> = ({ datetimeId, ...props }) => {
 	// add event name to the title
 	title = event?.name ? `${event.name}: ${title}` : title;
 
-	return <EditModalContainer component={Content} entity={datetime} title={title} {...props} />;
+	const onClose = useCallback(() => {
+		closeModal();
+		closePopover();
+	}, [closeModal, closePopover]);
+
+	return <EditModalContainer component={Content} entity={datetime} title={title} isOpen={isOpen} onClose={onClose} />;
 };
 
-export default React.memo(Container);
+export default Container;

--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Content.tsx
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Content.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import {
 	useDatetimeMutator,
@@ -46,7 +46,8 @@ const Content: React.FC<ContentProps> = ({ entity, onClose }) => {
 			updateRelatedTickets,
 		]
 	);
-	const formConfig = useDatetimeFormConfig(entity?.id, { onSubmit });
+	const config = useMemo(() => ({ onSubmit }), [onSubmit]);
+	const formConfig = useDatetimeFormConfig(entity?.id, config);
 
 	return <FormWithConfig {...formConfig} formWrapper={ContentWrapper} />;
 };

--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/types.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/types.ts
@@ -1,12 +1,6 @@
-import type { Disclosure } from '@eventespresso/utils';
-import type { EntityId } from '@eventespresso/data';
 import type { Datetime } from '@eventespresso/edtr-services';
 import type { FormRenderProps } from 'react-final-form';
 import type { DateFormShape } from '../types';
-
-export interface ContainerProps extends Omit<Disclosure, 'onOpen'> {
-	datetimeId?: EntityId;
-}
 
 export interface ContentProps {
 	entity: Datetime;

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDisclosure } from '@chakra-ui/hooks';
 
 import { DropdownMenu, DropdownToggleProps, Copy, Edit, Trash } from '@eventespresso/components';
 import { useConfirmationDialog } from '@eventespresso/components';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
+import { useGlobalModal } from '@eventespresso/registry';
 import { useMemoStringify } from '@eventespresso/hooks';
-import { Container as FormContainer } from '@edtrUI/datetimes/dateForm/multiStep';
 
 import type { DateMainMenuProps } from './types';
 import useActions from './useActions';
+import { EntityEditModalData } from '@edtrUI/types';
 
 const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 	const { copyDate, trashDate, trashed } = useActions({ datetimeId: datetime.id });
-
-	const { isOpen, onClose, onOpen: onOpenEditModal } = useDisclosure();
+	const { openWithData } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_DATE);
 
 	const title = trashed ? __('Permanently delete Datetime?') : __('Move Datetime to Trash?');
 	const message = trashed
@@ -36,6 +36,10 @@ const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 
 	const trashDateTitle = trashed ? __('delete permanently') : __('trash datetime');
 
+	const onOpenEditModal = useCallback(() => {
+		openWithData({ entityId: datetime.id });
+	}, [datetime.id, openWithData]);
+
 	return (
 		<>
 			<DropdownMenu toggleProps={toggleProps}>
@@ -44,7 +48,6 @@ const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 				<Trash onClick={onOpen} title={trashDateTitle} />
 			</DropdownMenu>
 			{confirmationDialog}
-			<FormContainer datetimeId={datetime.id} isOpen={isOpen} onClose={onClose} />
 		</>
 	);
 };

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/AddSingleDate.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/AddSingleDate.tsx
@@ -1,29 +1,28 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDisclosure } from '@chakra-ui/hooks';
 
 import { Button, ButtonSize, NewEntityOption } from '@eventespresso/components';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
+import { useGlobalModal } from '@eventespresso/registry';
 import { CalendarAlt } from '@eventespresso/icons';
-import { Container as FormContainer } from '@edtrUI/datetimes/dateForm/multiStep';
+
+import { EntityEditModalData } from '@edtrUI/types';
 
 type AddSingleDateProps = {
 	isOnlyButton?: boolean;
 };
 
 const AddSingleDate: React.FC<AddSingleDateProps> = ({ isOnlyButton }) => {
-	const { isOpen, onClose, onOpen: onAddNew } = useDisclosure();
+	const { open } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_DATE);
 
 	const output = (
-		<>
-			<Button
-				buttonText={isOnlyButton ? __('Add New Date') : __('Add Single Date')}
-				onClick={onAddNew}
-				buttonSize={isOnlyButton ? ButtonSize.BIG : null}
-				buttonType='primary'
-				icon={isOnlyButton && CalendarAlt}
-			/>
-			{isOpen && <FormContainer isOpen={true} onClose={onClose} />}
-		</>
+		<Button
+			buttonText={isOnlyButton ? __('Add New Date') : __('Add Single Date')}
+			onClick={open}
+			buttonSize={isOnlyButton ? ButtonSize.BIG : null}
+			buttonType='primary'
+			icon={isOnlyButton && CalendarAlt}
+		/>
 	);
 
 	if (isOnlyButton) {

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/NewDateButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/NewDateButton.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import useNewDateOptionItems from '@edtrUI/datetimes/hooks/useNewDateOptionItems';
-import OptionsPopover from './OptionsPopover';
+import OptionsPopoverButton from './OptionsPopoverButton';
 
 const NewDateButton: React.FC = () => {
 	const optionItems = useNewDateOptionItems();
 	if (optionItems.length > 1) {
-		return <OptionsPopover>{optionItems}</OptionsPopover>;
+		return <OptionsPopoverButton />;
 	}
 	return <>{optionItems}</>;
 };

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopover.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopover.tsx
@@ -1,28 +1,18 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDisclosure } from '@chakra-ui/hooks';
 
-import { Button, ButtonSize, NewEntityPopover } from '@eventespresso/components';
-import { Calendar } from '@eventespresso/icons';
+import { NewEntityPopover } from '@eventespresso/components';
+import useNewDateOptionItems from '@edtrUI/datetimes/hooks/useNewDateOptionItems';
+import { useGlobalModal } from '@eventespresso/registry';
 
-const OptionsPopover: React.FC = ({ children }) => {
-	const { isOpen, onClose, onOpen: openModal } = useDisclosure({ defaultIsOpen: false });
-	return (
-		<>
-			<Button
-				buttonSize={ButtonSize.BIG}
-				buttonText={__('Add New Date')}
-				icon={Calendar}
-				mr={2}
-				onClick={openModal}
-			/>
-			{isOpen && (
-				<NewEntityPopover isOpen={true} onClose={onClose} title={__('Add New Date')}>
-					{children}
-				</NewEntityPopover>
-			)}
-		</>
-	);
+const OptionsPopover: React.FC = () => {
+	const optionItems = useNewDateOptionItems();
+	const { isOpen, close } = useGlobalModal('newDatePopover');
+	return isOpen ? (
+		<NewEntityPopover isOpen={true} onClose={close} title={__('Add New Date')}>
+			{optionItems}
+		</NewEntityPopover>
+	) : null;
 };
 
 export default OptionsPopover;

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopover.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopover.tsx
@@ -4,15 +4,18 @@ import { __ } from '@wordpress/i18n';
 import { NewEntityPopover } from '@eventespresso/components';
 import useNewDateOptionItems from '@edtrUI/datetimes/hooks/useNewDateOptionItems';
 import { useGlobalModal } from '@eventespresso/registry';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
 const OptionsPopover: React.FC = () => {
 	const optionItems = useNewDateOptionItems();
-	const { isOpen, close } = useGlobalModal('newDatePopover');
-	return isOpen ? (
-		<NewEntityPopover isOpen={true} onClose={close} title={__('Add New Date')}>
-			{optionItems}
-		</NewEntityPopover>
-	) : null;
+	const { isOpen, close } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
+	return (
+		isOpen && (
+			<NewEntityPopover isOpen={true} onClose={close} title={__('Add New Date')}>
+				{optionItems}
+			</NewEntityPopover>
+		)
+	);
 };
 
 export default OptionsPopover;

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
@@ -4,9 +4,10 @@ import { __ } from '@wordpress/i18n';
 import { Button, ButtonSize } from '@eventespresso/components';
 import { useGlobalModal } from '@eventespresso/registry';
 import { Calendar } from '@eventespresso/icons';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
 const OptionsPopover: React.FC = () => {
-	const { open } = useGlobalModal('newDatePopover');
+	const { open } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
 	return <Button buttonSize={ButtonSize.BIG} buttonText={__('Add New Date')} icon={Calendar} mr={2} onClick={open} />;
 };
 

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
@@ -6,9 +6,9 @@ import { useGlobalModal } from '@eventespresso/registry';
 import { Calendar } from '@eventespresso/icons';
 import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
-const OptionsPopover: React.FC = () => {
+const OptionsPopoverButton: React.FC = () => {
 	const { open } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
 	return <Button buttonSize={ButtonSize.BIG} buttonText={__('Add New Date')} icon={Calendar} mr={2} onClick={open} />;
 };
 
-export default OptionsPopover;
+export default OptionsPopoverButton;

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/OptionsPopoverButton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { Button, ButtonSize } from '@eventespresso/components';
+import { useGlobalModal } from '@eventespresso/registry';
+import { Calendar } from '@eventespresso/icons';
+
+const OptionsPopover: React.FC = () => {
+	const { open } = useGlobalModal('newDatePopover');
+	return <Button buttonSize={ButtonSize.BIG} buttonText={__('Add New Date')} icon={Calendar} mr={2} onClick={open} />;
+};
+
+export default OptionsPopover;

--- a/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/index.ts
+++ b/domains/eventEditor/src/ui/datetimes/datesList/newDateOptions/index.ts
@@ -1,2 +1,3 @@
 export { default as NewDateButton } from './NewDateButton';
 export { default as AddSingleDate } from './AddSingleDate';
+export { default as NewDatePopover } from './OptionsPopover';

--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
+import { useEvent, useTicketItem, EdtrGlobalModals } from '@eventespresso/edtr-services';
 import { Container as EditModalContainer } from '@eventespresso/components';
-import { useEvent, useTicketItem } from '@eventespresso/edtr-services';
-import type { ContainerProps } from './types';
-import Content from './Content';
+import { useGlobalModal } from '@eventespresso/registry';
 
-const Container: React.FC<ContainerProps> = ({ ticketId, ...props }) => {
-	const ticket = useTicketItem({ id: ticketId });
+import Content from './Content';
+import { EntityEditModalData } from '@edtrUI/types';
+
+const Container: React.FC = () => {
+	const { getData, isOpen, close: onClose } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_TICKET);
+	const ticket = useTicketItem({ id: getData()?.entityId });
 	const event = useEvent();
 
 	let title = ticket?.dbId ? sprintf(__('Edit ticket %s'), `#${ticket.dbId}`) : __('New Ticket Details');
@@ -15,7 +18,7 @@ const Container: React.FC<ContainerProps> = ({ ticketId, ...props }) => {
 	// add event name to the title
 	title = event?.name ? `${event.name}: ${title}` : title;
 
-	return <EditModalContainer component={Content} entity={ticket} title={title} {...props} />;
+	return <EditModalContainer component={Content} entity={ticket} title={title} isOpen={isOpen} onClose={onClose} />;
 };
 
 export default Container;

--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/types.ts
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/types.ts
@@ -1,12 +1,6 @@
-import type { Disclosure } from '@eventespresso/utils';
-import type { EntityId } from '@eventespresso/data';
 import type { Ticket } from '@eventespresso/edtr-services';
 import type { FormRenderProps } from 'react-final-form';
 import type { TicketFormShape } from '../types';
-
-export interface ContainerProps extends Omit<Disclosure, 'onOpen'> {
-	ticketId?: EntityId;
-}
 
 export interface ContentProps {
 	entity: Ticket;

--- a/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDisclosure } from '@chakra-ui/hooks';
 
 import { Copy, Edit, Trash, DropdownMenu, DropdownToggleProps, useConfirmationDialog } from '@eventespresso/components';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
+import { useGlobalModal } from '@eventespresso/registry';
 import { useMemoStringify } from '@eventespresso/hooks';
 
-import { Container as FormContainer } from '@edtrUI/tickets/ticketForm/multiStep';
 import type { TicketMainMenuProps } from './types';
 import useActions from './useActions';
+import { EntityEditModalData } from '@edtrUI/types';
 
 const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 	const { copyTicket, trashTicket, trashed } = useActions({ ticketId: ticket.id });
-
-	const { isOpen, onClose, onOpen: onOpenEditModal } = useDisclosure();
+	const { openWithData } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_TICKET);
 
 	const title = trashed ? __('Permanently delete Ticket?') : __('Move Ticket to Trash?');
 	const message = trashed
@@ -32,6 +32,10 @@ const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 
 	const trashTicketTitle = trashed ? __('delete permanently') : __('trash ticket');
 
+	const onOpenEditModal = useCallback(() => {
+		openWithData({ entityId: ticket.id });
+	}, [ticket.id, openWithData]);
+
 	return (
 		<>
 			<DropdownMenu toggleProps={toggleProps}>
@@ -40,7 +44,6 @@ const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 				<Trash onClick={onOpen} title={trashTicketTitle} />
 			</DropdownMenu>
 			{confirmationDialog}
-			<FormContainer ticketId={ticket.id} isOpen={isOpen} onClose={onClose} />
 		</>
 	);
 };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/newTicketOptions/AddSingleTicket.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/newTicketOptions/AddSingleTicket.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDisclosure } from '@chakra-ui/hooks';
 
 import { Button, ButtonSize, NewEntityOption } from '@eventespresso/components';
 import { Ticket } from '@eventespresso/icons';
-import { Container as FormContainer } from '@edtrUI/tickets/ticketForm/multiStep';
+import { useGlobalModal } from '@eventespresso/registry';
+import { EntityEditModalData } from '@edtrUI/types';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
 type AddSingleTicketProps = {
 	isOnlyButton?: boolean;
 };
 
 const AddSingleTicket: React.FC<AddSingleTicketProps> = ({ isOnlyButton }) => {
-	const { isOpen, onClose, onOpen: onAddNew } = useDisclosure();
+	const { open } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_TICKET);
 
 	const output = (
-		<>
-			<Button
-				buttonText={__('Add New Ticket')}
-				onClick={onAddNew}
-				buttonSize={isOnlyButton ? ButtonSize.BIG : null}
-				icon={isOnlyButton ? Ticket : null}
-			/>
-			{isOpen && <FormContainer isOpen={true} onClose={onClose} />}
-		</>
+		<Button
+			buttonText={__('Add New Ticket')}
+			onClick={open}
+			buttonSize={isOnlyButton ? ButtonSize.BIG : null}
+			icon={isOnlyButton ? Ticket : null}
+		/>
 	);
 
 	if (isOnlyButton) {

--- a/domains/eventEditor/src/ui/types.ts
+++ b/domains/eventEditor/src/ui/types.ts
@@ -1,0 +1,5 @@
+import { EntityId } from '@eventespresso/data';
+
+export interface EntityEditModalData {
+	entityId?: EntityId;
+}

--- a/domains/rem/src/types.ts
+++ b/domains/rem/src/types.ts
@@ -3,3 +3,7 @@ import type { RelationalData } from '@eventespresso/services';
 export interface RemDomData {
 	relations?: RelationalData;
 }
+
+export enum RemGlobalModals {
+	MAIN = 'rem',
+}

--- a/domains/rem/src/ui/Modal/Container.tsx
+++ b/domains/rem/src/ui/Modal/Container.tsx
@@ -1,0 +1,26 @@
+import React, { useCallback } from 'react';
+
+import { useGlobalModal } from '@eventespresso/registry';
+
+import Modal from './Modal';
+import { useGenerateDates } from '../generatedDates';
+import { useFormState, useSubmitForm } from '../../data';
+import { withContext } from '../../context';
+
+const Container: React.FC = () => {
+	const { isOpen, close } = useGlobalModal('rem');
+
+	// rDates and gDates, no exDates
+	const generateDates = useGenerateDates();
+	const { getData } = useFormState();
+	const submitForm = useSubmitForm(getData(), generateDates);
+
+	const onSubmit = useCallback(() => {
+		close();
+		submitForm();
+	}, [close, submitForm]);
+
+	return isOpen ? <Modal isOpen={true} onClose={close} onSubmit={onSubmit} /> : null;
+};
+
+export default withContext(Container);

--- a/domains/rem/src/ui/Modal/Container.tsx
+++ b/domains/rem/src/ui/Modal/Container.tsx
@@ -1,14 +1,17 @@
 import React, { useCallback } from 'react';
 
 import { useGlobalModal } from '@eventespresso/registry';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
 import Modal from './Modal';
 import { useGenerateDates } from '../generatedDates';
 import { useFormState, useSubmitForm } from '../../data';
 import { withContext } from '../../context';
+import { RemGlobalModals } from '../../types';
 
 const Container: React.FC = () => {
-	const { isOpen, close } = useGlobalModal('rem');
+	const { isOpen, close } = useGlobalModal(RemGlobalModals.MAIN);
+	const { close: closePopover } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
 
 	// rDates and gDates, no exDates
 	const generateDates = useGenerateDates();
@@ -17,10 +20,11 @@ const Container: React.FC = () => {
 
 	const onSubmit = useCallback(() => {
 		close();
+		closePopover();
 		submitForm();
-	}, [close, submitForm]);
+	}, [close, closePopover, submitForm]);
 
-	return isOpen ? <Modal isOpen={true} onClose={close} onSubmit={onSubmit} /> : null;
+	return isOpen && <Modal isOpen={true} onClose={close} onSubmit={onSubmit} />;
 };
 
 export default withContext(Container);

--- a/domains/rem/src/ui/Modal/Modal.tsx
+++ b/domains/rem/src/ui/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { ModalWithAlert } from '@eventespresso/components';
 
 import { ContentBody, ContentFooter } from '../MultiStep';
-import { BaseProps } from '../types';
+import type { BaseProps } from '../types';
 
 import './styles.scss';
 

--- a/domains/rem/src/ui/Modal/Modal.tsx
+++ b/domains/rem/src/ui/Modal/Modal.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import type { UseDisclosureReturn } from '@chakra-ui/hooks';
 
 import { ModalWithAlert } from '@eventespresso/components';
 
 import { ContentBody, ContentFooter } from '../MultiStep';
-import { withContext } from '../../context';
+import { BaseProps } from '../types';
 
 import './styles.scss';
 
-const Modal: React.FC<Partial<UseDisclosureReturn>> = ({ isOpen, onClose }) => {
+const Modal: React.FC<BaseProps> = ({ isOpen, onClose, onSubmit }) => {
 	return (
 		<ModalWithAlert
 			bodyClassName='ee-rem-modal__body'
@@ -21,9 +20,9 @@ const Modal: React.FC<Partial<UseDisclosureReturn>> = ({ isOpen, onClose }) => {
 			withBorder
 		>
 			<ContentBody />
-			<ContentFooter onClose={onClose} />
+			<ContentFooter onSubmit={onSubmit} onClose={onClose} />
 		</ModalWithAlert>
 	);
 };
 
-export default withContext(Modal);
+export default Modal;

--- a/domains/rem/src/ui/MultiStep/ContentFooter.tsx
+++ b/domains/rem/src/ui/MultiStep/ContentFooter.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { isEmpty } from 'ramda';
-import type { UseDisclosureReturn } from '@chakra-ui/hooks';
 
 import { ButtonRow, Next, Previous } from '@eventespresso/components';
 
@@ -8,8 +7,9 @@ import CancelButton from './CancelButton';
 import SubmitButton from './SubmitButton';
 import { useStepsState } from '../../context';
 import { useFormState } from '../../data';
+import { BaseProps } from '../types';
 
-const ContentFooter: React.FC<Partial<UseDisclosureReturn>> = ({ onClose }) => {
+const ContentFooter: React.FC<BaseProps> = ({ onClose, onSubmit }) => {
 	const { current, next, prev } = useStepsState();
 	const { rRule, dateDetails, tickets } = useFormState();
 
@@ -41,7 +41,7 @@ const ContentFooter: React.FC<Partial<UseDisclosureReturn>> = ({ onClose }) => {
 			}
 			{
 				// last step
-				current === 3 && <SubmitButton onClose={onClose} />
+				current === 3 && <SubmitButton onClick={onSubmit} />
 			}
 		</ButtonRow>
 	);

--- a/domains/rem/src/ui/MultiStep/SubmitButton.tsx
+++ b/domains/rem/src/ui/MultiStep/SubmitButton.tsx
@@ -1,21 +1,12 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
-import type { UseDisclosureReturn } from '@chakra-ui/hooks';
 
-import { Button, ButtonType } from '@eventespresso/components';
+import { Button, ButtonType, ButtonProps } from '@eventespresso/components';
 import { useGenerateDates } from '../generatedDates';
-import { useSubmitForm, useFormState } from '../../data';
 
-const SubmitButton: React.FC<Partial<UseDisclosureReturn>> = ({ onClose }) => {
+const SubmitButton: React.FC<ButtonProps> = ({ onClick }) => {
 	// rDates and gDates, no exDates
 	const generateDates = useGenerateDates();
-	const { getData } = useFormState();
-	const submitForm = useSubmitForm(getData(), generateDates);
-
-	const onClick = useCallback(() => {
-		onClose();
-		submitForm();
-	}, [onClose, submitForm]);
 
 	return (
 		<Button

--- a/domains/rem/src/ui/RemButton.tsx
+++ b/domains/rem/src/ui/RemButton.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { Button, NewEntityOption } from '@eventespresso/components';
 import { useGlobalModal } from '@eventespresso/registry';
 import { Rem } from '@eventespresso/icons';
 import { RemGlobalModals } from '../types';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 
 const RemButton: React.FC = () => {
 	const { open: openRemModal } = useGlobalModal(RemGlobalModals.MAIN);
+	const { close: closeOptionsPopover } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
+
+	const onClick = useCallback(() => {
+		closeOptionsPopover();
+		openRemModal();
+	}, [closeOptionsPopover, openRemModal]);
 
 	return (
 		<NewEntityOption
@@ -16,7 +23,7 @@ const RemButton: React.FC = () => {
 			icon={Rem}
 			title={__('Recurring Dates')}
 		>
-			<Button buttonType='primary' onClick={openRemModal}>
+			<Button buttonType='primary' onClick={onClick}>
 				{__('Add Recurring Dates')}
 			</Button>
 		</NewEntityOption>

--- a/domains/rem/src/ui/RemButton.tsx
+++ b/domains/rem/src/ui/RemButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { Button, NewEntityOption } from '@eventespresso/components';
@@ -8,6 +8,12 @@ import { Rem } from '@eventespresso/icons';
 const RemButton: React.FC = () => {
 	const { open: openRemModal } = useGlobalModal('rem');
 	const { close: closeOptionsPopover } = useGlobalModal('newDatePopover');
+
+	const onClick = useCallback(() => {
+		closeOptionsPopover();
+		openRemModal();
+	}, [closeOptionsPopover, openRemModal]);
+
 	return (
 		<NewEntityOption
 			className={'ee-new-entity-option__recurring-datetime'}
@@ -15,13 +21,7 @@ const RemButton: React.FC = () => {
 			icon={Rem}
 			title={__('Recurring Dates')}
 		>
-			<Button
-				buttonType='primary'
-				onClick={() => {
-					closeOptionsPopover();
-					openRemModal();
-				}}
-			>
+			<Button buttonType='primary' onClick={onClick}>
 				{__('Add Recurring Dates')}
 			</Button>
 		</NewEntityOption>

--- a/domains/rem/src/ui/RemButton.tsx
+++ b/domains/rem/src/ui/RemButton.tsx
@@ -1,29 +1,30 @@
 import React from 'react';
-import { useDisclosure } from '@chakra-ui/hooks';
 import { __ } from '@wordpress/i18n';
 
 import { Button, NewEntityOption } from '@eventespresso/components';
+import { useGlobalModal } from '@eventespresso/registry';
 import { Rem } from '@eventespresso/icons';
 
-import Modal from './Modal';
-
 const RemButton: React.FC = () => {
-	const { isOpen, onOpen, ...disclosure } = useDisclosure();
-
+	const { open: openRemModal } = useGlobalModal('rem');
+	const { close: closeOptionsPopover } = useGlobalModal('newDatePopover');
 	return (
-		<>
-			<NewEntityOption
-				className={'ee-new-entity-option__recurring-datetime'}
-				description={__('Add multiple dates in bulk\nthat follow a recurring pattern')}
-				icon={Rem}
-				title={__('Recurring Dates')}
+		<NewEntityOption
+			className={'ee-new-entity-option__recurring-datetime'}
+			description={__('Add multiple dates in bulk that follow a recurring pattern')}
+			icon={Rem}
+			title={__('Recurring Dates')}
+		>
+			<Button
+				buttonType='primary'
+				onClick={() => {
+					closeOptionsPopover();
+					openRemModal();
+				}}
 			>
-				<Button buttonType='primary' onClick={onOpen}>
-					{__('Add Recurring Dates')}
-				</Button>
-				{isOpen && <Modal isOpen={true} {...disclosure} />}
-			</NewEntityOption>
-		</>
+				{__('Add Recurring Dates')}
+			</Button>
+		</NewEntityOption>
 	);
 };
 

--- a/domains/rem/src/ui/RemButton.tsx
+++ b/domains/rem/src/ui/RemButton.tsx
@@ -1,18 +1,13 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { Button, NewEntityOption } from '@eventespresso/components';
 import { useGlobalModal } from '@eventespresso/registry';
 import { Rem } from '@eventespresso/icons';
+import { RemGlobalModals } from '../types';
 
 const RemButton: React.FC = () => {
-	const { open: openRemModal } = useGlobalModal('rem');
-	const { close: closeOptionsPopover } = useGlobalModal('newDatePopover');
-
-	const onClick = useCallback(() => {
-		closeOptionsPopover();
-		openRemModal();
-	}, [closeOptionsPopover, openRemModal]);
+	const { open: openRemModal } = useGlobalModal(RemGlobalModals.MAIN);
 
 	return (
 		<NewEntityOption
@@ -21,7 +16,7 @@ const RemButton: React.FC = () => {
 			icon={Rem}
 			title={__('Recurring Dates')}
 		>
-			<Button buttonType='primary' onClick={onClick}>
+			<Button buttonType='primary' onClick={openRemModal}>
 				{__('Add Recurring Dates')}
 			</Button>
 		</NewEntityOption>

--- a/domains/rem/src/ui/index.tsx
+++ b/domains/rem/src/ui/index.tsx
@@ -3,6 +3,7 @@ import { domain } from '@eventespresso/edtr-services';
 import type { NewEntitySubscriptionCb, ModalSubscriptionCb } from '@eventespresso/registry';
 import RemButton from './RemButton';
 import Container from './Modal/Container';
+import { RemGlobalModals } from '../types';
 
 // Register new entity option
 const newEntitySubscription = new NewEntitySubscription(domain);
@@ -18,6 +19,6 @@ const modalSubscription = new ModalSubscription(domain);
 const modalRegistrationHandler: ModalSubscriptionCb<'rem'> = ({ registry }) => {
 	const { registerContainer } = registry;
 
-	registerContainer('rem', Container);
+	registerContainer(RemGlobalModals.MAIN, Container);
 };
 modalSubscription.subscribe(modalRegistrationHandler);

--- a/domains/rem/src/ui/index.tsx
+++ b/domains/rem/src/ui/index.tsx
@@ -1,16 +1,23 @@
-import { NewEntitySubscription } from '@eventespresso/registry';
+import { NewEntitySubscription, ModalSubscription } from '@eventespresso/registry';
 import { domain } from '@eventespresso/edtr-services';
-import type { NewEntitySubscriptionCb } from '@eventespresso/registry';
+import type { NewEntitySubscriptionCb, ModalSubscriptionCb } from '@eventespresso/registry';
 import RemButton from './RemButton';
+import Container from './Modal/Container';
 
-type DatesSubscriptionCallback = NewEntitySubscriptionCb<'datetime'>;
-
-const { subscribe } = new NewEntitySubscription(domain);
-
-const newDateOptionsHandler: DatesSubscriptionCallback = ({ registry }) => {
+// Register new entity option
+const newEntitySubscription = new NewEntitySubscription(domain);
+const newDateOptionsHandler: NewEntitySubscriptionCb<'datetime'> = ({ registry }) => {
 	const { registerElement: registerOptionItem } = registry;
 
 	registerOptionItem('rem', RemButton, 11);
 };
+newEntitySubscription.subscribe(newDateOptionsHandler, { entityType: 'datetime' });
 
-subscribe(newDateOptionsHandler, { entityType: 'datetime' });
+// Register REM modal
+const modalSubscription = new ModalSubscription(domain);
+const modalRegistrationHandler: ModalSubscriptionCb<'rem'> = ({ registry }) => {
+	const { registerContainer } = registry;
+
+	registerContainer('rem', Container);
+};
+modalSubscription.subscribe(modalRegistrationHandler);

--- a/domains/rem/src/ui/types.ts
+++ b/domains/rem/src/ui/types.ts
@@ -1,0 +1,5 @@
+export interface BaseProps {
+	isOpen?: boolean;
+	onClose?: VoidFunction;
+	onSubmit?: VoidFunction;
+}

--- a/packages/edtr-services/src/context/ContextProvider.tsx
+++ b/packages/edtr-services/src/context/ContextProvider.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DataProvider } from '@eventespresso/data';
 import { ThemeProvider } from '@eventespresso/adapters';
 import { ConfigProvider, RelationsProvider, StatusProvider } from '@eventespresso/services';
+import { GlobalModalProvider } from '@eventespresso/registry';
 import { EdtrStateProvider } from './EdtrStateContext';
 
 export const ServiceProvider: React.FC = ({ children }) => {
@@ -11,7 +12,9 @@ export const ServiceProvider: React.FC = ({ children }) => {
 			<StatusProvider>
 				<ConfigProvider>
 					<RelationsProvider>
-						<EdtrStateProvider>{children}</EdtrStateProvider>
+						<EdtrStateProvider>
+							<GlobalModalProvider>{children}</GlobalModalProvider>
+						</EdtrStateProvider>
 					</RelationsProvider>
 				</ConfigProvider>
 			</StatusProvider>

--- a/packages/edtr-services/src/types.ts
+++ b/packages/edtr-services/src/types.ts
@@ -19,3 +19,9 @@ export interface EditorData {
 export interface EventEditorDomData {
 	eventEditor: EventEditorData;
 }
+
+export enum EdtrGlobalModals {
+	EDIT_DATE = 'editDate',
+	EDIT_TICKET = 'editTicket',
+	NEW_DATE_POPOVER = 'newDatePopover',
+}

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1,4 +1,5 @@
 export * from './entityActionsMenu';
 export * from './filterBar';
+export * from './modals';
 export * from './newEntityOptions';
 export * from './subscription';

--- a/packages/registry/src/modals/ModalRegistry.ts
+++ b/packages/registry/src/modals/ModalRegistry.ts
@@ -1,0 +1,24 @@
+import { UIRegistry, ElementProps } from '../subscription';
+import type { ModalArgs } from './types';
+import { serviceName as service } from './constants';
+
+/**
+ * D: Domain name e.g. "eventEditor"
+ * MT: Modal Type: The current modal type e.g. "rem", "editTicket"
+ * EP: Element Props: The props of the component that's registerd by the consumer
+ */
+class ModalRegistry<D extends string, MT extends string, EP extends ElementProps = ElementProps> extends UIRegistry<
+	EP,
+	D,
+	typeof service
+> {
+	constructor({ domain, modalType, path }: ModalArgs<D, MT>) {
+		super({ domain, service, path: path || (modalType && [modalType]) });
+	}
+
+	registerContainer = (modalName: string, container: React.ComponentType<EP>): void => {
+		this.registerElement(modalName, container);
+	};
+}
+
+export default ModalRegistry;

--- a/packages/registry/src/modals/ModalSubscription.ts
+++ b/packages/registry/src/modals/ModalSubscription.ts
@@ -1,0 +1,24 @@
+import { filterSubscriptionsByOption, SubscriptionManager } from '../subscription';
+import type { ModalSubscriptionInterface } from './types';
+import { serviceName as service } from './constants';
+
+type MSI = ModalSubscriptionInterface;
+
+/**
+ * D: Domain name e.g. "eventEditor"
+ */
+class ModalSubscription<D extends string> implements MSI {
+	private subscriptionManager: SubscriptionManager<D, typeof service>;
+
+	constructor(domain: D) {
+		this.subscriptionManager = new SubscriptionManager<D, typeof service>({ domain, service });
+	}
+
+	subscribe: MSI['subscribe'] = (...args) => this.subscriptionManager.subscribe(...args);
+
+	getSubscriptions: MSI['getSubscriptions'] = (args) => {
+		return filterSubscriptionsByOption(this.subscriptionManager.getSubscriptions, 'modalType', args?.modalType);
+	};
+}
+
+export default ModalSubscription;

--- a/packages/registry/src/modals/constants.ts
+++ b/packages/registry/src/modals/constants.ts
@@ -1,0 +1,1 @@
+export const serviceName = 'modal';

--- a/packages/registry/src/modals/context/GlobalModalProvider.tsx
+++ b/packages/registry/src/modals/context/GlobalModalProvider.tsx
@@ -1,0 +1,15 @@
+import React, { createContext } from 'react';
+
+import { GlobalModalManager } from './types';
+import useGlobalModalManager from './useGlobalModalManager';
+
+const GlobalModalContext = createContext<GlobalModalManager>(null);
+
+const { Provider, Consumer: GlobalModalConsumer } = GlobalModalContext;
+
+const GlobalModalProvider: React.FC = ({ children }) => {
+	const value = useGlobalModalManager();
+	return <Provider value={value}>{children}</Provider>;
+};
+
+export { GlobalModalContext, GlobalModalProvider, GlobalModalConsumer };

--- a/packages/registry/src/modals/context/index.ts
+++ b/packages/registry/src/modals/context/index.ts
@@ -1,0 +1,4 @@
+export { default as useGlobalModal } from './useGlobalModal';
+
+export * from './GlobalModalProvider';
+export * from './types';

--- a/packages/registry/src/modals/context/reducer.ts
+++ b/packages/registry/src/modals/context/reducer.ts
@@ -1,0 +1,21 @@
+import { assocPath } from 'ramda';
+
+import { GlobalModalStateReducer } from './types';
+
+const reducer: GlobalModalStateReducer = (prevState, action) => {
+	const { data, type, modalName } = action;
+
+	switch (type) {
+		case 'OPEN_MODAL':
+			return assocPath([modalName, 'isOpen'], true, prevState);
+		case 'CLOSE_MODAL':
+			return assocPath([modalName, 'isOpen'], false, prevState);
+		case 'SET_MODAL_DATA':
+			return assocPath([modalName, 'data'], data, prevState);
+
+		default:
+			throw new Error('Unexpected action');
+	}
+};
+
+export default reducer;

--- a/packages/registry/src/modals/context/types.ts
+++ b/packages/registry/src/modals/context/types.ts
@@ -1,0 +1,40 @@
+import { Reducer } from 'react';
+import { AnyObject } from '@eventespresso/utils';
+
+export interface ModalState {
+	isOpen?: boolean;
+	data: AnyObject;
+}
+
+/**
+ * state = {
+ *     [modalId]: ModalState
+ * }
+ */
+export type GlobalModalState = AnyObject<ModalState>;
+
+export type GlobalModalActionType = 'OPEN_MODAL' | 'CLOSE_MODAL' | 'SET_MODAL_DATA';
+
+export interface GlobalModalAction {
+	data?: AnyObject;
+	modalName: string;
+	type: GlobalModalActionType;
+}
+
+export interface GlobalModalManager {
+	closeModal: (modalName: string) => void;
+	isModalOpen: (modalName: string) => boolean;
+	openModal: (modalName: string) => void;
+	openModalWithData: (modalName: string, data: AnyObject) => void;
+	setModalData: (modalName: string, data: AnyObject) => void;
+}
+
+export type GlobalModalStateReducer = Reducer<GlobalModalState, GlobalModalAction>;
+
+export interface GlobalModal {
+	close: () => void;
+	isOpen: boolean;
+	open: () => void;
+	openWithData: (data: AnyObject) => void;
+	setData: (data: AnyObject) => void;
+}

--- a/packages/registry/src/modals/context/types.ts
+++ b/packages/registry/src/modals/context/types.ts
@@ -21,20 +21,23 @@ export interface GlobalModalAction {
 	type: GlobalModalActionType;
 }
 
-export interface GlobalModalManager {
+export interface GlobalModalManager<D = AnyObject> {
 	closeModal: (modalName: string) => void;
+	getData: () => GlobalModalState;
+	getModalData: (modalName: string) => D;
 	isModalOpen: (modalName: string) => boolean;
 	openModal: (modalName: string) => void;
-	openModalWithData: (modalName: string, data: AnyObject) => void;
-	setModalData: (modalName: string, data: AnyObject) => void;
+	openModalWithData: (modalName: string, data: D) => void;
+	setModalData: (modalName: string, data: D) => void;
 }
 
 export type GlobalModalStateReducer = Reducer<GlobalModalState, GlobalModalAction>;
 
-export interface GlobalModal {
+export interface GlobalModal<D = AnyObject> {
 	close: () => void;
+	getData: () => D;
 	isOpen: boolean;
 	open: () => void;
-	openWithData: (data: AnyObject) => void;
-	setData: (data: AnyObject) => void;
+	openWithData: (data: D) => void;
+	setData: (data: D) => void;
 }

--- a/packages/registry/src/modals/context/useGlobalModal.ts
+++ b/packages/registry/src/modals/context/useGlobalModal.ts
@@ -1,0 +1,31 @@
+import { useMemo, useCallback } from 'react';
+
+import type { GlobalModal } from './types';
+import useGlobalModalContext from './useGlobalModalContext';
+
+const useGlobalModal = (name: string): GlobalModal => {
+	const { closeModal, isModalOpen, openModal, openModalWithData, setModalData } = useGlobalModalContext();
+
+	const close = useCallback<GlobalModal['close']>(() => closeModal(name), [closeModal, name]);
+
+	const isOpen = useMemo<GlobalModal['isOpen']>(() => isModalOpen(name), [name, isModalOpen]);
+
+	const open = useCallback<GlobalModal['open']>(() => openModal(name), [name, openModal]);
+
+	const openWithData = useCallback<GlobalModal['openWithData']>((data) => openModalWithData(name, data), [
+		name,
+		openModalWithData,
+	]);
+
+	const setData = useCallback<GlobalModal['setData']>((data) => setModalData(name, data), [name, setModalData]);
+
+	return useMemo(() => ({ close, isOpen, open, openWithData, setData }), [
+		close,
+		isOpen,
+		open,
+		openWithData,
+		setData,
+	]);
+};
+
+export default useGlobalModal;

--- a/packages/registry/src/modals/context/useGlobalModal.ts
+++ b/packages/registry/src/modals/context/useGlobalModal.ts
@@ -1,26 +1,34 @@
 import { useMemo, useCallback } from 'react';
 
+import { AnyObject } from '@eventespresso/utils';
 import type { GlobalModal } from './types';
 import useGlobalModalContext from './useGlobalModalContext';
 
-const useGlobalModal = (name: string): GlobalModal => {
-	const { closeModal, isModalOpen, openModal, openModalWithData, setModalData } = useGlobalModalContext();
+const useGlobalModal = <D = AnyObject>(name: string): GlobalModal<D> => {
+	const modalContext = useGlobalModalContext<D>();
 
-	const close = useCallback<GlobalModal['close']>(() => closeModal(name), [closeModal, name]);
+	const { closeModal, getModalData, isModalOpen, openModal, openModalWithData, setModalData } = modalContext;
 
-	const isOpen = useMemo<GlobalModal['isOpen']>(() => isModalOpen(name), [name, isModalOpen]);
+	type GM = GlobalModal<D>;
 
-	const open = useCallback<GlobalModal['open']>(() => openModal(name), [name, openModal]);
+	const close = useCallback<GM['close']>(() => closeModal(name), [closeModal, name]);
 
-	const openWithData = useCallback<GlobalModal['openWithData']>((data) => openModalWithData(name, data), [
+	const getData = useCallback<GM['getData']>(() => getModalData(name), [getModalData, name]);
+
+	const isOpen = useMemo<GM['isOpen']>(() => isModalOpen(name), [name, isModalOpen]);
+
+	const open = useCallback<GM['open']>(() => openModal(name), [name, openModal]);
+
+	const openWithData = useCallback<GM['openWithData']>((data) => openModalWithData(name, data), [
 		name,
 		openModalWithData,
 	]);
 
-	const setData = useCallback<GlobalModal['setData']>((data) => setModalData(name, data), [name, setModalData]);
+	const setData = useCallback<GM['setData']>((data) => setModalData(name, data), [name, setModalData]);
 
-	return useMemo(() => ({ close, isOpen, open, openWithData, setData }), [
+	return useMemo(() => ({ close, getData, isOpen, open, openWithData, setData }), [
 		close,
+		getData,
 		isOpen,
 		open,
 		openWithData,

--- a/packages/registry/src/modals/context/useGlobalModalContext.ts
+++ b/packages/registry/src/modals/context/useGlobalModalContext.ts
@@ -1,9 +1,12 @@
 import { useContext } from 'react';
+
+import { AnyObject } from '@eventespresso/utils';
+
 import { GlobalModalContext } from './GlobalModalProvider';
 import type { GlobalModalManager } from './types';
 
-const useGlobalModalContext = (): GlobalModalManager => {
-	return useContext(GlobalModalContext);
+const useGlobalModalContext = <D = AnyObject>(): GlobalModalManager<D> => {
+	return useContext(GlobalModalContext) as GlobalModalManager<D>;
 };
 
 export default useGlobalModalContext;

--- a/packages/registry/src/modals/context/useGlobalModalContext.ts
+++ b/packages/registry/src/modals/context/useGlobalModalContext.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { GlobalModalContext } from './GlobalModalProvider';
+import type { GlobalModalManager } from './types';
+
+const useGlobalModalContext = (): GlobalModalManager => {
+	return useContext(GlobalModalContext);
+};
+
+export default useGlobalModalContext;

--- a/packages/registry/src/modals/context/useGlobalModalManager.ts
+++ b/packages/registry/src/modals/context/useGlobalModalManager.ts
@@ -19,11 +19,30 @@ const useGlobalModalManager = (): GMM => {
 		dispatch({ type: 'CLOSE_MODAL', modalName });
 	}, []);
 
+	const stateStr = JSON.stringify(state);
+
+	const getData: GMM['getData'] = useCallback(
+		() => {
+			return state;
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[stateStr]
+	);
+
+	const getModalData: GMM['getModalData'] = useCallback(
+		(modalName) => {
+			return state[modalName]?.data;
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[stateStr]
+	);
+
 	const isModalOpen: GMM['isModalOpen'] = useCallback(
 		(modalName) => {
-			return state[modalName]?.isOpen;
+			return Boolean(state[modalName]?.isOpen);
 		},
-		[state]
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[stateStr]
 	);
 
 	const openModal: GMM['openModal'] = useCallback((modalName) => {
@@ -42,12 +61,14 @@ const useGlobalModalManager = (): GMM => {
 	return useMemo<GMM>(
 		() => ({
 			closeModal,
+			getData,
+			getModalData,
 			isModalOpen,
 			openModal,
 			openModalWithData,
 			setModalData,
 		}),
-		[closeModal, isModalOpen, openModal, openModalWithData, setModalData]
+		[closeModal, getData, getModalData, isModalOpen, openModal, openModalWithData, setModalData]
 	);
 };
 

--- a/packages/registry/src/modals/context/useGlobalModalManager.ts
+++ b/packages/registry/src/modals/context/useGlobalModalManager.ts
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useReducer, useEffect } from 'react';
+
+import type { GlobalModalManager, GlobalModalState } from './types';
+import reducer from './reducer';
+
+type GMM = GlobalModalManager;
+
+const INITIAL_STATE: GlobalModalState = {};
+
+const useGlobalModalManager = (): GMM => {
+	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+
+	// temporary
+	useEffect(() => {
+		console.log('Global Modal state', state);
+	}, [state]);
+
+	const closeModal: GMM['closeModal'] = useCallback((modalName) => {
+		dispatch({ type: 'CLOSE_MODAL', modalName });
+	}, []);
+
+	const isModalOpen: GMM['isModalOpen'] = useCallback(
+		(modalName) => {
+			return state[modalName]?.isOpen;
+		},
+		[state]
+	);
+
+	const openModal: GMM['openModal'] = useCallback((modalName) => {
+		dispatch({ type: 'OPEN_MODAL', modalName });
+	}, []);
+
+	const openModalWithData: GMM['openModalWithData'] = useCallback((modalName, data) => {
+		dispatch({ type: 'SET_MODAL_DATA', modalName, data });
+		dispatch({ type: 'OPEN_MODAL', modalName });
+	}, []);
+
+	const setModalData: GMM['setModalData'] = useCallback((modalName, data) => {
+		dispatch({ type: 'SET_MODAL_DATA', modalName, data });
+	}, []);
+
+	return useMemo<GMM>(
+		() => ({
+			closeModal,
+			isModalOpen,
+			openModal,
+			openModalWithData,
+			setModalData,
+		}),
+		[closeModal, isModalOpen, openModal, openModalWithData, setModalData]
+	);
+};
+
+export default useGlobalModalManager;

--- a/packages/registry/src/modals/index.ts
+++ b/packages/registry/src/modals/index.ts
@@ -1,0 +1,6 @@
+export { default as ModalRegistry } from './ModalRegistry';
+
+export { default as ModalSubscription } from './ModalSubscription';
+
+export * from './context';
+export * from './types';

--- a/packages/registry/src/modals/types.ts
+++ b/packages/registry/src/modals/types.ts
@@ -1,0 +1,39 @@
+import type React from 'react';
+import type { BaseSubscriptionOptions, Subscriptions, ElementProps } from '../subscription';
+import type ModalRegistry from './ModalRegistry';
+
+export interface ModalSubscriptionsOptions<T extends string> {
+	modalType?: T; // to limit the subscription only to specific modalType
+}
+
+export interface ModalSubscriptionCbArgs<T extends string, EP extends ElementProps = ElementProps>
+	extends ModalSubscriptionsOptions<T> {
+	registry: ModalRegistry<string, T, EP>;
+}
+
+export interface ModalSubscriptionInterface {
+	subscribe: ModalSubscribeFn;
+	getSubscriptions: <T extends string>(
+		options?: ModalSubscriptionsOptions<T>
+	) => Subscriptions<ModalSubscriptionCbArgs<T>, ModalSubscriptionsOptions<T>>;
+}
+
+export type ModalSubscribeFn = <T extends string>(
+	cb: ModalSubscriptionCb<T>,
+	options?: ModalSubscriptionsOptions<T>
+) => VoidFunction;
+
+export type ModalSubscriptionCb<T extends string, EP extends ElementProps = ElementProps> = (
+	args: ModalSubscriptionCbArgs<T, EP>
+) => void;
+
+/* UI related types */
+export interface ModalArgs<D extends string, MT extends string> extends BaseSubscriptionOptions<D> {
+	modalType?: MT;
+	path?: Array<string>;
+}
+
+export interface ModalProps {
+	className?: string;
+	optionItems: Array<React.ReactNode>;
+}

--- a/packages/registry/src/newEntityOptions/types.ts
+++ b/packages/registry/src/newEntityOptions/types.ts
@@ -17,13 +17,6 @@ export interface NewEntitySubscriptionInterface {
 	) => Subscriptions<NewEntitySubscriptionCbArgs<T>, NewEntitySubscriptionsOptions<T>>;
 }
 
-export interface NewEntitySubscription {
-	subscribe: NewEntitySubscribeFn;
-	getSubscriptions: <T extends string>(
-		options?: NewEntitySubscriptionsOptions<T>
-	) => Subscriptions<NewEntitySubscriptionCbArgs<T>, NewEntitySubscriptionsOptions<T>>;
-}
-
 export type NewEntitySubscribeFn = <T extends string>(
 	cb: NewEntitySubscriptionCb<T>,
 	options?: NewEntitySubscriptionsOptions<T>
@@ -45,11 +38,3 @@ export interface NewEntityOptionsProps {
 	className?: string;
 	optionItems: Array<React.ReactNode>;
 }
-
-export interface ActionsOptionsComponentProps {
-	[key: string]: any;
-}
-
-export type EntityOptionItems = {
-	[key: string]: React.ComponentType;
-};


### PR DESCRIPTION
This PR creates the million dollar modal registry to place the modal containers in global scope so that they can be opened closed from anywhere. This also prevents React state updates on closed (unmounted) modals.
Closes #186 