### PR TITLE
Fix duplicate modal buttons

### DIFF
--- a/packages/components/src/Modal/useCancelButtonProps.tsx
+++ b/packages/components/src/Modal/useCancelButtonProps.tsx
@@ -1,21 +1,18 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import type { ButtonProps } from '@eventespresso/adapters';
 
-const useCancelButtonProps = (onCloseModal: VoidFunction): ButtonProps => {
-	const onClick: ButtonProps['onClick'] = useCallback(() => {
-		onCloseModal();
-	}, [onCloseModal]);
-
-	return useMemo<ButtonProps>(
-		() => ({
-			buttonText: __('Cancel'),
-			onClick,
-			type: 'reset',
-		}),
-		[onClick]
-	);
+const useCancelButtonProps = (onCancel: VoidFunction): ButtonProps => {
+	return useMemo<ButtonProps>(() => {
+		return onCancel
+			? {
+					buttonText: __('Cancel'),
+					onCancel,
+					type: 'reset',
+			  }
+			: null;
+	}, [onCancel]);
 };
 
 export default useCancelButtonProps;

--- a/packages/components/src/Modal/useSubmitButtonProps.tsx
+++ b/packages/components/src/Modal/useSubmitButtonProps.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { SaveOutlined } from '@eventespresso/icons';
@@ -6,25 +6,18 @@ import { SaveOutlined } from '@eventespresso/icons';
 import { ButtonType } from '../../';
 import type { ButtonProps } from '../../';
 
-const useSubmitButtonProps = (onCloseModal: VoidFunction): ButtonProps => {
-	const onSubmit: ButtonProps['onClick'] = useCallback(
-		(e) => {
-			e.preventDefault();
-			onCloseModal();
-		},
-		[onCloseModal]
-	);
-
-	return useMemo<ButtonProps>(
-		() => ({
-			buttonText: __('Submit'),
-			buttonType: ButtonType.PRIMARY,
-			icon: SaveOutlined,
-			onClick: onSubmit,
-			type: 'submit',
-		}),
-		[onSubmit]
-	);
+const useSubmitButtonProps = (onSubmit: VoidFunction): ButtonProps => {
+	return useMemo<ButtonProps>(() => {
+		return onSubmit
+			? {
+					buttonText: __('Submit'),
+					buttonType: ButtonType.PRIMARY,
+					icon: SaveOutlined,
+					onClick: onSubmit,
+					type: 'submit',
+			  }
+			: null;
+	}, [onSubmit]);
 };
 
 export default useSubmitButtonProps;


### PR DESCRIPTION
Sometimes, we want to have custom submit or navigation buttons inside a modal. For example we have custom buttons in multi-step and REM modals. We usually use `ModalWithAlert` component for modals which renders the footer buttons by default.

This PR fixes that issue and doesn't render footer buttons unless their `onClick` callbacks are passed.