### PR TITLE
Unit tests for rrule-generator toString utils

### DIFF
--- a/packages/rrule-generator/src/components/Repeat/Frequency.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Frequency.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { __ } from '@wordpress/i18n';
 
 import Yearly from './Yearly';
 import Monthly from './Monthly';

--- a/packages/rrule-generator/src/components/Repeat/Frequency.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Frequency.tsx
@@ -10,18 +10,9 @@ import Hourly from './Hourly';
 import { Frequency as FrequencyType } from '../../types';
 import { useRRuleConfig } from '../../hooks';
 import { FrequencyProps } from './types';
+import { FREQUENCY } from '../../constants';
 
 import './styles.scss';
-
-const frequencyLabels: { [key in FrequencyType]: string } = {
-	YEARLY: __('Yearly'),
-	MONTHLY: __('Monthly'),
-	WEEKLY: __('Weekly'),
-	DAILY: __('Daily'),
-	HOURLY: __('Hourly'),
-	MINUTELY: __('Minutely'),
-	SECONDLY: __('Secondly'),
-};
 
 const Frequency: React.FC<FrequencyProps> = ({ id, frequency, onChange }) => {
 	const { frequencies: frequencyTypes } = useRRuleConfig();
@@ -44,7 +35,7 @@ const Frequency: React.FC<FrequencyProps> = ({ id, frequency, onChange }) => {
 				{frequencyTypes.map((frequencyType) => {
 					return (
 						<option key={frequencyType} value={frequencyType}>
-							{frequencyLabels?.[frequencyType]}
+							{FREQUENCY?.[frequencyType]}
 						</option>
 					);
 				})}

--- a/packages/rrule-generator/src/constants.ts
+++ b/packages/rrule-generator/src/constants.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { Weekday, Frequency } from './types';
 
 export const MONTHS = {
 	Jan: __('Jan'),
@@ -36,4 +37,16 @@ export const SHORT_DAYS = {
 	FR: __('Fri'),
 	SA: __('Sat'),
 	SU: __('Sun'),
+};
+
+export const ALL_WEEKDAYS: Array<Weekday> = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
+export const FREQUENCY: { [key in Frequency]: string } = {
+	YEARLY: __('Yearly'),
+	MONTHLY: __('Monthly'),
+	WEEKLY: __('Weekly'),
+	DAILY: __('Daily'),
+	HOURLY: __('Hourly'),
+	MINUTELY: __('Minutely'),
+	SECONDLY: __('Secondly'),
 };

--- a/packages/rrule-generator/src/utils/computeRRule/fromString/computeWeeklyDays.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/fromString/computeWeeklyDays.ts
@@ -2,7 +2,7 @@ import { Weekday, Frequency } from 'rrule';
 
 import { ComputeRule } from './types';
 import { WeeklyRepeatOption } from '../../../types';
-import { ALL_WEEKDAYS } from '../toString/utils';
+import { ALL_WEEKDAYS } from '../../../constants';
 
 const computeWeeklyDays: ComputeRule<WeeklyRepeatOption['days']> = (data, rruleObj) => {
 	let weekdays = [];

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeDaily.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeDaily.test.ts
@@ -1,0 +1,84 @@
+import { RRule, Frequency as RRuleFrequency } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+
+describe('toString.computeDaily', () => {
+	it('contains the passed DAILY value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'DAILY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.DAILY);
+	});
+
+	it('contains value for interval in rrule string when DAILY mode', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'DAILY',
+			daily: {
+				...rRuleState.repeat.daily,
+				interval: 46,
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('interval');
+		expect(parsedRRule.interval).toBe(46);
+	});
+
+	it('does not contain value for interval in rrule string when frequency is not DAILY', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('interval');
+	});
+
+	it('does not contain value for interval in rrule string when interval is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((interval) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency: 'DAILY',
+				daily: {
+					...rRuleState.repeat.daily,
+					interval,
+				},
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('interval');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeEnd.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeEnd.test.ts
@@ -1,0 +1,73 @@
+import { RRule } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from 'packages/rrule-generator/src/state';
+
+describe('toString.computeEnd', () => {
+	it('contains value for "count" in rrule string for default state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('count');
+		expect(parsedRRule).not.toHaveProperty('until');
+		expect(parsedRRule.count).toBe(rRuleState?.end?.after);
+	});
+	it('contains value for "count" in rrule string when end mode is "AFTER"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const end: RRuleState['end'] = {
+			...rRuleState.end,
+			mode: 'AFTER',
+		};
+
+		const result = computeRRule({ ...rRuleState, end }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('count');
+		expect(parsedRRule).not.toHaveProperty('until');
+		expect(parsedRRule.count).toBe(rRuleState?.end?.after);
+	});
+	it('contains value for "until" in rrule string when end mode is "AFTER"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const end: RRuleState['end'] = {
+			...rRuleState.end,
+			mode: 'ON_DATE',
+		};
+
+		const result = computeRRule({ ...rRuleState, end }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('until');
+		expect(parsedRRule).not.toHaveProperty('count');
+		expect(parsedRRule.until).toBeInstanceOf(Date);
+	});
+
+	it('does not contain value for "count" or "until" in rrule string when end mode is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((mode) => {
+			const end: RRuleState['end'] = {
+				mode,
+			};
+
+			const result = computeRRule({ ...rRuleState, end }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('until');
+			expect(parsedRRule).not.toHaveProperty('count');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeHourly.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeHourly.test.ts
@@ -1,0 +1,84 @@
+import { RRule, Frequency as RRuleFrequency } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+
+describe('toString.computeHourly', () => {
+	it('contains the passed HOURLY value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'HOURLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.HOURLY);
+	});
+
+	it('contains value for interval in rrule string when HOURLY mode', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'HOURLY',
+			hourly: {
+				...rRuleState.repeat.hourly,
+				interval: 46,
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('interval');
+		expect(parsedRRule.interval).toBe(46);
+	});
+
+	it('does not contain value for interval in rrule string when frequency is not HOURLY', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('interval');
+	});
+
+	it('does not contain value for interval in rrule string when interval is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((interval) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency: 'HOURLY',
+				hourly: {
+					...rRuleState.repeat.hourly,
+					interval,
+				},
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('interval');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthly.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthly.test.ts
@@ -1,0 +1,84 @@
+import { RRule, Frequency as RRuleFrequency } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+
+describe('toString.computeMonthly', () => {
+	it('contains the passed MONTHLY value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'MONTHLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.MONTHLY);
+	});
+
+	it('contains value for interval in rrule string when MONTHLY mode', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'MONTHLY',
+			monthly: {
+				...rRuleState.repeat.monthly,
+				interval: 46,
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('interval');
+		expect(parsedRRule.interval).toBe(46);
+	});
+
+	it('does not contain value for interval in rrule string when frequency is not MONTHLY', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('interval');
+	});
+
+	it('does not contain value for interval in rrule string when interval is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((interval) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency: 'MONTHLY',
+				monthly: {
+					...rRuleState.repeat.monthly,
+					interval,
+				},
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('interval');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthlyOn.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthlyOn.test.ts
@@ -1,0 +1,74 @@
+import { RRule } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+
+describe('toString.computeMonthlyOn', () => {
+	it('contains the value for bymonth and bymonthday for the passed values', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			frequency: 'MONTHLY',
+			monthly: {
+				...rRuleState?.repeat?.monthly,
+				mode: 'ON',
+				on: {
+					day: 23,
+				},
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bymonthday');
+		expect(parsedRRule.bymonthday).toBe(23);
+	});
+
+	it('does not contain the value for bymonthday mode is not "ON"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			frequency: 'MONTHLY',
+			monthly: {
+				...rRuleState?.repeat?.monthly,
+				mode: 'ON_THE',
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bymonthday');
+	});
+
+	it('does not contain the value for bymonthday mode is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((mode) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState?.repeat,
+				frequency: 'MONTHLY',
+				monthly: {
+					...rRuleState?.repeat?.monthly,
+					mode,
+				},
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('bymonthday');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthlyOnThe.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeMonthlyOnThe.test.ts
@@ -1,0 +1,74 @@
+import { RRule, Weekday } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+import { getBySetPos } from '../utils';
+
+describe('toString.computeMonthlyOnThe', () => {
+	it('does not contain the default value for bysetpos and byweekday for default state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			frequency: 'MONTHLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bysetpos');
+		expect(parsedRRule).not.toHaveProperty('byweekday');
+	});
+
+	it('contains the value for bymonth, bysetpos and byweekday when mode is "ON_THE"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			frequency: 'MONTHLY',
+			monthly: {
+				...rRuleState?.repeat?.monthly,
+				mode: 'ON_THE',
+				onThe: {
+					day: 'FR',
+					which: 'SECOND',
+				},
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bysetpos');
+		expect(parsedRRule).toHaveProperty('byweekday');
+		expect(parsedRRule.bysetpos).toBe(getBySetPos('SECOND'));
+		expect(parsedRRule.byweekday[0]).toEqual(Weekday.fromStr('FR'));
+	});
+
+	it('does not contain the value for bysetpos and byweekday mode is not "ON_THE"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			frequency: 'MONTHLY',
+			monthly: {
+				...rRuleState?.repeat?.monthly,
+				mode: 'ON',
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bysetpos');
+		expect(parsedRRule).not.toHaveProperty('byweekday');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeOptions.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeOptions.test.ts
@@ -1,0 +1,63 @@
+import { RRule, Weekday, WeekdayStr } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { ALL_WEEKDAYS } from '../../../../constants';
+
+describe('toString.computeOptions', () => {
+	it('contains value for "dtstart" and default "wkst" in rrule string for default config', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('dtstart');
+		expect(parsedRRule).toHaveProperty('wkst');
+		expect(parsedRRule.dtstart).toBeInstanceOf(Date);
+		expect((parsedRRule.wkst as Weekday).weekday).toBe(Weekday.fromStr(DEFAULT_CONFIG.weekStartsOn).weekday);
+	});
+
+	it('does not contain value for "dtstart" when hideStart is passed', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const hideStart = true;
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG, hideStart);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('dtstart');
+	});
+
+	it('does not contain value for "wkst" when "weekStartsOn" is empty or nill', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		['', null, undefined].forEach((weekStartsOn: WeekdayStr) => {
+			const result = computeRRule(rRuleState, { ...DEFAULT_CONFIG, weekStartsOn });
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('wkst');
+		});
+	});
+
+	it('contains the passed value for "wkst" in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		ALL_WEEKDAYS.forEach((weekStartsOn) => {
+			const result = computeRRule(rRuleState, { ...DEFAULT_CONFIG, weekStartsOn });
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).toHaveProperty('wkst');
+			expect(parsedRRule.wkst).toBeInstanceOf(Weekday);
+			expect(parsedRRule.wkst.toString()).toBe(weekStartsOn);
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeRepeat.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeRepeat.test.ts
@@ -1,0 +1,61 @@
+import { RRule, Frequency as RRuleFrequency } from 'rrule';
+import { omit } from 'ramda';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+import { Frequency } from '../../../../types';
+import { FREQUENCY } from '../../../../constants';
+
+describe('toString.computeRepeat', () => {
+	it('contains default value for frequency in rrule string for default state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRule?.[rRuleState?.repeat?.frequency]);
+	});
+
+	it('contains the passed value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		// 'MINUTELY', 'SECONDLY' are not handled by rrule-generator
+		Object.keys(omit(['MINUTELY', 'SECONDLY'], FREQUENCY)).forEach((frequency: Frequency) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency,
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).toHaveProperty('freq');
+			expect(parsedRRule.freq).toBe(RRuleFrequency?.[frequency]);
+		});
+	});
+
+	it('does not contain value for frequency in rrule string when frequency is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((frequency) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency,
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('freq');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeStart.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeStart.test.ts
@@ -1,0 +1,56 @@
+import { RRule } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+
+describe('toString.computeStart', () => {
+	it('contains default value for DTSTART in rrule string when start date is in state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('dtstart');
+		expect(parsedRRule.dtstart).toBeInstanceOf(Date);
+	});
+
+	it('contains default value for DTSTART in rrule string when start date is NOT in state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule({ ...rRuleState, start: {} }, DEFAULT_CONFIG);
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('dtstart');
+		expect(parsedRRule.dtstart).toBeInstanceOf(Date);
+	});
+
+	it('contains default value for DTSTART in rrule string when start date is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((date) => {
+			const result = computeRRule({ ...rRuleState, start: { date } }, DEFAULT_CONFIG);
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).toHaveProperty('dtstart');
+			expect(parsedRRule.dtstart).toBeInstanceOf(Date);
+		});
+	});
+
+	it('contains the passed value for DTSTART in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const inputDate = new Date(Date.UTC(2020, 8 /* Sep */, 2, 9));
+
+		const result = computeRRule({ ...rRuleState, start: { date: inputDate } }, DEFAULT_CONFIG);
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('dtstart');
+		expect(parsedRRule.dtstart).toBeInstanceOf(Date);
+		expect(parsedRRule.dtstart).toEqual(inputDate);
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeWeekly.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeWeekly.test.ts
@@ -1,0 +1,118 @@
+import { RRule, Frequency as RRuleFrequency, Weekday } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+import { weekdayStringToNumber } from '../utils';
+
+describe('toString.computeWeekly', () => {
+	it('contains the passed WEEKLY value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'WEEKLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.WEEKLY);
+	});
+
+	it('contains value for interval in rrule string when WEEKLY mode', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'WEEKLY',
+			weekly: {
+				...rRuleState.repeat.weekly,
+				interval: 46,
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('interval');
+		expect(parsedRRule.interval).toBe(46);
+	});
+
+	it('does not contain value for interval in rrule string when frequency is not WEEKLY', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('interval');
+	});
+
+	it('does not contain value for interval in rrule string when interval is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((interval) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency: 'WEEKLY',
+				weekly: {
+					...rRuleState.repeat.weekly,
+					interval,
+				},
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('interval');
+		});
+	});
+
+	it('contains passed value for byweekday in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'WEEKLY',
+			weekly: {
+				...rRuleState.repeat.weekly,
+				days: {
+					...rRuleState.repeat.weekly.days,
+					WE: true,
+					FR: true,
+				},
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		// convert weekday object to numbers
+		const weekdayNumbers = (parsedRRule.byweekday as Weekday[]).map((weekday) => weekday.weekday);
+
+		expect(parsedRRule).toHaveProperty('byweekday');
+		expect(weekdayNumbers).toContain(weekdayStringToNumber('WE'));
+		expect(weekdayNumbers).toContain(weekdayStringToNumber('FR'));
+		expect(weekdayNumbers).not.toContain(weekdayStringToNumber('MO'));
+		expect(weekdayNumbers).not.toContain(weekdayStringToNumber('TU'));
+		expect(weekdayNumbers).not.toContain(weekdayStringToNumber('TH'));
+		expect(weekdayNumbers).not.toContain(weekdayStringToNumber('SA'));
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearly.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearly.test.ts
@@ -1,0 +1,77 @@
+import { RRule, Frequency as RRuleFrequency } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+
+describe('toString.computeYearly', () => {
+	it('contains the passed YEARLY value for frequency in rrule string', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.YEARLY);
+	});
+
+	it('contains value for bymonth in rrule string when YEARLY mode', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'YEARLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bymonth');
+	});
+
+	it('does not contain YEARLY value for frequency in rrule string when frequency is not YEARLY', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState.repeat,
+			frequency: 'MONTHLY',
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('freq');
+		expect(parsedRRule.freq).toBe(RRuleFrequency.MONTHLY);
+		expect(parsedRRule.freq).not.toBe(RRuleFrequency.YEARLY);
+	});
+
+	it('does not contain YEARLY value for frequency in rrule string when frequency is null or undefined', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		[null, undefined].forEach((frequency) => {
+			const repeat: RRuleState['repeat'] = {
+				...rRuleState.repeat,
+				frequency,
+			};
+
+			const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+			// parse the generated string
+			const parsedRRule = RRule.parseString(result);
+
+			expect(parsedRRule).not.toHaveProperty('freq');
+		});
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearlyOn.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearlyOn.test.ts
@@ -1,0 +1,68 @@
+import { RRule } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+import { getByMonth } from '../utils';
+
+describe('toString.computeYearlyOn', () => {
+	it('contains the default value for bymonth and bymonthday for default state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bymonth');
+		expect(parsedRRule).toHaveProperty('bymonthday');
+		expect(parsedRRule.bymonth).toBe(getByMonth(rRuleState?.repeat?.yearly?.on?.month));
+		expect(parsedRRule.bymonthday).toBe(rRuleState?.repeat?.yearly?.on?.day);
+	});
+
+	it('contains the value for bymonth and bymonthday for the passed values', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			yearly: {
+				...rRuleState?.repeat?.yearly,
+				mode: 'ON',
+				on: {
+					month: 'Aug',
+					day: 23,
+				},
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bymonth');
+		expect(parsedRRule).toHaveProperty('bymonthday');
+		expect(parsedRRule.bymonth).toBe(8 /* Aug */);
+		expect(parsedRRule.bymonthday).toBe(23);
+	});
+
+	it('does not contain the value for bymonthday mode is not "ON"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			yearly: {
+				...rRuleState?.repeat?.yearly,
+				mode: 'ON_THE',
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bymonthday');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearlyOnThe.test.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/tests/computeYearlyOnThe.test.ts
@@ -1,0 +1,70 @@
+import { RRule, Weekday } from 'rrule';
+
+import computeRRule from '../computeRRule';
+import { getDefaultRRuleState } from '../../../misc';
+import { DEFAULT_CONFIG } from '../../../../context';
+import { RRuleState } from '../../../../state';
+import { getBySetPos } from '../utils';
+
+describe('toString.computeYearlyOnThe', () => {
+	it('does not contain the default value for bysetpos and byweekday for default state', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const result = computeRRule(rRuleState, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bysetpos');
+		expect(parsedRRule).not.toHaveProperty('byweekday');
+	});
+
+	it('contains the value for bymonth, bysetpos and byweekday when mode is "ON_THE"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			yearly: {
+				...rRuleState?.repeat?.yearly,
+				mode: 'ON_THE',
+				onThe: {
+					day: 'FR',
+					which: 'SECOND',
+					month: 'Jun',
+				},
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).toHaveProperty('bysetpos');
+		expect(parsedRRule).toHaveProperty('bymonth');
+		expect(parsedRRule).toHaveProperty('byweekday');
+		expect(parsedRRule.bymonth).toBe(6 /* Jun */);
+		expect(parsedRRule.bysetpos).toBe(getBySetPos('SECOND'));
+		expect(parsedRRule.byweekday[0]).toEqual(Weekday.fromStr('FR'));
+	});
+
+	it('does not contain the value for bysetpos and byweekday mode is not "ON_THE"', () => {
+		const rRuleState = getDefaultRRuleState();
+
+		const repeat: RRuleState['repeat'] = {
+			...rRuleState?.repeat,
+			yearly: {
+				...rRuleState?.repeat?.yearly,
+				mode: 'ON',
+			},
+		};
+
+		const result = computeRRule({ ...rRuleState, repeat }, DEFAULT_CONFIG);
+
+		// parse the generated string
+		const parsedRRule = RRule.parseString(result);
+
+		expect(parsedRRule).not.toHaveProperty('bysetpos');
+		expect(parsedRRule).not.toHaveProperty('byweekday');
+	});
+});

--- a/packages/rrule-generator/src/utils/computeRRule/toString/utils.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/utils.ts
@@ -3,8 +3,7 @@ import { Weekday } from 'rrule/dist/es5/rrule';
 import { parse, getMonth } from 'date-fns';
 
 import { Which, Day, Month } from '../../../types';
-
-export const ALL_WEEKDAYS: Array<WeekdayStr> = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+import { ALL_WEEKDAYS } from '../../../constants';
 
 export const getBySetPos = (which: Which): number => {
 	let bysetpos: number;


### PR DESCRIPTION
This PR adds tests for `toString` utils of `rrule-generator` package.

Closes #128 