### PR TITLE
Unit tests for rrule-generator fromString utils

### DIFF
--- a/packages/rrule-generator/setupTests.ts
+++ b/packages/rrule-generator/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '../styles/node_modules/@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom/extend-expect';

--- a/packages/rrule-generator/src/context/ConfigProvider.tsx
+++ b/packages/rrule-generator/src/context/ConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import React, { createContext, useMemo } from 'react';
 
 import { RRuleConfig } from '../types';
 
@@ -10,7 +10,7 @@ export interface ConfigProviderProps {
 	config?: RRuleConfig;
 }
 
-const DEFAULT_CONFIG: RRuleConfig = {
+export const DEFAULT_CONFIG: RRuleConfig = {
 	frequencies: ['YEARLY', 'MONTHLY', 'WEEKLY', 'DAILY'],
 	yearlyModes: ['ON', 'ON_THE'],
 	monthlyModes: ['ON', 'ON_THE'],
@@ -21,7 +21,8 @@ const DEFAULT_CONFIG: RRuleConfig = {
 };
 
 const ConfigProvider: React.FC<ConfigProviderProps> = ({ children, config }) => {
-	const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+	const mergedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+
 	return <Provider value={mergedConfig}>{children}</Provider>;
 };
 

--- a/packages/rrule-generator/src/state/useInitialState.ts
+++ b/packages/rrule-generator/src/state/useInitialState.ts
@@ -1,81 +1,23 @@
 import { useCallback, useMemo } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { RRuleConfig } from '../types';
-import { StateInitializer, RRuleState } from './types';
-import { computeRRuleFromString } from '../utils';
+import { StateInitializer } from './types';
+import { computeRRuleFromString, getDefaultRRuleState } from '../utils';
 
 /**
  * Initializes the state dynamically by using the config.
  */
 const useInitialState = (config: RRuleConfig, rRuleString?: string): StateInitializer => {
-	const state = useMemo<RRuleState>(
-		() => ({
-			hash: uuidv4(),
-			start: {
-				date: new Date(),
-			},
-			repeat: {
-				frequency: config?.frequencies?.[0] || 'YEARLY',
-				yearly: {
-					mode: config?.yearlyModes?.[0] || 'ON',
-					on: {
-						month: 'Jan',
-						day: 1,
-					},
-					onThe: {
-						month: 'Jan',
-						day: 'MO',
-						which: 'FIRST',
-					},
-				},
-				monthly: {
-					mode: config?.monthlyModes?.[0] || 'ON',
-					interval: 1,
-					on: {
-						day: 1,
-					},
-					onThe: {
-						day: 'MO',
-						which: 'FIRST',
-					},
-				},
-				weekly: {
-					interval: 1,
-					days: {
-						MO: false,
-						TU: false,
-						WE: false,
-						TH: false,
-						FR: false,
-						SA: false,
-						SU: false,
-					},
-				},
-				daily: {
-					interval: 1,
-				},
-				hourly: {
-					interval: 1,
-				},
-			},
-			end: {
-				mode: config?.endModes?.[0] || 'NEVER',
-				after: 1,
-				date: new Date(),
-			},
-		}),
-		[config?.endModes, config?.frequencies, config?.monthlyModes, config?.yearlyModes]
-	);
+	const defaultState = useMemo(() => getDefaultRRuleState(config), [config]);
 
 	return useCallback<StateInitializer>(
 		(initialState) => {
 			// if rRule string is provided, use it to generate initial state
-			const data = rRuleString ? computeRRuleFromString(state, rRuleString) : state;
+			const state = rRuleString ? computeRRuleFromString(defaultState, rRuleString) : defaultState;
 
-			return { ...initialState, ...data };
+			return { ...initialState, ...state };
 		},
-		[rRuleString, state]
+		[rRuleString, defaultState]
 	);
 };
 

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeWeeklyDays.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeWeeklyDays.ts
@@ -1,8 +1,8 @@
 import { Weekday, Frequency } from 'rrule';
-import { ALL_WEEKDAYS } from 'rrule/dist/esm/src/weekday';
 
 import { ComputeRule } from './types';
 import { WeeklyRepeatOption } from '../../../types';
+import { ALL_WEEKDAYS } from '../toString/utils';
 
 const computeWeeklyDays: ComputeRule<WeeklyRepeatOption['days']> = (data, rruleObj) => {
 	let weekdays = [];

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeYearlyOnTheMonth.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeYearlyOnTheMonth.ts
@@ -5,7 +5,7 @@ import { Month } from '../../../types';
 import { getOnMonth } from './utils';
 
 const computeYearlyOnTheMonth: ComputeRule<Month> = (data, rruleObj) => {
-	if (rruleObj.freq !== Frequency.YEARLY || !rruleObj.byweekday) {
+	if (rruleObj.freq !== Frequency.YEARLY || !rruleObj.bymonth) {
 		return data?.repeat?.yearly?.onThe?.month;
 	}
 

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeYearlyOnTheWhich.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeYearlyOnTheWhich.ts
@@ -5,7 +5,7 @@ import { Which } from '../../../types';
 import { getOnTheWhich } from './utils';
 
 const computeYearlyOnTheWhich: ComputeRule<Which> = (data, rruleObj) => {
-	if (rruleObj.freq !== Frequency.YEARLY || !rruleObj.byweekday) {
+	if (rruleObj.freq !== Frequency.YEARLY || !rruleObj.bysetpos) {
 		return data?.repeat?.yearly?.onThe?.which;
 	}
 

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeDailyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeDailyInterval.test.ts
@@ -1,0 +1,24 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeDailyInterval from '../computeDailyInterval';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeDailyInterval', () => {
+	it('returns the default daily interval when frequency is not DAILY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeDailyInterval(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.daily?.interval);
+	});
+
+	it('returns the daily interval as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeDailyInterval(rRuleState, rruleObj);
+		expect(result).toBe(9);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeDailyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeDailyInterval.test.ts
@@ -21,4 +21,13 @@ describe('fromString.computeDailyInterval', () => {
 		const result = computeDailyInterval(rRuleState, rruleObj);
 		expect(result).toBe(9);
 	});
+
+	it('returns undefined when no interval is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeDailyInterval(rRuleState, rruleObj);
+		expect(result).toBeUndefined();
+	});
 });

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndAfter.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndAfter.test.ts
@@ -1,0 +1,24 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeEndAfter from '../computeEndAfter';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeEndAfter', () => {
+	it('returns the default end after when end mode is not after', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndAfter(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.end?.after);
+	});
+
+	it('returns the end after as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;COUNT=19;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndAfter(rRuleState, rruleObj);
+		expect(result).toBe(19);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndDate.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndDate.test.ts
@@ -1,0 +1,43 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeEndDate from '../computeEndDate';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeEndDate', () => {
+	it('returns the end date from generated rrule object', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndDate(rRuleState, rruleObj);
+		expect(result).toEqual(new Date(Date.UTC(2020, 8 /* Sep */, 22, 9, 39, 24)));
+	});
+
+	it('returns the end date from default state if rrule object does not have end date', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndDate(rRuleState, rruleObj);
+		expect(result).toEqual(rRuleState.end.date);
+	});
+
+	it('returns the end date from default state if end mode is not "ON_DATE"', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;COUNT=19;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndDate(rRuleState, rruleObj);
+		expect(result).toEqual(rRuleState.end.date);
+	});
+
+	it('returns undefined when rrule object does not have start date and no default is provided in data', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		// set start date to be null
+		const result = computeEndDate({ ...rRuleState, end: null }, rruleObj);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndMode.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeEndMode.test.ts
@@ -1,0 +1,33 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeEndMode from '../computeEndMode';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeEndMode', () => {
+	it('returns "AFTER" when COUNT is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;COUNT=19;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndMode(rRuleState, rruleObj);
+		expect(result).toBe('AFTER');
+	});
+
+	it('returns "ON_DATE" when UNTIL is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndMode(rRuleState, rruleObj);
+		expect(result).toBe('ON_DATE');
+	});
+
+	it('returns "NEVER" when no end is specified', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=9;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeEndMode(rRuleState, rruleObj);
+		expect(result).toBe('NEVER');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeFrequency.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeFrequency.test.ts
@@ -1,0 +1,60 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeFrequency from '../computeFrequency';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeFrequency', () => {
+	it('returns "YEARLY" for rrule string with yearly frequency', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=YEARLY';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe('YEARLY');
+	});
+
+	it('returns "MONTHLY" for rrule string with monthly frequency', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=MONTHLY';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe('MONTHLY');
+	});
+
+	it('returns "WEEKLY" for rrule string with weekly frequency', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=WEEKLY';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe('WEEKLY');
+	});
+
+	it('returns "DAILY" for rrule string with daily frequency', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=DAILY';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe('DAILY');
+	});
+
+	it('returns "HOURLY" for rrule string with hourly frequency', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=HOURLY';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe('HOURLY');
+	});
+
+	it('returns the default frequency for rrule string with no frequency set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200902T090000Z\nRRULE:COUNT=3\n';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeFrequency(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.frequency);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeHourlyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeHourlyInterval.test.ts
@@ -1,0 +1,24 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeHourlyInterval from '../computeHourlyInterval';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeHourlyInterval', () => {
+	it('returns the default hourly interval when frequency is not HOURLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeHourlyInterval(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.hourly?.interval);
+	});
+
+	it('returns the hourly interval as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=HOURLY;INTERVAL=11;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeHourlyInterval(rRuleState, rruleObj);
+		expect(result).toBe(11);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeHourlyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeHourlyInterval.test.ts
@@ -21,4 +21,13 @@ describe('fromString.computeHourlyInterval', () => {
 		const result = computeHourlyInterval(rRuleState, rruleObj);
 		expect(result).toBe(11);
 	});
+
+	it('returns undefined when no interval is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=HOURLY;UNTIL=20200922T093924Z;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeHourlyInterval(rRuleState, rruleObj);
+		expect(result).toBeUndefined();
+	});
 });

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyInterval.test.ts
@@ -1,0 +1,33 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeMonthlyInterval from '../computeMonthlyInterval';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeMonthlyInterval', () => {
+	it('returns the default monthly interval when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyInterval(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.interval);
+	});
+
+	it('returns the interval as set in rrule string when mode is "ON"', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=4;BYMONTHDAY=3;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyInterval(rRuleState, rruleObj);
+		expect(result).toBe(4);
+	});
+
+	it('returns the interval as set in rrule string when mode is "ON_THE"', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=1;BYDAY=WE;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyInterval(rRuleState, rruleObj);
+		expect(result).toBe(7);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyInterval.test.ts
@@ -30,4 +30,13 @@ describe('fromString.computeMonthlyInterval', () => {
 		const result = computeMonthlyInterval(rRuleState, rruleObj);
 		expect(result).toBe(7);
 	});
+
+	it('returns undefined when no interval is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;BYSETPOS=1;BYDAY=WE;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyInterval(rRuleState, rruleObj);
+		expect(result).toBeUndefined();
+	});
 });

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyMode.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyMode.test.ts
@@ -1,0 +1,33 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeMonthlyMode from '../computeMonthlyMode';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeMonthlyMode', () => {
+	it('returns the default monthly mode when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyMode(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.mode);
+	});
+
+	it('returns "ON" when BYMONTHDAY is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyMode(rRuleState, rruleObj);
+		expect(result).toBe('ON');
+	});
+
+	it('returns "ON_THE" when BYMONTHDAY is NOT set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYSETPOS=1;BYDAY=MO;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyMode(rRuleState, rruleObj);
+		expect(result).toBe('ON_THE');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnDay.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnDay.test.ts
@@ -1,0 +1,43 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeMonthlyOnDay from '../computeMonthlyOnDay';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeMonthlyOnDay', () => {
+	it('returns the default monthly on day when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=TU,WE;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnDay(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.on?.day);
+	});
+
+	it('returns the default monthly on day when bymonthday is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=9;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnDay(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.on?.day);
+	});
+
+	it('returns the monthly on day as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// 5
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYMONTHDAY=5;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeMonthlyOnDay(rRuleState, rruleObj);
+		expect(result).toBe(5);
+		// 31
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=31;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnDay(rRuleState, rruleObj);
+		expect(result).toBe(31);
+		// 1
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnDay(rRuleState, rruleObj);
+		expect(result).toBe(1);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnTheDay.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnTheDay.test.ts
@@ -1,0 +1,43 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeMonthlyOnTheDay from '../computeMonthlyOnTheDay';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeMonthlyOnTheDay', () => {
+	it('returns the default monthly on the day when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=DAILY;INTERVAL=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnTheDay(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.onThe?.day);
+	});
+
+	it('returns the default monthly on the day when byweekday is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnTheDay(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.onThe?.day);
+	});
+
+	it('returns the monthly on the day as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// FR
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=2;BYDAY=FR;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeMonthlyOnTheDay(rRuleState, rruleObj);
+		expect(result).toBe('FR');
+		// TU
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=3;BYDAY=TU;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheDay(rRuleState, rruleObj);
+		expect(result).toBe('TU');
+		// SA
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=3;BYDAY=SA;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheDay(rRuleState, rruleObj);
+		expect(result).toBe('SA');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnTheWhich.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeMonthlyOnTheWhich.test.ts
@@ -1,0 +1,53 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeMonthlyOnTheWhich from '../computeMonthlyOnTheWhich';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeMonthlyOnTheWhich', () => {
+	it('returns the default monthly on the which when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.onThe?.which);
+	});
+
+	it('returns the default monthly on the which when bysetpos is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYDAY=TU;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.monthly?.onThe?.which);
+	});
+
+	it('returns the monthly on the which as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// FIRST
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=1;BYDAY=TU;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('FIRST');
+		// SECOND
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=2;BYDAY=MO;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('SECOND');
+		// THIRD
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=3;BYDAY=MO;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('THIRD');
+		// FOURTH
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=4;BYDAY=MO;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('FOURTH');
+		// LAST
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=7;BYSETPOS=-1;BYDAY=MO;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeMonthlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('LAST');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeStartDate.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeStartDate.test.ts
@@ -1,0 +1,34 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeStartDate from '../computeStartDate';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeStartDate', () => {
+	it('returns the start date from generated rrule object', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200902T090000Z\nRRULE:FREQ=YEARLY;COUNT=3\n';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeStartDate(rRuleState, rruleObj);
+		expect(result).toEqual(new Date(Date.UTC(2020, 8 /* Sep */, 2, 9)));
+	});
+
+	it('returns the start date from default state if rrule object does not have start date', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=YEARLY;COUNT=3\n';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeStartDate(rRuleState, rruleObj);
+		expect(result).toEqual(rRuleState.start.date);
+	});
+
+	it('returns undefined when rrule object does not have start date and no default is provided in data', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'RRULE:FREQ=YEARLY;COUNT=3\n';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		// set start date to be null
+		const result = computeStartDate({ ...rRuleState, start: null }, rruleObj);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyDays.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyDays.test.ts
@@ -1,0 +1,39 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeWeeklyDays from '../computeWeeklyDays';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeWeeklyDays', () => {
+	it('returns the default weekly days when frequency is not WEEKLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyDays(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.weekly?.days);
+	});
+
+	it('returns the default weekly days when weekdays are not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyDays(rRuleState, rruleObj);
+		Object.entries(result).forEach(([, isDayActive]) => {
+			expect(isDayActive).toBe(false);
+		});
+	});
+
+	it('returns the weekdays as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		const weeklyDays = ['WE', 'TH', 'SA'];
+		const rrule =
+			'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=' + weeklyDays.join(',') + ';COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyDays(rRuleState, rruleObj);
+		Object.entries(result).forEach(([day, isDayActive]) => {
+			expect(isDayActive).toBe(weeklyDays.includes(day));
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyInterval.test.ts
@@ -1,0 +1,33 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeWeeklyInterval from '../computeWeeklyInterval';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeWeeklyInterval', () => {
+	it('returns the default weekly interval when frequency is not WEEKLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyInterval(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.weekly?.interval);
+	});
+
+	it('returns the weekly interval as set in rrule string when no weekday is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyInterval(rRuleState, rruleObj);
+		expect(result).toBe(2);
+	});
+
+	it('returns the weekly interval as set in rrule string when weekday is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;INTERVAL=8;BYDAY=WE,TH,SA;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyInterval(rRuleState, rruleObj);
+		expect(result).toBe(8);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyInterval.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeWeeklyInterval.test.ts
@@ -30,4 +30,13 @@ describe('fromString.computeWeeklyInterval', () => {
 		const result = computeWeeklyInterval(rRuleState, rruleObj);
 		expect(result).toBe(8);
 	});
+
+	it('returns undefined when no interval is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=WEEKLY;BYDAY=WE,TH,SA;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeWeeklyInterval(rRuleState, rruleObj);
+		expect(result).toBeUndefined();
+	});
 });

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyMode.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyMode.test.ts
@@ -1,0 +1,43 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyMode from '../computeYearlyMode';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyMode', () => {
+	it('returns the default yearly mode when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyMode(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.mode);
+	});
+
+	it('returns the default yearly mode when bymonth is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyMode(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.mode);
+	});
+
+	it('returns "ON" when BYMONTHDAY is set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyMode(rRuleState, rruleObj);
+		expect(result).toBe('ON');
+	});
+
+	it('returns "ON_THE" when BYMONTHDAY is NOT set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule =
+			'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=1;BYDAY=MO;BYMONTH=1;COUNT=1;WKST=MO;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyMode(rRuleState, rruleObj);
+		expect(result).toBe('ON_THE');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnMonth.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnMonth.test.ts
@@ -1,0 +1,51 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyOnMonth from '../computeYearlyOnMonth';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyOnMonth', () => {
+	it('returns the default yearly on month when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.on?.month);
+	});
+
+	it('returns the default yearly on month when bymonthday is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.on?.month);
+	});
+
+	it('returns the yearly on month as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// Jan
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe('Jan');
+
+		// Feb
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe('Feb');
+
+		// May
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe('May');
+
+		// Dec
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonth(rRuleState, rruleObj);
+		expect(result).toBe('Dec');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnMonthday.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnMonthday.test.ts
@@ -1,0 +1,48 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyOnMonthday from '../computeYearlyOnMonthday';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyOnMonthday', () => {
+	it('returns the default yearly on month day when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.on?.day);
+	});
+
+	it('returns the default yearly on month day when bymonthday is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.on?.day);
+	});
+
+	it('returns the yearly on month day as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// 1 for Feb
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=1;COUNT=1';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(1);
+		// 28 for Feb
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=28;COUNT=1';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(28);
+		// 29 for Feb
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29;COUNT=1';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(29);
+		// 31 for July
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYMONTH=7;BYMONTHDAY=31;COUNT=1';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnMonthday(rRuleState, rruleObj);
+		expect(result).toBe(31);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheMonth.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheMonth.test.ts
@@ -1,0 +1,51 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyOnTheMonth from '../computeYearlyOnTheMonth';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyOnTheMonth', () => {
+	it('returns the default yearly on the month when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.month);
+	});
+
+	it('returns the default yearly on month when bymonth is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=MO;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.month);
+	});
+
+	it('returns the yearly on the month as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// Jan
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=MO;BYMONTH=1;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe('Jan');
+
+		// Feb
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=MO;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe('Feb');
+
+		// May
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=MO;BYMONTH=5;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe('May');
+
+		// Dec
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=MO;BYMONTH=12;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheMonth(rRuleState, rruleObj);
+		expect(result).toBe('Dec');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheMonthday.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheMonthday.test.ts
@@ -1,0 +1,43 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyOnTheMonthday from '../computeYearlyOnTheMonthday';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyOnTheMonthday', () => {
+	it('returns the default yearly on the month day when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheMonthday(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.day);
+	});
+
+	it('returns the default yearly on the month day when byweekday is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheMonthday(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.day);
+	});
+
+	it('returns the yearly on the month day as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// TU
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=TU;BYMONTH=2;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeYearlyOnTheMonthday(rRuleState, rruleObj);
+		expect(result).toBe('TU');
+		// WE
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheMonthday(rRuleState, rruleObj);
+		expect(result).toBe('WE');
+		// SA
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=SA;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheMonthday(rRuleState, rruleObj);
+		expect(result).toBe('SA');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheWhich.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/tests/computeYearlyOnTheWhich.test.ts
@@ -1,0 +1,53 @@
+import { rrulestr as RRuleObjectFromString } from 'rrule';
+
+import computeYearlyOnTheWhich from '../computeYearlyOnTheWhich';
+import { getDefaultRRuleState } from '../../../misc';
+
+describe('fromString.computeYearlyOnTheWhich', () => {
+	it('returns the default yearly on the which when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.which);
+	});
+
+	it('returns the default yearly on the which when bysetpos is not set', () => {
+		const rRuleState = getDefaultRRuleState();
+		const rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		const rruleObj = RRuleObjectFromString(rrule).origOptions;
+
+		const result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe(rRuleState?.repeat?.yearly?.onThe?.which);
+	});
+
+	it('returns the yearly on the which as set in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+		// FIRST
+		let rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		let rruleObj = RRuleObjectFromString(rrule).origOptions;
+		let result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('FIRST');
+		// SECOND
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=2;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('SECOND');
+		// THIRD
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=3;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('THIRD');
+		// FOURTH
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=4;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('FOURTH');
+		// LAST
+		rrule = 'DTSTART:20200901T092307Z\nRRULE:FREQ=YEARLY;BYSETPOS=-1;BYDAY=WE;BYMONTH=2;COUNT=1;WKST=MO';
+		rruleObj = RRuleObjectFromString(rrule).origOptions;
+		result = computeYearlyOnTheWhich(rRuleState, rruleObj);
+		expect(result).toBe('LAST');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/utils.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/utils.ts
@@ -1,8 +1,10 @@
 import { WeekdayStr } from 'rrule';
-import { ALL_WEEKDAYS, Weekday } from 'rrule/dist/esm/src/weekday';
+import { Weekday } from 'rrule/dist/es5/rrule';
 import { parse, getMonth } from 'date-fns';
 
 import { Which, Day, Month } from '../../../types';
+
+export const ALL_WEEKDAYS: Array<WeekdayStr> = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
 
 export const getBySetPos = (which: Which): number => {
 	let bysetpos: number;

--- a/packages/rrule-generator/src/utils/misc.ts
+++ b/packages/rrule-generator/src/utils/misc.ts
@@ -1,6 +1,10 @@
-import { RRuleStateManager as RSM } from '../state';
-import { OnChangeInput } from '../components/types';
 import { useCallback } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { RRuleStateManager as RSM, RRuleState } from '../state';
+import { OnChangeInput } from '../components/types';
+import { DEFAULT_CONFIG } from '../context';
+
 export const getNumericValue = (value: unknown, defaultValue?: 0): number => {
 	// Convert input from a string to a number
 	const numericValue = Math.abs(value as number);
@@ -18,4 +22,62 @@ export const useIntervalUpdater = (
 		},
 		[repeatKey, setRepeatInterval]
 	);
+};
+
+export const getDefaultRRuleState = (config = DEFAULT_CONFIG): RRuleState => {
+	return {
+		hash: uuidv4(),
+		start: {
+			date: new Date(),
+		},
+		repeat: {
+			frequency: config?.frequencies?.[0] || 'YEARLY',
+			yearly: {
+				mode: config?.yearlyModes?.[0] || 'ON',
+				on: {
+					month: 'Jan',
+					day: 1,
+				},
+				onThe: {
+					month: 'Jan',
+					day: 'MO',
+					which: 'FIRST',
+				},
+			},
+			monthly: {
+				mode: config?.monthlyModes?.[0] || 'ON',
+				interval: 1,
+				on: {
+					day: 1,
+				},
+				onThe: {
+					day: 'MO',
+					which: 'FIRST',
+				},
+			},
+			weekly: {
+				interval: 1,
+				days: {
+					MO: false,
+					TU: false,
+					WE: false,
+					TH: false,
+					FR: false,
+					SA: false,
+					SU: false,
+				},
+			},
+			daily: {
+				interval: 1,
+			},
+			hourly: {
+				interval: 1,
+			},
+		},
+		end: {
+			mode: config?.endModes?.[0] || 'NEVER',
+			after: 1,
+			date: new Date(),
+		},
+	};
 };


### PR DESCRIPTION
This PR adds unit tests to `rrule-generator` package `fromString` utils and thus fixes a few minor issues with the utils.

Closes #127