### PR TITLE
Clean up test console

### DIFF
--- a/domains/eventEditor/src/services/context/EventEditorContext/ContextProviders.test.tsx
+++ b/domains/eventEditor/src/services/context/EventEditorContext/ContextProviders.test.tsx
@@ -8,16 +8,19 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { useStatus } from '@eventespresso/services';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('ContextProviders', () => {
-	it('checks for Apollo context without ContextProviders', () => {
+	it('checks for Apollo context without ContextProviders', async () => {
 		const { result } = renderHook(() => useApolloClient());
+		await actWait();
 
 		expect(result.error).toBeInstanceOf(InvariantError);
 	});
 
-	it('checks for Apollo context with ContextProviders', () => {
+	it('checks for Apollo context with ContextProviders', async () => {
 		const { result } = renderHook(() => useApolloClient(), { wrapper: ApolloMockedProvider() });
+		await actWait();
 
 		expect(result.current).toBeInstanceOf(ApolloClient);
 	});
@@ -32,8 +35,9 @@ describe('ContextProviders', () => {
 		expect(getByText('Status Manager is: NULL')).toBeInTheDocument();
 	});
 
-	it('checks for statusProvider context with ContextProviders', () => {
+	it('checks for statusProvider context with ContextProviders', async () => {
 		const { getByText } = render(<StatusComponent />, { wrapper: ApolloMockedProvider() });
+		await actWait();
 		expect(getByText('Status Manager is: NOT_NULL')).toBeInTheDocument();
 	});
 });

--- a/domains/eventEditor/src/services/filterState/tickets/test/useTicketsListFilterStateManager.test.ts
+++ b/domains/eventEditor/src/services/filterState/tickets/test/useTicketsListFilterStateManager.test.ts
@@ -4,10 +4,12 @@ import { DisplayStartOrEndDate } from '@eventespresso/edtr-services';
 import useTicketsListFilterStateManager from '../useTicketsListFilterStateManager';
 import { TicketsSales, TicketsStatus } from '../types';
 import wrapper from './Wrapper';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useTicketsListFilterStateManager', () => {
-	test('useTicketsListFilterStateManager initial state and result', () => {
+	test('useTicketsListFilterStateManager initial state and result', async () => {
 		const { result } = renderHook(() => useTicketsListFilterStateManager(), { wrapper });
+		await actWait();
 
 		expect(typeof result.current.sortBy).toBe('string');
 		expect(typeof result.current.displayStartOrEndDate).toBe('string');
@@ -19,8 +21,9 @@ describe('useTicketsListFilterStateManager', () => {
 		expect(result.current.isChained).toBe(true);
 	});
 
-	test('should update sortBy by invoking setSortBy with corresponding accepted enums', () => {
+	test('should update sortBy by invoking setSortBy with corresponding accepted enums', async () => {
 		const { result } = renderHook(() => useTicketsListFilterStateManager(), { wrapper });
+		await actWait();
 
 		act(() => {
 			result.current.setSortBy('name');
@@ -43,8 +46,9 @@ describe('useTicketsListFilterStateManager', () => {
 		expect(result.current.sortBy).toBe('date');
 	});
 
-	test('should update displayStartOrEndDate by invoking setDisplayStartOrEndDate with corresponding accepted enums', () => {
+	test('should update displayStartOrEndDate by invoking setDisplayStartOrEndDate with corresponding accepted enums', async () => {
 		const { result } = renderHook(() => useTicketsListFilterStateManager(), { wrapper });
+		await actWait();
 
 		act(() => {
 			result.current.setDisplayStartOrEndDate(DisplayStartOrEndDate.start);
@@ -62,8 +66,9 @@ describe('useTicketsListFilterStateManager', () => {
 		expect(result.current.displayStartOrEndDate).toBe('both');
 	});
 
-	test('should update sales by invoking setSales with corresponding accepted enums', () => {
+	test('should update sales by invoking setSales with corresponding accepted enums', async () => {
 		const { result } = renderHook(() => useTicketsListFilterStateManager(), { wrapper });
+		await actWait();
 
 		act(() => {
 			result.current.setSales(TicketsSales.above50Sold);
@@ -71,8 +76,9 @@ describe('useTicketsListFilterStateManager', () => {
 		expect(result.current.sales).toBe('above-50-sold');
 	});
 
-	test('should update status by invoking setStatus with corresponding accepted enums', () => {
+	test('should update status by invoking setStatus with corresponding accepted enums', async () => {
 		const { result } = renderHook(() => useTicketsListFilterStateManager(), { wrapper });
+		await actWait();
 
 		act(() => {
 			result.current.setStatus(TicketsStatus.all);

--- a/packages/data/src/queries/currentUser/test/useCurrentUser.test.ts
+++ b/packages/data/src/queries/currentUser/test/useCurrentUser.test.ts
@@ -4,11 +4,13 @@ import { useCurrentUser } from '..';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
 import { currentUser, successMocks } from './data';
 import useInitCurrentUserTestCache from './useInitCurrentUserTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useCurrentUser', () => {
 	it('checks for the current user when the cache is empty', async () => {
 		const wrapper = ApolloMockedProvider([], false);
 		const { result } = renderHook(() => useCurrentUser(), { wrapper });
+		await actWait();
 
 		expect(result.current).toBe(undefined);
 	});
@@ -22,6 +24,7 @@ describe('useCurrentUser', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		expect(result.current).toBeDefined();
 	});
@@ -35,6 +38,7 @@ describe('useCurrentUser', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		const { current: cachedUser } = result;
 

--- a/packages/data/src/queries/currentUser/test/useUpdateCurrentUserCache.test.ts
+++ b/packages/data/src/queries/currentUser/test/useUpdateCurrentUserCache.test.ts
@@ -6,6 +6,7 @@ import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/t
 import useUpdateCurrentUserCache from '../useUpdateCurrentUserCache';
 import { useCurrentUser } from '..';
 import { request } from './data';
+import { actWait } from '@eventespresso/utils/src/test';
 
 const timeout = 5000; // milliseconds
 describe('useUpdateCurrentUserCache', () => {
@@ -24,6 +25,7 @@ describe('useUpdateCurrentUserCache', () => {
 				wrapper,
 			}
 		);
+		await actWait();
 
 		const currentUser = result.current.currentUser;
 		const updatedUser = {
@@ -54,6 +56,7 @@ describe('useUpdateCurrentUserCache', () => {
 				wrapper,
 			}
 		);
+		await actWait();
 
 		const cachedCurrentUser = cacheResult.current;
 

--- a/packages/data/src/queries/currentUser/useCurrentUser.ts
+++ b/packages/data/src/queries/currentUser/useCurrentUser.ts
@@ -1,6 +1,8 @@
-import { useCacheQuery } from '../';
+import { useMemoStringify } from '@eventespresso/hooks';
 import type { CurrentUserProps, Viewer } from '@eventespresso/services';
+
 import useCurrentUserQueryOptions from './useCurrentUserQueryOptions';
+import { useCacheQuery } from '../';
 
 /**
  * A custom react hook for retrieving CurrentUser
@@ -9,7 +11,7 @@ const useCurrentUser = (): CurrentUserProps => {
 	const options = useCurrentUserQueryOptions();
 	const { data } = useCacheQuery<Viewer>(options);
 
-	return data?.viewer;
+	return useMemoStringify(data?.viewer);
 };
 
 export default useCurrentUser;

--- a/packages/data/src/queries/generalSettings/test/useGeneralSettings.test.ts
+++ b/packages/data/src/queries/generalSettings/test/useGeneralSettings.test.ts
@@ -4,11 +4,13 @@ import { useGeneralSettings } from '..';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
 import { generalSettings, successMocks } from './data';
 import useInitGeneralSettingsTestCache from './useInitGeneralSettingsTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useGeneralSettings', () => {
-	it('checks for the general settings when the cache is empty', () => {
+	it('checks for the general settings when the cache is empty', async () => {
 		const wrapper = ApolloMockedProvider([], false);
 		const { result } = renderHook(() => useGeneralSettings(), { wrapper });
+		await actWait();
 
 		expect(result.current).toBe(undefined);
 	});
@@ -22,6 +24,7 @@ describe('useGeneralSettings', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		expect(result.current).toBeDefined();
 	});
@@ -35,6 +38,7 @@ describe('useGeneralSettings', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		const { current: cachedSettings } = result;
 

--- a/packages/data/src/queries/generalSettings/test/useUpdateGeneralSettingsCache.test.ts
+++ b/packages/data/src/queries/generalSettings/test/useUpdateGeneralSettingsCache.test.ts
@@ -6,6 +6,7 @@ import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/t
 import useUpdateGeneralSettingsCache from '../useUpdateGeneralSettingsCache';
 import { useGeneralSettings } from '..';
 import { request } from './data';
+import { actWait } from '@eventespresso/utils/src/test';
 
 const timeout = 5000; // milliseconds
 describe('useUpdateGeneralSettingsCache', () => {
@@ -24,6 +25,7 @@ describe('useUpdateGeneralSettingsCache', () => {
 				wrapper,
 			}
 		);
+		await actWait();
 
 		const generalSettings = result.current.generalSettings;
 
@@ -55,6 +57,7 @@ describe('useUpdateGeneralSettingsCache', () => {
 				wrapper,
 			}
 		);
+		await actWait();
 
 		const cachedGeneralSettings = cacheResult.current;
 

--- a/packages/data/src/queries/generalSettings/useGeneralSettings.ts
+++ b/packages/data/src/queries/generalSettings/useGeneralSettings.ts
@@ -1,6 +1,9 @@
-import { useCacheQuery } from '../';
+import { useMemoStringify } from '@eventespresso/hooks';
 import { GeneralSettings, GeneralSettingsData } from '@eventespresso/services';
+
 import useGeneralSettingsQueryOptions from './useGeneralSettingsQueryOptions';
+import { useCacheQuery } from '../';
+
 /**
  * A custom react hook for retrieving GeneralSettings
  */
@@ -8,7 +11,7 @@ const useGeneralSettings = (): GeneralSettings => {
 	const options = useGeneralSettingsQueryOptions();
 	const { data } = useCacheQuery<GeneralSettingsData>(options);
 
-	return data?.generalSettings;
+	return useMemoStringify(data?.generalSettings);
 };
 
 export default useGeneralSettings;

--- a/packages/edtr-services/src/apollo/initialization/test/useCacheRehydration.test.ts
+++ b/packages/edtr-services/src/apollo/initialization/test/useCacheRehydration.test.ts
@@ -3,11 +3,11 @@ import { renderHook } from '@testing-library/react-hooks';
 import useCacheRehydration from '../useCacheRehydration';
 import { useDatetimes, useTickets, usePriceTypes } from '../../queries';
 import { ApolloMockedProvider } from '../../../context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useCacheRehydration', () => {
 	it('checks for datetimes rehydration', async () => {
-		const { result: datetimeResult, waitForNextUpdate } = renderHook(
+		const { result: datetimeResult } = renderHook(
 			() => {
 				useCacheRehydration();
 				return useDatetimes();
@@ -16,7 +16,7 @@ describe('useCacheRehydration', () => {
 				wrapper: ApolloMockedProvider(),
 			}
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: datetimesList } = datetimeResult;
 
@@ -28,7 +28,7 @@ describe('useCacheRehydration', () => {
 	});
 
 	it('checks for tickets rehydration', async () => {
-		const { result: ticketResult, waitForNextUpdate } = renderHook(
+		const { result: ticketResult } = renderHook(
 			() => {
 				useCacheRehydration();
 				return useTickets();
@@ -37,7 +37,7 @@ describe('useCacheRehydration', () => {
 				wrapper: ApolloMockedProvider(),
 			}
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: ticketsList } = ticketResult;
 
@@ -49,7 +49,7 @@ describe('useCacheRehydration', () => {
 	});
 
 	it('checks for price types rehydration', async () => {
-		const { result: priceResult, waitForNextUpdate } = renderHook(
+		const { result: priceResult } = renderHook(
 			() => {
 				useCacheRehydration();
 				return usePriceTypes();
@@ -58,7 +58,7 @@ describe('useCacheRehydration', () => {
 				wrapper: ApolloMockedProvider(),
 			}
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: priceTypesList } = priceResult;
 

--- a/packages/edtr-services/src/apollo/initialization/test/useCacheRehydrationData.test.ts
+++ b/packages/edtr-services/src/apollo/initialization/test/useCacheRehydrationData.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import useCacheRehydrationData from '../useCacheRehydrationData';
 import { ApolloMockedProvider } from '../../../context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useCacheRehydrationData', () => {
 	it('checks for event data', async () => {
@@ -10,6 +11,7 @@ describe('useCacheRehydrationData', () => {
 		} = renderHook(() => useCacheRehydrationData(), {
 			wrapper: ApolloMockedProvider(),
 		});
+		await actWait();
 
 		expect(data.eventEditor.event.dbId).toBeGreaterThan(1);
 
@@ -30,6 +32,7 @@ describe('useCacheRehydrationData', () => {
 		} = renderHook(() => useCacheRehydrationData(), {
 			wrapper: ApolloMockedProvider(),
 		});
+		await actWait();
 
 		expect(data.currentUser).toHaveProperty('name');
 
@@ -42,6 +45,7 @@ describe('useCacheRehydrationData', () => {
 		} = renderHook(() => useCacheRehydrationData(), {
 			wrapper: ApolloMockedProvider(),
 		});
+		await actWait();
 
 		expect(data.generalSettings).toHaveProperty('dateFormat');
 

--- a/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimeIds.test.ts
+++ b/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimeIds.test.ts
@@ -5,16 +5,18 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitDatetimeTestCache from './useInitDatetimeTestCache';
 import { getGuids } from '@eventespresso/predicates';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useDatetimeIds', () => {
 	const wrapper = ApolloMockedProvider();
-	it('checks for the empty datetime IDs', () => {
+	it('checks for the empty datetime IDs', async () => {
 		const { result } = renderHook(() => useDatetimeIds(), { wrapper });
+		await actWait();
 
 		expect(result.current.length).toBe(0);
 	});
 
-	it('checks for datetime IDs after the cache is updated', () => {
+	it('checks for datetime IDs after the cache is updated', async () => {
 		const { result } = renderHook(
 			() => {
 				useInitDatetimeTestCache();
@@ -22,6 +24,7 @@ describe('useDatetimeIds', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		const { current: cachedDatetimeIds } = result;
 		const passedDatetimeIds = getGuids(nodes);

--- a/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimeQueryOptions.test.ts
+++ b/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimeQueryOptions.test.ts
@@ -2,11 +2,13 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import useDatetimeQueryOptions from '../useDatetimeQueryOptions';
 import { ApolloMockedProvider, eventId } from '../../../../context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useDatetimeQueryOptions()', () => {
-	it('checks if the query operation variables are correct', () => {
+	it('checks if the query operation variables are correct', async () => {
 		const wrapper = ApolloMockedProvider();
 		const { result } = renderHook(() => useDatetimeQueryOptions(), { wrapper });
+		await actWait();
 
 		expect(result.current.variables.where.eventId).toEqual(eventId);
 	});

--- a/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimes.test.ts
+++ b/packages/edtr-services/src/apollo/queries/datetimes/test/useDatetimes.test.ts
@@ -4,27 +4,26 @@ import useDatetimes from '../useDatetimes';
 import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitDatetimeTestCache from './useInitDatetimeTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useDatetimes()', () => {
 	const wrapper = ApolloMockedProvider();
 	it('checks for the empty datetimes', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => useDatetimes(), { wrapper });
-
-		await waitForNextUpdate({ timeout });
+		const { result } = renderHook(() => useDatetimes(), { wrapper });
+		await actWait();
 
 		expect(result.current.length).toBe(0);
 	});
 
 	it('checks for the updated datetimes cache', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitDatetimeTestCache();
 				return useDatetimes();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedDatetimes } = result;
 

--- a/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
+++ b/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
@@ -17,8 +17,6 @@ describe('useEvent', () => {
 		await actWait();
 
 		expect(result.current).toBeUndefined();
-
-		expect(result.current).toBeUndefined();
 	});
 
 	it('checks for response data', async () => {

--- a/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
+++ b/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
@@ -4,20 +4,19 @@ import useEvent from '../useEvent';
 import { ApolloMockedProvider } from '../../../../context/test';
 import { successMocks, nodes } from './data';
 import useEventQueryOptions from '../useEventQueryOptions';
+import { actWait } from '@eventespresso/utils/src/test';
 
 const mockEvent = nodes[0];
 
-const timeout = 5000; // milliseconds
 describe('useEvent', () => {
 	it('returns undefined when the given eventdoes not exist', async () => {
 		const wrapper = ApolloMockedProvider();
-		const { result, waitForNextUpdate } = renderHook(() => useEvent(), {
+		const { result } = renderHook(() => useEvent(), {
 			wrapper,
 		});
+		await actWait();
 
 		expect(result.current).toBeUndefined();
-
-		await waitForNextUpdate({ timeout }); // wait for response
 
 		expect(result.current).toBeUndefined();
 	});
@@ -29,15 +28,14 @@ describe('useEvent', () => {
 		} = renderHook(() => useEventQueryOptions(), {
 			wrapper: ApolloMockedProvider(),
 		});
+		await actWait();
+
 		const wrapper = ApolloMockedProvider(successMocks.map((mock) => ({ ...mock, request })));
 		/* Set query options and the wrapper */
-		const { result, waitForNextUpdate } = renderHook(() => useEvent(), {
+		const { result } = renderHook(() => useEvent(), {
 			wrapper,
 		});
-
-		expect(result.current).toBeUndefined();
-
-		await waitForNextUpdate({ timeout }); // wait for response
+		await actWait();
 
 		expect(result.current).toBeDefined();
 		expect(result.current.id).toBe(mockEvent.id);

--- a/packages/edtr-services/src/apollo/queries/priceTypes/test/useDefaultPriceType.test.ts
+++ b/packages/edtr-services/src/apollo/queries/priceTypes/test/useDefaultPriceType.test.ts
@@ -5,41 +5,42 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes, edge } from './data';
 import useInitPriceTypeTestCache from './useInitPriceTypeTestCache';
 import { isFlatFeeSurcharge } from '@eventespresso/predicates';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useDefaultPriceType()', () => {
 	const wrapper = ApolloMockedProvider();
 	it('returns null as default price type when the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => useDefaultPriceType(), { wrapper });
+		const { result } = renderHook(() => useDefaultPriceType(), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		expect(result.current).toBeNull();
 	});
 
 	it('checks for the default price type when none exists and the cache is NOT empty', async () => {
 		const nonDefaultPriceTypeNodes = nodes.filter((priceType) => !isFlatFeeSurcharge(priceType));
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache({ ...edge, nodes: nonDefaultPriceTypeNodes });
 				return useDefaultPriceType();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		expect(result.current).toBeNull();
 	});
 
 	it('checks for the default price type when at least one exists and the cache is NOT empty', async () => {
 		const defaultPriceType = nodes.filter(isFlatFeeSurcharge)[0];
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache();
 				return useDefaultPriceType();
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedDefaultPriceType } = result;
 

--- a/packages/edtr-services/src/apollo/queries/priceTypes/test/usePriceTypeForPrice.test.ts
+++ b/packages/edtr-services/src/apollo/queries/priceTypes/test/usePriceTypeForPrice.test.ts
@@ -7,28 +7,28 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes, edge } from './data';
 import { nodes as prices } from '../../prices/test/data';
 import useInitPriceTypeTestCache from './useInitPriceTypeTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('usePriceTypeForPrice()', () => {
 	const wrapper = ApolloMockedProvider();
 	const existingPrice = prices[0];
 	it('returns null as price type when the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => usePriceTypeForPrice(existingPrice.id), { wrapper });
+		const { result } = renderHook(() => usePriceTypeForPrice(existingPrice.id), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 		expect(result.current).toBeNull();
 	});
 
 	it('returns null as price type when the price does not exist and the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => usePriceTypeForPrice('fake-id'), { wrapper });
+		const { result } = renderHook(() => usePriceTypeForPrice('fake-id'), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 		expect(result.current).toBeNull();
 	});
 
 	it('returns null as price type when the price and default price type do not exist but the cache is NOT empty', async () => {
 		const nonDefaultPriceTypeNodes = nodes.filter((priceType) => !isFlatFeeSurcharge(priceType));
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache({ ...edge, nodes: nonDefaultPriceTypeNodes });
 				return usePriceTypeForPrice('fake-id');
@@ -36,20 +36,21 @@ describe('usePriceTypeForPrice()', () => {
 			{ wrapper }
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		expect(result.current).toBeNull();
 	});
 
 	it('returns the default price type when the price does not exist and the cache is NOT empty', async () => {
 		const defaultPriceType = nodes.filter(isFlatFeeSurcharge)[0];
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache();
 				return usePriceTypeForPrice('fake-id');
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedDefaultPriceType } = result;
 
@@ -61,13 +62,13 @@ describe('usePriceTypeForPrice()', () => {
 	});
 
 	it('returns null as price type when the price exists, has relation with a price type but the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				return usePriceTypeForPrice(existingPrice.id);
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		expect(result.current).toBeNull();
 	});
@@ -76,6 +77,7 @@ describe('usePriceTypeForPrice()', () => {
 		const {
 			result: { current: relationsManager },
 		} = renderHook(() => useRelations(), { wrapper });
+		await actWait();
 
 		const relatedPriceTypeId = relationsManager.getRelations({
 			entity: 'prices',
@@ -83,14 +85,14 @@ describe('usePriceTypeForPrice()', () => {
 			relation: 'priceTypes',
 		})[0];
 
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache();
 				return usePriceTypeForPrice(existingPrice.id);
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedRelatedPriceType } = result;
 

--- a/packages/edtr-services/src/apollo/queries/priceTypes/test/usePriceTypes.test.ts
+++ b/packages/edtr-services/src/apollo/queries/priceTypes/test/usePriceTypes.test.ts
@@ -4,19 +4,20 @@ import usePriceTypes from '../usePriceTypes';
 import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitPriceTypeTestCache from './useInitPriceTypeTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('usePriceTypes()', () => {
 	const wrapper = ApolloMockedProvider();
 	it('checks for the empty price types', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => usePriceTypes(), { wrapper });
+		const { result } = renderHook(() => usePriceTypes(), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		expect(result.current.length).toBe(0);
 	});
 
 	it('checks for the updated price types cache', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTypeTestCache();
 				return usePriceTypes();
@@ -24,7 +25,8 @@ describe('usePriceTypes()', () => {
 			{ wrapper }
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		const { current: cachedPriceTypes } = result;
 
 		expect(cachedPriceTypes).toEqual(nodes);

--- a/packages/edtr-services/src/apollo/queries/prices/test/usePriceQueryOptions.test.ts
+++ b/packages/edtr-services/src/apollo/queries/prices/test/usePriceQueryOptions.test.ts
@@ -5,19 +5,19 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from '../../tickets/test/data';
 import useInitTicketTestCache from '../../tickets/test/useInitTicketTestCache';
 import { getGuids } from '@eventespresso/predicates';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('usePriceQueryOptions()', () => {
 	it('checks if the query operation variables are correct', async () => {
 		const wrapper = ApolloMockedProvider();
-		const { result, waitForNextUpdate: waitForUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				return usePriceQueryOptions();
 			},
 			{ wrapper }
 		);
-		await waitForUpdate({ timeout });
+		await actWait();
 
 		expect(result.current.variables.where.ticketIn).toEqual(getGuids(nodes).sort());
 	});

--- a/packages/edtr-services/src/apollo/queries/prices/test/usePrices.test.ts
+++ b/packages/edtr-services/src/apollo/queries/prices/test/usePrices.test.ts
@@ -4,27 +4,27 @@ import usePrices from '../usePrices';
 import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitPriceTestCache from './useInitPriceTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('usePrices()', () => {
 	const wrapper = ApolloMockedProvider();
 	it('checks for the empty prices', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => usePrices(), { wrapper });
+		const { result } = renderHook(() => usePrices(), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		expect(result.current.length).toBe(0);
 	});
 
 	it('checks for the updated prices cache', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitPriceTestCache();
 				return usePrices();
 			},
 			{ wrapper }
 		);
-
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedPrices } = result;
 

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useTicketIds.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useTicketIds.test.ts
@@ -5,16 +5,18 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitTicketTestCache from './useInitTicketTestCache';
 import { getGuids } from '@eventespresso/predicates';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useTicketIds', () => {
 	const wrapper = ApolloMockedProvider();
-	it('checks for the empty ticket IDs', () => {
+	it('checks for the empty ticket IDs', async () => {
 		const { result } = renderHook(() => useTicketIds(), { wrapper });
+		await actWait();
 
 		expect(result.current.length).toBe(0);
 	});
 
-	it('checks for ticket IDs after the cache is updated', () => {
+	it('checks for ticket IDs after the cache is updated', async () => {
 		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
@@ -22,6 +24,7 @@ describe('useTicketIds', () => {
 			},
 			{ wrapper }
 		);
+		await actWait();
 
 		const { current: cachedTicketIds } = result;
 		const passedTicketIds = getGuids(nodes);

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useTicketPrices.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useTicketPrices.test.ts
@@ -7,16 +7,16 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitTicketTestCache from './useInitTicketTestCache';
 import useInitPriceTestCache from '../../prices/test/useInitPriceTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useTicketPrices', () => {
 	const wrapper = ApolloMockedProvider();
 	const existingTicket = nodes[0];
 
 	it('returns empty array for ticket prices when the ticket exists and the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => useTicketPrices(existingTicket.id), { wrapper });
+		const { result } = renderHook(() => useTicketPrices(existingTicket.id), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTicketPrices } = result;
 
@@ -24,9 +24,9 @@ describe('useTicketPrices', () => {
 	});
 
 	it('returns empty array for ticket prices when the ticket does not exist and the cache is empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => useTicketPrices('fake-id'), { wrapper });
+		const { result } = renderHook(() => useTicketPrices('fake-id'), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTicketPrices } = result;
 
@@ -34,7 +34,7 @@ describe('useTicketPrices', () => {
 	});
 
 	it('returns empty array for ticket prices when the ticket does not exist and the ticket cache is NOT empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				return useTicketPrices('fake-id');
@@ -42,7 +42,7 @@ describe('useTicketPrices', () => {
 			{ wrapper }
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTicketPrices } = result;
 
@@ -50,7 +50,7 @@ describe('useTicketPrices', () => {
 	});
 
 	it('returns empty array for ticket prices when the ticket exists, has price relations, ticket cache is NOT empty but price cache IS empty', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				return useTicketPrices(existingTicket.id);
@@ -58,7 +58,7 @@ describe('useTicketPrices', () => {
 			{ wrapper }
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTicketPrices } = result;
 
@@ -67,6 +67,7 @@ describe('useTicketPrices', () => {
 
 	it('returns an array of related ticket prices when the ticket exists, has price relations and the ticket/price cache is NOT empty', async () => {
 		const { result: relationsResult } = renderHook(() => useRelations(), { wrapper });
+		await actWait();
 
 		const relatedTicketPriceIds = relationsResult.current.getRelations({
 			entity: 'tickets',
@@ -74,7 +75,7 @@ describe('useTicketPrices', () => {
 			relation: 'prices',
 		});
 
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				useInitPriceTestCache();
@@ -82,7 +83,7 @@ describe('useTicketPrices', () => {
 			},
 			{ wrapper }
 		);
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTicketPrices } = result;
 

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useTicketQueryOptions.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useTicketQueryOptions.test.ts
@@ -5,19 +5,19 @@ import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from '../../datetimes/test/data';
 import useInitDatetimeTestCache from '../../datetimes/test/useInitDatetimeTestCache';
 import { getGuids } from '@eventespresso/predicates';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useTicketQueryOptions', () => {
 	it('checks if the query operation variables are correct', async () => {
 		const wrapper = ApolloMockedProvider();
-		const { result, waitForNextUpdate: waitForUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitDatetimeTestCache();
 				return useTicketQueryOptions();
 			},
 			{ wrapper }
 		);
-		await waitForUpdate({ timeout });
+		await actWait();
 
 		expect(result.current.variables.where.datetimeIn).toEqual(getGuids(nodes).sort());
 	});

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useTickets.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useTickets.test.ts
@@ -4,19 +4,20 @@ import useTickets from '../useTickets';
 import { ApolloMockedProvider } from '../../../../context/test';
 import { nodes } from './data';
 import useInitTicketTestCache from './useInitTicketTestCache';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('useTickets()', () => {
 	const wrapper = ApolloMockedProvider();
 	it('checks for the empty tickets', async () => {
-		const { result, waitForNextUpdate } = renderHook(() => useTickets(), { wrapper });
+		const { result } = renderHook(() => useTickets(), { wrapper });
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
+
 		expect(result.current.length).toBe(0);
 	});
 
 	it('checks for the updated tickets cache', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				return useTickets();
@@ -24,7 +25,7 @@ describe('useTickets()', () => {
 			{ wrapper }
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const { current: cachedTickets } = result;
 

--- a/packages/edtr-services/src/context/test/ContextProvider.test.tsx
+++ b/packages/edtr-services/src/context/test/ContextProvider.test.tsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { useStatus } from '@eventespresso/services';
 import { useEventId } from '../../apollo/queries/events';
 import { ApolloMockedProvider, eventId } from '../test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('ContextProviders', () => {
 	it('checks for Apollo context without ContextProviders', () => {
@@ -17,8 +18,9 @@ describe('ContextProviders', () => {
 		expect(result.error).toBeInstanceOf(InvariantError);
 	});
 
-	it('checks for Apollo context with ContextProviders', () => {
+	it('checks for Apollo context with ContextProviders', async () => {
 		const { result } = renderHook(() => useApolloClient(), { wrapper: ApolloMockedProvider() });
+		await actWait();
 
 		expect(result.current).toBeInstanceOf(ApolloClient);
 	});
@@ -33,8 +35,10 @@ describe('ContextProviders', () => {
 		expect(getByText('Status Manager is: NULL')).toBeInTheDocument();
 	});
 
-	it('checks for statusProvider context with ContextProviders', () => {
+	it('checks for statusProvider context with ContextProviders', async () => {
 		const { getByText } = render(<StatusComponent />, { wrapper: ApolloMockedProvider() });
+		await actWait();
+
 		expect(getByText('Status Manager is: NOT_NULL')).toBeInTheDocument();
 	});
 
@@ -48,8 +52,10 @@ describe('ContextProviders', () => {
 		expect(getByText('Event ID is: 0')).toBeInTheDocument();
 	});
 
-	it('checks for event id context with ContextProviders', () => {
+	it('checks for event id context with ContextProviders', async () => {
 		const { getByText } = render(<EventIdComponent />, { wrapper: ApolloMockedProvider() });
+		await actWait();
+
 		expect(getByText(`Event ID is: ${eventId}`)).toBeInTheDocument();
 	});
 });

--- a/packages/registry/src/modals/context/useGlobalModalManager.ts
+++ b/packages/registry/src/modals/context/useGlobalModalManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer, useEffect } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
 
 import type { GlobalModalManager, GlobalModalState } from './types';
 import reducer from './reducer';
@@ -9,11 +9,6 @@ const INITIAL_STATE: GlobalModalState = {};
 
 const useGlobalModalManager = (): GMM => {
 	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
-
-	// temporary
-	useEffect(() => {
-		console.log('Global Modal state', state);
-	}, [state]);
 
 	const closeModal: GMM['closeModal'] = useCallback((modalName) => {
 		dispatch({ type: 'CLOSE_MODAL', modalName });

--- a/packages/services/src/context/test/RelationsProvider.test.tsx
+++ b/packages/services/src/context/test/RelationsProvider.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { RelationsProvider, RelationsConsumer } from '../RelationsProvider';
 import { RelationsManager, RelationalData } from '../../relations';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('RelationsProvider', () => {
 	it('checks for relationsProvider functions', () => {
@@ -30,7 +31,7 @@ describe('RelationsProvider', () => {
 		expect(relationsProvider.updateRelations).toBeInstanceOf(Function);
 	});
 
-	it('checks for relationsProvider data from global context', () => {
+	it('checks for relationsProvider data from global context', async () => {
 		let relationalData: RelationalData = null;
 		const consumer = (
 			<RelationsConsumer>
@@ -42,6 +43,7 @@ describe('RelationsProvider', () => {
 		);
 
 		render(consumer, { wrapper: ApolloMockedProvider() });
+		await actWait();
 
 		expect(relationalData).toHaveProperty('datetimes');
 		expect(relationalData).toHaveProperty('tickets');

--- a/packages/services/src/hooks/test/useMoneyDisplay.test.ts
+++ b/packages/services/src/hooks/test/useMoneyDisplay.test.ts
@@ -3,12 +3,15 @@ import { renderHook } from '@testing-library/react-hooks';
 import useMoneyDisplay from '../useMoneyDisplay';
 import { mockEspressoDomData } from '../../config/test/data';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 describe('useMoneyDisplay', () => {
 	const wrapper = ApolloMockedProvider();
 
-	it('checks for existence of properties', () => {
+	it('checks for existence of properties', async () => {
 		const { result } = renderHook(() => useMoneyDisplay(), { wrapper });
+
+		await actWait();
 
 		expect(result.current).toHaveProperty('beforeAmount');
 		expect(result.current).toHaveProperty('afterAmount');
@@ -16,8 +19,10 @@ describe('useMoneyDisplay', () => {
 		expect(result.current).toHaveProperty('formatAmount');
 	});
 
-	it('checks for returned properties data', () => {
+	it('checks for returned properties data', async () => {
 		const { result } = renderHook(() => useMoneyDisplay(), { wrapper });
+
+		await actWait();
 
 		expect(result.current.formatAmount).toBeInstanceOf(Function);
 

--- a/packages/services/src/hooks/test/useTimeZoneTime.test.ts
+++ b/packages/services/src/hooks/test/useTimeZoneTime.test.ts
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 
 import useTimeZoneTime from '../useTimeZoneTime';
 import { ApolloMockedProvider } from '@eventespresso/edtr-services/src/context/test';
+import { actWait } from '@eventespresso/utils/src/test';
 
 const formatString = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
@@ -10,24 +11,26 @@ describe('useTimeZoneTime', () => {
 	const wrapper = ApolloMockedProvider();
 
 	describe('siteTimeToUtc', () => {
-		it('returns UTC date for ISO date string given in site timezone', () => {
+		it('returns UTC date for ISO date string given in site timezone', async () => {
 			const testDate = '2020-01-28T13:00:20'; // in IST
 			const expectedDate = '2020-01-28T07:30:20.000Z'; // in UTC (5:30 behind IST)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
+			await actWait();
 
 			const result = TZ.siteTimeToUtc(testDate);
 
 			expect(result.toISOString()).toBe(expectedDate);
 		});
 
-		it('returns UTC date for Date insatance given in site timezone', () => {
+		it('returns UTC date for Date insatance given in site timezone', async () => {
 			const testDate = new Date(2020, 0 /* Jan */, 28, 13, 0, 20, 0); // in IST
 			const expectedDate = '2020-01-28T07:30:20.000Z'; // in UTC (5:30 behind IST)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
+			await actWait();
 
 			const result = TZ.siteTimeToUtc(testDate);
 
@@ -36,24 +39,26 @@ describe('useTimeZoneTime', () => {
 	});
 
 	describe('utcToSiteTime', () => {
-		it('returns date in site timezone for a given UTC date as ISO string', () => {
+		it('returns date in site timezone for a given UTC date as ISO string', async () => {
 			const testDate = '2020-01-28T07:30:20.123Z'; // in UTC
 			const expectedDate = '2020-01-28T13:00:20.123'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
+			await actWait();
 
 			const result = TZ.utcToSiteTime(testDate);
 
 			expect(format(result, formatString)).toBe(expectedDate);
 		});
 
-		it('returns date in site timezone for a given UTC date as Date insatance', () => {
+		it('returns date in site timezone for a given UTC date as Date insatance', async () => {
 			const testDate = new Date('2020-01-28T07:30:20.123Z'); // in UTC
 			const expectedDate = '2020-01-28T13:00:20.123'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
+			await actWait();
 
 			const result = TZ.utcToSiteTime(testDate);
 

--- a/packages/tpc/src/data/test/data.addPrice.test.ts
+++ b/packages/tpc/src/data/test/data.addPrice.test.ts
@@ -7,11 +7,11 @@ import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('TPC:data.addPrice', () => {
 	it('adds a price at the end of the price list', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -24,8 +24,7 @@ describe('TPC:data.addPrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
-
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -57,7 +56,7 @@ describe('TPC:data.addPrice', () => {
 	});
 
 	it('adds a price at a specific index of the price list', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -71,7 +70,7 @@ describe('TPC:data.addPrice', () => {
 			}
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());

--- a/packages/tpc/src/data/test/data.calculations.test.ts
+++ b/packages/tpc/src/data/test/data.calculations.test.ts
@@ -9,11 +9,11 @@ import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
 import { getBasePrice } from '@eventespresso/predicates';
 import { calculateBasePrice, calculateTicketTotal } from '../../utils';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('TPC:data.calculations', () => {
 	it('adds a price to reflect the change in ticket total when reverseCalculate is false', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -27,7 +27,7 @@ describe('TPC:data.calculations', () => {
 			}
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -74,7 +74,7 @@ describe('TPC:data.calculations', () => {
 	});
 
 	it('adds a price to reflect the change base price when reverseCalculate is true', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -88,7 +88,7 @@ describe('TPC:data.calculations', () => {
 			}
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -147,6 +147,7 @@ describe('TPC:data.calculations', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());
@@ -192,6 +193,7 @@ describe('TPC:data.calculations', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -236,6 +238,7 @@ describe('TPC:data.calculations', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -279,6 +282,7 @@ describe('TPC:data.calculations', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());
@@ -323,6 +327,7 @@ describe('TPC:data.calculations', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());

--- a/packages/tpc/src/data/test/data.deletePrice.test.ts
+++ b/packages/tpc/src/data/test/data.deletePrice.test.ts
@@ -7,8 +7,8 @@ import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import { useDataState } from '../';
 import TestWrapper from './TestWrapper';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('TPC:data.deletePrice', () => {
 	it('deletes the last price and adds it to deleted list', async () => {
 		const { result } = renderHook(
@@ -19,6 +19,7 @@ describe('TPC:data.deletePrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());
@@ -38,7 +39,7 @@ describe('TPC:data.deletePrice', () => {
 	});
 
 	it('deletes a newly added price and does NOT add it to deleted list', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -52,7 +53,7 @@ describe('TPC:data.deletePrice', () => {
 			}
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());

--- a/packages/tpc/src/data/test/data.updatePrice.test.ts
+++ b/packages/tpc/src/data/test/data.updatePrice.test.ts
@@ -7,11 +7,11 @@ import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
+import { actWait } from '@eventespresso/utils/src/test';
 
-const timeout = 5000; // milliseconds
 describe('TPC:data.updatePrice', () => {
 	it('adds a price at the end of the price list and then updates its amount', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				const defaultPriceModifier = usePriceModifier(defaultPrice);
 				return {
@@ -24,8 +24,7 @@ describe('TPC:data.updatePrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
-
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.dataState.reset());
@@ -63,6 +62,7 @@ describe('TPC:data.updatePrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());
@@ -85,6 +85,7 @@ describe('TPC:data.updatePrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());
@@ -113,6 +114,7 @@ describe('TPC:data.updatePrice', () => {
 				wrapper: TestWrapper,
 			}
 		);
+		await actWait();
 
 		// Make sure the state is properly set before moving ahead
 		act(() => result.current.reset());

--- a/packages/tpc/src/data/test/useInitialState.test.ts
+++ b/packages/tpc/src/data/test/useInitialState.test.ts
@@ -3,13 +3,13 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInitialState from '../useInitialState';
 import { nodes as tickets } from '@eventespresso/edtr-services/src/apollo/queries/tickets/test/data';
 import TestWrapper from './TestWrapper';
+import { actWait } from '@eventespresso/utils/src/test';
 
 const mockTicket = tickets[0];
 
-const timeout = 5000; // milliseconds
 describe('TPC:useInitialState', () => {
 	it('returns the computed initial state for the passed ticketId', async () => {
-		const { result, waitForNextUpdate } = renderHook(
+		const { result } = renderHook(
 			() => {
 				return useInitialState({ ticketId: mockTicket.id });
 			},
@@ -18,7 +18,7 @@ describe('TPC:useInitialState', () => {
 			}
 		);
 
-		await waitForNextUpdate({ timeout });
+		await actWait();
 
 		const initialState = result.current(null);
 

--- a/packages/utils/src/test/index.ts
+++ b/packages/utils/src/test/index.ts
@@ -1,0 +1,11 @@
+import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Wait for initial setup of cache etc.
+ * Apollo returns promises for query hooks which create warnings when testing in sync
+ * We need to wait for those promises to resolve in order to avoid state updates synchronously.
+ *
+ * @see https://github.com/apollographql/apollo-client/issues/5920
+ */
+export const actWait = async (): Promise<any> => await act(() => waitFor(() => null));


### PR DESCRIPTION
This PR fixes the console warnings for unit tests caused by async nature of Apollo query hooks.

Closes #242 