### PR TITLE
i18n strings extraction

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,5 +13,17 @@ module.exports = function (api) {
 	return {
 		presets,
 		plugins,
+		env: {
+			production: {
+				plugins: [
+					[
+						'@wordpress/babel-plugin-makepot',
+						{
+							output: 'build/js-translations.pot',
+						},
+					],
+				],
+			},
+		},
 	};
 };

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"@types/ramda": "^0.27.6",
 		"@typescript-eslint/eslint-plugin": "^3.4.0",
 		"@typescript-eslint/parser": "^3.4.0",
+		"@wordpress/babel-plugin-makepot": "^3.8.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
 		"babel-eslint": "10.1.0",
 		"babel-jest": "^26.1.0",

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -76,6 +76,12 @@ rm -rf $ASSETS_PATH/*
 # Make sure the directory exists
 mkdir -p $ASSETS_PATH
 
+# Convert POT file to PHP
+npx pot-to-php $BASE/$BUILD_PATH/js-translations.pot languages/event_espresso-js-translations.php event_espresso
+
+# Remove POT file
+rm $BASE/$BUILD_PATH/js-translations.pot
+
 # copy files from build folder to target assets folder
 cp -r $BASE/$BUILD_PATH/* $ASSETS_PATH/
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5111,6 +5111,15 @@
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+"@wordpress/babel-plugin-makepot@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-3.8.0.tgz#de5dd240565835e56dbe60f450adaf5591ff3fa4"
+  integrity sha512-Yye1ossaWIYUU6+m8SBiuEGDFViFcOcJT/WYl69ZXgvuysjfhptdp/0qcRSwkEHAnw+FiHN5UztjNFQyK43iqA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.19"
+
 "@wordpress/blob@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-2.9.0.tgz#6453418a897431c54921eff03f67d21e373ced8d"


### PR DESCRIPTION
This PR wires up i18n string extraction with webpack/babel. After this PR, the target repos of the domains will receive the translation strings from JS code in the form of a PHP file (`languages/event_espresso-js-translations.php`) to let build machine pick those strings.

Closes #216 