### PR TITLE
rrule-generator state unit tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,14 @@ jobs:
               run: yarn install --frozen-lockfile
             # Build the core domains along with all the packages
             # because all packages will goto core
-            - name: Build core domains and all packages
+            - name: Build core domains and all its packages
               run: yarn build:core
             # Deploy the built assets to core repo's assets/dist
             - name: Deploy to event-espresso-core
               run: source tools/deploy.sh "event-espresso-core"
             # Build REM domain without packages
             # because core will load/register the packages
-            - name: Build REM without building packages
+            - name: Build REM with its packages
               run: yarn build:rem
             # Deploy the built assets to REM assets/dist
             - name: Deploy to REM

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
               run: yarn install --frozen-lockfile
             # Build the core domains along with all the packages
             # because all packages will goto core
-            - name: Build core domains and all its packages
+            - name: Build core domains and all their packages
               run: yarn build:core
             # Deploy the built assets to core repo's assets/dist
             - name: Deploy to event-espresso-core

--- a/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
@@ -21,7 +21,7 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 	const onChangeWhich = useCallback<OnChangeSelect>(
 		(event) => {
 			const value = event.target.value as Which;
-			setRepeatWhich('monthly', 'onThe', value);
+			setRepeatWhich('monthly', value);
 		},
 		[setRepeatWhich]
 	);

--- a/packages/rrule-generator/src/components/Repeat/PositionSelect.tsx
+++ b/packages/rrule-generator/src/components/Repeat/PositionSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { __ } from '@wordpress/i18n';
 
 import { PositionSelectProps } from './types';
+import { WHICH } from '../../constants';
 
 const PositionSelect: React.FC<PositionSelectProps> = ({ id, isActive, name, onChangeWhich, value, ...props }) => (
 	<select
@@ -13,11 +13,11 @@ const PositionSelect: React.FC<PositionSelectProps> = ({ id, isActive, name, onC
 		disabled={!isActive}
 		onChange={onChangeWhich}
 	>
-		<option value='FIRST'>{__('First')}</option>
-		<option value='SECOND'>{__('Second')}</option>
-		<option value='THIRD'>{__('Third')}</option>
-		<option value='FOURTH'>{__('Fourth')}</option>
-		<option value='LAST'>{__('Last')}</option>
+		{Object.entries(WHICH).map(([key, label]) => (
+			<option key={key} value={key}>
+				{label}
+			</option>
+		))}
 	</select>
 );
 

--- a/packages/rrule-generator/src/components/Repeat/Yearly/OnThe.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Yearly/OnThe.tsx
@@ -22,7 +22,7 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 	const onChangeWhich = useCallback<OnChangeSelect>(
 		(event) => {
 			const value = event.target.value as Which;
-			setRepeatWhich('yearly', 'onThe', value);
+			setRepeatWhich('yearly', value);
 		},
 		[setRepeatWhich]
 	);

--- a/packages/rrule-generator/src/constants.ts
+++ b/packages/rrule-generator/src/constants.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Weekday, Frequency } from './types';
+import { Weekday, Frequency, Which } from './types';
 
 export const MONTHS = {
 	Jan: __('Jan'),
@@ -49,4 +49,12 @@ export const FREQUENCY: { [key in Frequency]: string } = {
 	HOURLY: __('Hourly'),
 	MINUTELY: __('Minutely'),
 	SECONDLY: __('Secondly'),
+};
+
+export const WHICH: { [key in Which]: string } = {
+	FIRST: __('First'),
+	SECOND: __('Second'),
+	THIRD: __('Third'),
+	FOURTH: __('Fourth'),
+	LAST: __('Last'),
 };

--- a/packages/rrule-generator/src/context/ConfigProvider.tsx
+++ b/packages/rrule-generator/src/context/ConfigProvider.tsx
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG: RRuleConfig = {
 	endModes: ['AFTER', 'ON_DATE'],
 	weekStartsOn: 'MO',
 	enableTimepicker: true,
-	// locale: 'en_US',
+	locale: 'en_US',
 };
 
 const ConfigProvider: React.FC<ConfigProviderProps> = ({ children, config }) => {

--- a/packages/rrule-generator/src/state/tests/getData.test.ts
+++ b/packages/rrule-generator/src/state/tests/getData.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { getDefaultRRuleState } from '../../utils';
+
+describe('RRuleStateManager.getData', () => {
+	it('returns the initial state', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const state = result.current.getData();
+
+		expect(state).toHaveProperty('start');
+		expect(state).toHaveProperty('end');
+		expect(state).toHaveProperty('repeat');
+	});
+
+	it('returns the state set via setData', () => {
+		const defaultState = getDefaultRRuleState(DEFAULT_CONFIG);
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setData(defaultState);
+		});
+
+		const state = result.current.getData();
+
+		expect(state).toEqual(defaultState);
+	});
+
+	it('returns the updated state when it is mutated', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevState = result.current.getData();
+
+		act(() => {
+			result.current.setEndMode('ON_DATE');
+			result.current.setRepeatFrequency('DAILY');
+		});
+
+		const nextState = result.current.getData();
+
+		expect(prevState).not.toEqual(nextState);
+		// hash must have changed.
+		expect(prevState.hash).not.toBe(nextState.hash);
+		// check for changed values
+		expect(nextState.end.mode).toBe('ON_DATE');
+		expect(nextState.repeat.frequency).toBe('DAILY');
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setData.test.ts
+++ b/packages/rrule-generator/src/state/tests/setData.test.ts
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { getDefaultRRuleState } from '../../utils';
+
+describe('RRuleStateManager.setData', () => {
+	it('updates the state upon calling setData', () => {
+		const defaultState = getDefaultRRuleState(DEFAULT_CONFIG);
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const updatedState = { ...defaultState, start: { date: new Date() } };
+
+		act(() => {
+			result.current.setData(updatedState);
+		});
+
+		const state = result.current.getData();
+
+		expect(state).toStrictEqual(updatedState);
+	});
+
+	it('does not change the value of hash', () => {
+		const defaultState = getDefaultRRuleState(DEFAULT_CONFIG);
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const hash = 'uRVUBt7BYBJguFYBJ';
+
+		const updatedState = { ...defaultState, hash };
+
+		act(() => {
+			result.current.setData(updatedState);
+		});
+
+		const state = result.current.getData();
+
+		expect(state.hash).toBe(hash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setEndAfter.test.ts
+++ b/packages/rrule-generator/src/state/tests/setEndAfter.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setEndAfter', () => {
+	it('updates the end after to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setEndAfter(10);
+		});
+
+		expect(result.current.end.after).toBe(10);
+	});
+
+	it('updates the end after to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextEndAfter) => {
+			const prevEndAfter = result.current.end.after;
+
+			act(() => {
+				result.current.setEndAfter(nextEndAfter);
+			});
+
+			expect(result.current.end.after).not.toEqual(prevEndAfter);
+			expect(result.current.end.after).toBe(nextEndAfter);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setEndAfter(78);
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setEndDate.test.ts
+++ b/packages/rrule-generator/src/state/tests/setEndDate.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setEndDate', () => {
+	it('updates the end date to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevEndDate = result.current.end.date;
+		const nextEndDate = new Date(2020, 8, 1);
+
+		act(() => {
+			result.current.setEndDate(nextEndDate);
+		});
+
+		expect(result.current.end.date).not.toEqual(prevEndDate);
+		expect(result.current.end.date).toBe(nextEndDate);
+	});
+
+	it('updates the end date to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextEndDate) => {
+			const prevEndDate = result.current.end.date;
+
+			act(() => {
+				result.current.setEndDate(nextEndDate);
+			});
+
+			expect(result.current.end.date).not.toEqual(prevEndDate);
+			expect(result.current.end.date).toBe(nextEndDate);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setEndDate(new Date());
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setEndMode.test.ts
+++ b/packages/rrule-generator/src/state/tests/setEndMode.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setEndMode', () => {
+	it('updates the end mode to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setEndMode('ON_DATE');
+		});
+
+		expect(result.current.end.mode).not.toEqual('AFTER');
+		expect(result.current.end.mode).toBe('ON_DATE');
+	});
+
+	it('updates the end mode to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextEndMode) => {
+			const prevEndMode = result.current.end.mode;
+
+			act(() => {
+				result.current.setEndMode(nextEndMode);
+			});
+
+			expect(result.current.end.mode).not.toEqual(prevEndMode);
+			expect(result.current.end.mode).toBe(nextEndMode);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setEndMode('NEVER');
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatDay.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatDay.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setRepeatDay', () => {
+	it('updates the repeat day for yearly frequency for "ON" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatDay('yearly', 'on', 23);
+		});
+
+		expect(result.current.repeat.yearly.on.day).toBe(23);
+	});
+
+	it('updates the repeat day for yearly frequency for "ON_THE" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatDay('yearly', 'onThe', 'TH');
+		});
+
+		expect(result.current.repeat.yearly.onThe.day).toBe('TH');
+	});
+
+	it('updates the repeat day for monthly frequency for "ON" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatDay('monthly', 'on', 23);
+		});
+
+		expect(result.current.repeat.monthly.on.day).toBe(23);
+	});
+
+	it('updates the repeat day for monthly frequency for "ON_THE" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatDay('monthly', 'onThe', 'TH');
+		});
+
+		expect(result.current.repeat.monthly.onThe.day).toBe('TH');
+	});
+
+	it('updates the repeat day to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatDay) => {
+			act(() => {
+				result.current.setRepeatDay('yearly', 'on', nextRepeatDay);
+				result.current.setRepeatDay('yearly', 'onThe', nextRepeatDay);
+			});
+
+			expect(result.current.repeat.yearly.onThe.day).toBe(nextRepeatDay);
+			expect(result.current.repeat.yearly.on.day).toBe(nextRepeatDay);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatDay('monthly', 'on', 26);
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatFrequency.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatFrequency.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { FREQUENCY } from '../../constants';
+import { Frequency } from '../../types';
+
+describe('RRuleStateManager.setRepeatFrequency', () => {
+	it('updates the repeat frequency to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		Object.keys(FREQUENCY).forEach((frequency: Frequency) => {
+			act(() => {
+				result.current.setRepeatFrequency(frequency);
+			});
+
+			expect(result.current.repeat.frequency).toBe(frequency);
+		});
+	});
+
+	it('updates the repeat frequency to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatFrequency) => {
+			const prevRepeatFrequency = result.current.repeat.frequency;
+
+			act(() => {
+				result.current.setRepeatFrequency(nextRepeatFrequency);
+			});
+
+			expect(result.current.repeat.frequency).not.toEqual(prevRepeatFrequency);
+			expect(result.current.repeat.frequency).toBe(nextRepeatFrequency);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatFrequency('WEEKLY');
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatInterval.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatInterval.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { RRuleStateManager } from '../types';
+
+describe('RRuleStateManager.setRepeatInterval', () => {
+	it('updates the repeat interval to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const repeatKeys: Array<Parameters<RRuleStateManager['setRepeatInterval']>[0]> = [
+			'monthly',
+			'weekly',
+			'daily',
+			'hourly',
+		];
+
+		let interval = 10;
+
+		repeatKeys.forEach((repeatKey) => {
+			const newInterval = interval++;
+			act(() => {
+				result.current.setRepeatInterval(repeatKey, newInterval);
+			});
+
+			expect(result.current.repeat?.[repeatKey]?.interval).toBe(newInterval);
+		});
+	});
+
+	it('updates the repeat interval to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatInterval) => {
+			const repeatKeys: Array<Parameters<RRuleStateManager['setRepeatInterval']>[0]> = [
+				'monthly',
+				'weekly',
+				'daily',
+				'hourly',
+			];
+
+			repeatKeys.forEach((repeatKey) => {
+				act(() => {
+					result.current.setRepeatInterval(repeatKey, nextRepeatInterval);
+				});
+
+				expect(result.current.repeat?.[repeatKey]?.interval).toBe(nextRepeatInterval);
+			});
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatInterval('monthly', 67);
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatMode.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatMode.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setRepeatMode', () => {
+	it('updates the repeat mode to the passed value for monthly requency', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatMode('monthly', 'ON_THE');
+		});
+		expect(result.current.repeat.monthly.mode).not.toEqual('ON');
+		expect(result.current.repeat.monthly.mode).toBe('ON_THE');
+
+		act(() => {
+			result.current.setRepeatMode('monthly', 'ON');
+		});
+		expect(result.current.repeat.monthly.mode).not.toEqual('ON_THE');
+		expect(result.current.repeat.monthly.mode).toBe('ON');
+	});
+
+	it('updates the repeat mode to the passed value for yearly requency', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		act(() => {
+			result.current.setRepeatMode('yearly', 'ON_THE');
+		});
+		expect(result.current.repeat.yearly.mode).not.toEqual('ON');
+		expect(result.current.repeat.yearly.mode).toBe('ON_THE');
+
+		act(() => {
+			result.current.setRepeatMode('yearly', 'ON');
+		});
+		expect(result.current.repeat.yearly.mode).not.toEqual('ON_THE');
+		expect(result.current.repeat.yearly.mode).toBe('ON');
+	});
+
+	it('updates the repeat mode to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatMode) => {
+			act(() => {
+				result.current.setRepeatMode('yearly', nextRepeatMode);
+			});
+			expect(result.current.repeat.yearly.mode).toBe(nextRepeatMode);
+
+			act(() => {
+				result.current.setRepeatMode('monthly', nextRepeatMode);
+			});
+			expect(result.current.repeat.monthly.mode).toBe(nextRepeatMode);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatMode('monthly', 'ON_THE');
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatMonth.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatMonth.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { MONTHS } from '../../constants';
+import { Month } from '../../types';
+
+describe('RRuleStateManager.setRepeatMonth', () => {
+	it('updates the repeat month for yearly frequency for "ON" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		Object.keys(MONTHS).forEach((month: Month) => {
+			act(() => {
+				result.current.setRepeatMonth('on', month);
+			});
+
+			expect(result.current.repeat.yearly.on.month).toBe(month);
+		});
+	});
+
+	it('updates the repeat month for yearly frequency for "ON_THE" mode', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		Object.keys(MONTHS).forEach((month: Month) => {
+			act(() => {
+				result.current.setRepeatMonth('onThe', month);
+			});
+
+			expect(result.current.repeat.yearly.onThe.month).toBe(month);
+		});
+	});
+
+	it('updates the repeat month to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatMonth) => {
+			act(() => {
+				result.current.setRepeatMonth('on', nextRepeatMonth);
+				result.current.setRepeatMonth('onThe', nextRepeatMonth);
+			});
+
+			expect(result.current.repeat.yearly.on.month).toBe(nextRepeatMonth);
+			expect(result.current.repeat.yearly.onThe.month).toBe(nextRepeatMonth);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatMonth('on', 'Mar');
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatWeeklyDays.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatWeeklyDays.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { WeeklyRepeatOption } from '../../types';
+
+describe('RRuleStateManager.setRepeatWeeklyDays', () => {
+	it('updates the weekly days', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const activeDays: WeeklyRepeatOption['days'] = {
+			MO: false,
+			TU: true,
+			WE: true,
+			TH: false,
+			FR: true,
+			SA: false,
+			SU: true,
+		};
+
+		act(() => {
+			result.current.setRepeatWeeklyDays(activeDays);
+		});
+
+		Object.entries(result.current.repeat.weekly.days).forEach(([day, isActive]) => {
+			expect(result.current.repeat.weekly.days?.[day]).toBe(isActive);
+		});
+	});
+
+	it('passing null or undefined does not affect the weekly days', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextWeeklyDays) => {
+			act(() => {
+				result.current.setRepeatWeeklyDays(nextWeeklyDays);
+			});
+
+			expect(result.current.repeat.weekly.days).not.toEqual(nextWeeklyDays);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatWeeklyDays(null);
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setRepeatWhich.test.ts
+++ b/packages/rrule-generator/src/state/tests/setRepeatWhich.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+import { WHICH } from '../../constants';
+import { Which } from '../../types';
+
+describe('RRuleStateManager.setRepeatWhich', () => {
+	it('updates the repeat which for yearly frequency', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		Object.keys(WHICH).forEach((which: Which) => {
+			act(() => {
+				result.current.setRepeatWhich('yearly', which);
+			});
+
+			expect(result.current.repeat.yearly.onThe.which).toBe(which);
+		});
+	});
+
+	it('updates the repeat which for monthly frequency', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		Object.keys(WHICH).forEach((which: Which) => {
+			act(() => {
+				result.current.setRepeatWhich('monthly', which);
+			});
+
+			expect(result.current.repeat.monthly.onThe.which).toBe(which);
+		});
+	});
+
+	it('updates the repeat which to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextRepeatWhich) => {
+			act(() => {
+				result.current.setRepeatWhich('monthly', nextRepeatWhich);
+			});
+
+			expect(result.current.repeat.monthly.onThe.which).toBe(nextRepeatWhich);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setRepeatWhich('monthly', 'THIRD');
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/tests/setStartDate.test.ts
+++ b/packages/rrule-generator/src/state/tests/setStartDate.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRRuleStateManager from '../useRRuleStateManager';
+import { DEFAULT_CONFIG } from '../../context';
+
+describe('RRuleStateManager.setStartDate', () => {
+	it('updates the start date to the passed value', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevStartDate = result.current.start.date;
+		const nextStartDate = new Date(2020, 8, 1);
+
+		act(() => {
+			result.current.setStartDate(nextStartDate);
+		});
+
+		expect(result.current.start.date).not.toEqual(prevStartDate);
+		expect(result.current.start.date).toBe(nextStartDate);
+	});
+
+	it('updates the start date to null or undefined', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		[null, undefined].forEach((nextStartDate) => {
+			const prevStartDate = result.current.start.date;
+
+			act(() => {
+				result.current.setStartDate(nextStartDate);
+			});
+
+			expect(result.current.start.date).not.toEqual(prevStartDate);
+			expect(result.current.start.date).toBe(nextStartDate);
+		});
+	});
+
+	it('changes the value of hash', () => {
+		const { result } = renderHook(() => useRRuleStateManager(DEFAULT_CONFIG));
+
+		const prevHash = result.current.hash;
+
+		act(() => {
+			result.current.setStartDate(new Date());
+		});
+
+		expect(result.current).toHaveProperty('hash');
+		expect(typeof result.current.hash).toBe('string');
+		expect(result.current.hash).not.toEqual(prevHash);
+	});
+});

--- a/packages/rrule-generator/src/state/types.ts
+++ b/packages/rrule-generator/src/state/types.ts
@@ -64,18 +64,14 @@ export interface RRuleStateManager extends Readonly<RRuleState> {
 	setRepeatFrequency: (repeatKey: Frequency) => void;
 	setRepeatInterval: (repeatKey: keyof Omit<RepeatRule, 'frequency' | 'yearly'>, interval: number) => void;
 	setRepeatMonth: (monthYearMode: RRuleAction['monthYearMode'], month: Month) => void;
-	setRepeatWhich: (
-		repeatKey: keyof Pick<RepeatRule, 'yearly' | 'monthly'>,
-		monthYearMode: RRuleAction['monthYearMode'],
-		which: Which
-	) => void;
+	setRepeatWhich: (repeatKey: keyof Pick<RepeatRule, 'yearly' | 'monthly'>, which: Which) => void;
 	setRepeatWeeklyDays: (days: WeeklyRepeatOption['days']) => void;
 	setRepeatDay: (
 		repeatKey: keyof Pick<RepeatRule, 'yearly' | 'monthly'>,
 		monthYearMode: RRuleAction['monthYearMode'],
 		day: Day
 	) => void;
-	setRepeatMode: (repeatKey: RRuleAction['repeatKey'], mode: RepeatMode) => void;
+	setRepeatMode: (repeatKey: keyof Pick<RepeatRule, 'yearly' | 'monthly'>, mode: RepeatMode) => void;
 }
 
 export type RRuleStateReducer = Reducer<RRuleState, RRuleAction>;

--- a/packages/rrule-generator/src/state/useRRuleStateManager.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer, useEffect } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
 
 import type { RRuleStateManager } from './types';
 import useInitialState from './useInitialState';
@@ -11,11 +11,6 @@ const useRRuleStateManager = (config: RRuleConfig, rRuleString?: string): RSM =>
 	const initializer = useInitialState(config, rRuleString);
 	const dataReducer = useRRuleStateReducer(initializer);
 	const [state, dispatch] = useReducer(dataReducer, null, initializer);
-
-	// temporary
-	useEffect(() => {
-		console.log('RRule state', state);
-	}, [state]);
 
 	/**
 	 * Returns the current data.
@@ -69,8 +64,8 @@ const useRRuleStateManager = (config: RRuleConfig, rRuleString?: string): RSM =>
 		dispatch({ type: 'SET_REPEAT_WEEKLY_DAYS', days });
 	}, []);
 
-	const setRepeatWhich: RSM['setRepeatWhich'] = useCallback((repeatKey, monthYearMode, which) => {
-		dispatch({ type: 'SET_REPEAT_WHICH', repeatKey, monthYearMode, which });
+	const setRepeatWhich: RSM['setRepeatWhich'] = useCallback((repeatKey, which) => {
+		dispatch({ type: 'SET_REPEAT_WHICH', repeatKey, which });
 	}, []);
 
 	return useMemo<RSM>(

--- a/packages/rrule-generator/src/state/useRRuleStateReducer.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateReducer.ts
@@ -1,65 +1,67 @@
+import { useCallback } from 'react';
 import { assocPath } from 'ramda';
 import { v4 as uuidv4 } from 'uuid';
 
 import { RRuleStateReducer, StateInitializer } from './types';
 
 const useRRuleStateReducer = (initializer: StateInitializer): RRuleStateReducer => {
-	const dataReducer: RRuleStateReducer = (prevState, action) => {
-		const {
-			after,
-			data,
-			date,
-			day,
-			days,
-			endMode,
-			frequency,
-			interval,
-			mode,
-			month,
-			monthYearMode,
-			repeatKey,
-			type,
-			which,
-		} = action;
+	return useCallback<RRuleStateReducer>(
+		(prevState, action) => {
+			const {
+				after,
+				data,
+				date,
+				day,
+				days,
+				endMode,
+				frequency,
+				interval,
+				mode,
+				month,
+				monthYearMode,
+				repeatKey,
+				type,
+				which,
+			} = action;
 
-		// dispatching 'SET_DATA' means the state didn't change as a result of user action
-		// it was set/reset, so, we won't update the hash in that case
-		const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuidv4() };
+			// dispatching 'SET_DATA' means the state didn't change as a result of user action
+			// it was set/reset, so, we won't update the hash in that case
+			const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuidv4() };
 
-		switch (type) {
-			case 'SET_START_DATE':
-				return assocPath(['start', 'date'], date, state);
-			case 'SET_END_MODE':
-				return assocPath(['end', 'mode'], endMode, state);
-			case 'SET_END_AFTER':
-				return assocPath(['end', 'after'], after, state);
-			case 'SET_END_DATE':
-				return assocPath(['end', 'date'], date, state);
-			case 'SET_REPEAT_FREQUENCY':
-				return assocPath(['repeat', 'frequency'], frequency, state);
-			case 'SET_REPEAT_INTERVAL':
-				return assocPath(['repeat', repeatKey, 'interval'], interval, state);
-			case 'SET_REPEAT_MONTH':
-				return assocPath(['repeat', 'yearly', monthYearMode, 'month'], month, state);
-			case 'SET_REPEAT_DAY':
-				return assocPath(['repeat', repeatKey, monthYearMode, 'day'], day, state);
-			case 'SET_REPEAT_WHICH':
-				return assocPath(['repeat', repeatKey, monthYearMode, 'which'], which, state);
-			case 'SET_REPEAT_WEEKLY_DAYS':
-				return assocPath(['repeat', 'weekly', 'days'], { ...state.repeat.weekly?.days, ...days }, state);
-			case 'SET_REPEAT_MODE':
-				return assocPath(['repeat', repeatKey, 'mode'], mode, state);
-			case 'SET_DATA':
-				return data;
-			case 'RESET':
-				return initializer(null);
+			switch (type) {
+				case 'SET_START_DATE':
+					return assocPath(['start', 'date'], date, state);
+				case 'SET_END_MODE':
+					return assocPath(['end', 'mode'], endMode, state);
+				case 'SET_END_AFTER':
+					return assocPath(['end', 'after'], after, state);
+				case 'SET_END_DATE':
+					return assocPath(['end', 'date'], date, state);
+				case 'SET_REPEAT_FREQUENCY':
+					return assocPath(['repeat', 'frequency'], frequency, state);
+				case 'SET_REPEAT_INTERVAL':
+					return assocPath(['repeat', repeatKey, 'interval'], interval, state);
+				case 'SET_REPEAT_MONTH':
+					return assocPath(['repeat', 'yearly', monthYearMode, 'month'], month, state);
+				case 'SET_REPEAT_DAY':
+					return assocPath(['repeat', repeatKey, monthYearMode, 'day'], day, state);
+				case 'SET_REPEAT_WHICH':
+					return assocPath(['repeat', repeatKey, 'onThe', 'which'], which, state);
+				case 'SET_REPEAT_WEEKLY_DAYS':
+					return assocPath(['repeat', 'weekly', 'days'], { ...state.repeat.weekly?.days, ...days }, state);
+				case 'SET_REPEAT_MODE':
+					return assocPath(['repeat', repeatKey, 'mode'], mode, state);
+				case 'SET_DATA':
+					return { ...data };
+				case 'RESET':
+					return initializer(null);
 
-			default:
-				throw new Error('Unexpected action');
-		}
-	};
-
-	return dataReducer;
+				default:
+					throw new Error('Unexpected action');
+			}
+		},
+		[initializer]
+	);
 };
 
 export default useRRuleStateReducer;

--- a/packages/rrule-generator/src/utils/computeRRule/toString/computeEnd.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/computeEnd.ts
@@ -1,4 +1,5 @@
 import { Options } from 'rrule';
+import { isValid } from 'date-fns';
 
 import { RRuleState } from '../../../state';
 
@@ -9,7 +10,7 @@ const computeEnd = ({ mode, after, date }: RRuleState['end']): Partial<Options> 
 		end.count = after;
 	}
 
-	if (mode === 'ON_DATE') {
+	if (mode === 'ON_DATE' && isValid(date)) {
 		end.until = date;
 	}
 

--- a/packages/rrule-generator/src/utils/computeRRule/toString/computeStart.ts
+++ b/packages/rrule-generator/src/utils/computeRRule/toString/computeStart.ts
@@ -1,6 +1,6 @@
 import { Options } from 'rrule';
-
 import { isValid } from 'date-fns';
+
 import { RRuleState } from '../../../state';
 
 const computeStart = ({ date }: RRuleState['start']): Partial<Options> => {


### PR DESCRIPTION
This PR adds unit tests for `rrule-generator` state management.

Closes #126 