### PR TITLE
Fix REM/rrule-generator input attributes

### DIFF
--- a/domains/rem/src/ui/rRule/PatternEditor.tsx
+++ b/domains/rem/src/ui/rRule/PatternEditor.tsx
@@ -9,8 +9,8 @@ const config: RRuleConfig = {
 	enableTimepicker: false,
 };
 
-const PatternEditor: React.FC<PatternEditorProps> = ({ id, rRuleString, onChange, type }) => {
-	return <RRuleGenerator config={config} id={`rrule-${type}-${id}`} onChange={onChange} value={rRuleString} />;
+const PatternEditor: React.FC<PatternEditorProps> = ({ id, rRuleString, onChange }) => {
+	return <RRuleGenerator config={config} id={id} onChange={onChange} value={rRuleString} />;
 };
 
 export default PatternEditor;

--- a/domains/rem/src/ui/rRule/RRuleEditor.tsx
+++ b/domains/rem/src/ui/rRule/RRuleEditor.tsx
@@ -16,7 +16,7 @@ const RRuleEditor: React.FC<RRuleEditorProps> = ({ desc, icon, id, onChange, rRu
 	return (
 		<div className={wrapperClassName}>
 			{sidebarLabel && <FormSectionSidebar desc={desc} Icon={icon} title={sidebarLabel} />}
-			<PatternEditor id={id} onChange={onChange} rRuleString={rRuleString} type={type} />
+			<PatternEditor id={id} onChange={onChange} rRuleString={rRuleString} />
 		</div>
 	);
 };

--- a/domains/rem/src/ui/rRule/types.ts
+++ b/domains/rem/src/ui/rRule/types.ts
@@ -11,7 +11,7 @@ interface CommonProps {
 
 export interface EditorControlsProps {}
 
-export interface PatternEditorProps extends CommonProps {}
+export interface PatternEditorProps extends Omit<CommonProps, 'type'> {}
 
 export interface RRuleEditorProps extends CommonProps, EditorControlsProps {
 	icon?: React.ComponentType<{ className?: string }>;

--- a/packages/rrule-generator/src/components/End/After.tsx
+++ b/packages/rrule-generator/src/components/End/After.tsx
@@ -18,7 +18,7 @@ const After: React.FC<AfterProps> = ({ id, after, onChange }) => {
 				aria-label={__('End after')}
 				className='rrule-generator__form-control rrule-generator__input'
 				id={id}
-				name='end.after'
+				name={id}
 				onChange={onChangeAfter}
 				type='number'
 				value={after}

--- a/packages/rrule-generator/src/components/End/Mode.tsx
+++ b/packages/rrule-generator/src/components/End/Mode.tsx
@@ -26,6 +26,7 @@ const Mode: React.FC<ModeProps> = ({ id, mode, onChange }) => {
 			id={id}
 			className='rrule-generator__form-control rrule-generator__form-control--medium-width rrule-generator__select'
 			value={mode}
+			name={id}
 			onChange={onChangeMode}
 		>
 			{endModes.map((endMode) => {

--- a/packages/rrule-generator/src/components/Repeat/Daily/index.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Daily/index.tsx
@@ -20,7 +20,7 @@ const Daily: React.FC<BaseProps> = ({ id }) => {
 					aria-label={__('Repeat daily interval')}
 					className='rrule-generator__form-control rrule-generator__input'
 					id={`${id}-interval`}
-					name='repeat.daily.interval'
+					name={`${id}-interval`}
 					onChange={onChangeInterval}
 					type='number'
 					value={daily?.interval}

--- a/packages/rrule-generator/src/components/Repeat/Frequency.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Frequency.tsx
@@ -28,6 +28,7 @@ const Frequency: React.FC<FrequencyProps> = ({ id, frequency, onChange }) => {
 			<select
 				className='rrule-generator__form-control rrule-generator__select'
 				id={id}
+				name={id}
 				onChange={onChangeFrequency}
 				value={frequency}
 			>

--- a/packages/rrule-generator/src/components/Repeat/Hourly/index.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Hourly/index.tsx
@@ -21,7 +21,7 @@ const Hourly: React.FC<BaseProps> = ({ id }) => {
 					aria-label={__('Repeat hourly interval')}
 					className='rrule-generator__form-control rrule-generator__input'
 					id={`${id}-interval`}
-					name='repeat.hourly.interval'
+					name={`${id}-interval`}
 					onChange={onChangeInterval}
 					type='number'
 					value={hourly?.interval}

--- a/packages/rrule-generator/src/components/Repeat/Monthly/On.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Monthly/On.tsx
@@ -43,7 +43,7 @@ const On: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 
 			<select
 				id={`${id}-day`}
-				name='repeat.monthly.on.day'
+				name={`${id}-day`}
 				aria-label={__('Repeat monthly on a day')}
 				className='rrule-generator__form-control rrule-generator__select rrule-generator__day'
 				value={on.day}

--- a/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
@@ -62,7 +62,7 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 
 			<select
 				id={`${id}-day`}
-				name='repeat.monthly.onThe.day'
+				name={`${id}-day`}
 				aria-label={__('Repeat monthly on the day')}
 				className='rrule-generator__form-control rrule-generator__select rrule-generator__month'
 				value={onThe.day}

--- a/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Monthly/OnThe.tsx
@@ -56,7 +56,6 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 				aria-label={__('Repeat monthly on the which')}
 				id={id}
 				isActive={isActive}
-				name='repeat.monthly.onThe.which'
 				onChangeWhich={onChangeWhich}
 				value={onThe.which}
 			/>

--- a/packages/rrule-generator/src/components/Repeat/Monthly/index.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Monthly/index.tsx
@@ -34,7 +34,7 @@ const Monthly: React.FC<BaseProps> = ({ id }) => {
 					aria-label={__('Repeat monthly interval')}
 					className='rrule-generator__form-control rrule-generator__input'
 					id={`${id}-interval`}
-					name='repeat.monthly.interval'
+					name={`${id}-interval`}
 					onChange={onChangeInterval}
 					type='number'
 					value={monthly?.interval}

--- a/packages/rrule-generator/src/components/Repeat/PositionSelect.tsx
+++ b/packages/rrule-generator/src/components/Repeat/PositionSelect.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { PositionSelectProps } from './types';
 import { WHICH } from '../../constants';
 
-const PositionSelect: React.FC<PositionSelectProps> = ({ id, isActive, name, onChangeWhich, value, ...props }) => (
+const PositionSelect: React.FC<PositionSelectProps> = ({ id, isActive, onChangeWhich, value, ...props }) => (
 	<select
 		aria-label={props['aria-label']}
 		id={`${id}-which`}
-		name={name}
+		name={`${id}-which`}
 		className='rrule-generator__form-control rrule-generator__select'
 		value={value}
 		disabled={!isActive}

--- a/packages/rrule-generator/src/components/Repeat/Weekly/index.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Weekly/index.tsx
@@ -35,7 +35,7 @@ const Weekly: React.FC<BaseProps> = ({ id }) => {
 
 				<input
 					id={`${id}-interval`}
-					name='repeat.weekly.interval'
+					name={`${id}-interval`}
 					aria-label={__('Repeat weekly interval')}
 					className='rrule-generator__form-control rrule-generator__input'
 					type='number'

--- a/packages/rrule-generator/src/components/Repeat/Yearly/On.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Yearly/On.tsx
@@ -59,7 +59,7 @@ const On: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 
 			<select
 				id={`${id}-month`}
-				name='repeat.yearly.on.month'
+				name={`${id}-month`}
 				aria-label={__('Repeat yearly on month')}
 				className='rrule-generator__form-control rrule-generator__select rrule-generator__month'
 				value={on.month}
@@ -75,7 +75,7 @@ const On: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 
 			<select
 				id={`${id}-day`}
-				name='repeat.yearly.on.day'
+				name={`${id}-day`}
 				aria-label={__('Repeat yearly on a day')}
 				className='rrule-generator__form-control rrule-generator__select rrule-generator__day'
 				value={on.day}

--- a/packages/rrule-generator/src/components/Repeat/Yearly/OnThe.tsx
+++ b/packages/rrule-generator/src/components/Repeat/Yearly/OnThe.tsx
@@ -52,7 +52,7 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 						className='rrule-generator__input-radio'
 						id={id}
 						type='radio'
-						name='repeat.yearly.mode'
+						name={id}
 						checked={isActive}
 						value='ON_THE'
 						onChange={onChangeMode}
@@ -65,14 +65,13 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 				aria-label={__('Repeat yearly on the')}
 				id={id}
 				isActive={isActive}
-				name='repeat.yearly.onThe.which'
 				onChangeWhich={onChangeWhich}
 				value={onThe.which}
 			/>
 
 			<select
 				id={`${id}-day`}
-				name='repeat.yearly.onThe.day'
+				name={`${id}-day`}
 				aria-label={__('Repeat yearly on the day')}
 				className='rrule-generator__form-control rrule-generator__select'
 				value={onThe.day}
@@ -90,7 +89,7 @@ const OnThe: React.FC<OnProps> = ({ id, isTheOnlyMode, onChangeMode }) => {
 
 			<select
 				id={`${id}-month`}
-				name='repeat.yearly.onThe.month'
+				name={`${id}-month`}
 				aria-label={__('Repeat yearly on the month')}
 				className='rrule-generator__form-control rrule-generator__select rrule-generator__month'
 				value={onThe.month}

--- a/packages/rrule-generator/src/components/Repeat/types.ts
+++ b/packages/rrule-generator/src/components/Repeat/types.ts
@@ -15,7 +15,6 @@ export interface PositionSelectProps {
 	'aria-label': string;
 	id: string;
 	isActive: boolean;
-	name: string;
 	onChangeWhich: OnChangeSelect;
 	value: string;
 }


### PR DESCRIPTION
This PR fixes the duplicate names in REM RRule and ExRule editor inputs.

Closes #260 