### PR TITLE
Persist entity list view to browser storage

### DIFF
--- a/domains/eventEditor/src/services/filterState/datetimes/useDatesListFilterStateManager.ts
+++ b/domains/eventEditor/src/services/filterState/datetimes/useDatesListFilterStateManager.ts
@@ -1,8 +1,8 @@
 import { useCallback, useMemo } from 'react';
 
-import { DisplayStartOrEndDate, SortBy } from '@eventespresso/edtr-services';
+import { DisplayStartOrEndDate, SortBy, datesList } from '@eventespresso/edtr-services';
 import { useEntityListFilterStateManager } from '@eventespresso/components';
-import { useSessionStorageReducer } from '@eventespresso/services';
+import { useSessionStorageReducer } from '@eventespresso/storage';
 
 import reducer from './reducer';
 import { DatetimeSales, DatetimeStatus } from './types';
@@ -19,7 +19,7 @@ const initialState: DatetimesFilterState = {
 const useDatesListFilterStateManager = (): FSM => {
 	const [state, dispatch] = useSessionStorageReducer('dates-list-filter-state', reducer, initialState);
 
-	const entityFilterState = useEntityListFilterStateManager<SortBy>('order');
+	const entityFilterState = useEntityListFilterStateManager<SortBy>('order', datesList);
 
 	const { setPageNumber } = entityFilterState;
 

--- a/domains/eventEditor/src/services/filterState/tickets/useTicketsListFilterStateManager.ts
+++ b/domains/eventEditor/src/services/filterState/tickets/useTicketsListFilterStateManager.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { DisplayStartOrEndDate, SortBy } from '@eventespresso/edtr-services';
+import { DisplayStartOrEndDate, SortBy, ticketsList } from '@eventespresso/edtr-services';
 import { useEntityListFilterStateManager } from '@eventespresso/components';
 import { useEdtrState } from '@eventespresso/edtr-services';
-import { useSessionStorageReducer } from '@eventespresso/services';
+import { useSessionStorageReducer } from '@eventespresso/storage';
 
 import reducer from './reducer';
 import { TicketsSales, TicketsStatus } from './types';
@@ -25,7 +25,7 @@ const useTicketsListFilterStateManager = (): FSM => {
 
 	const { visibleDatetimeIds } = useEdtrState();
 
-	const entityFilterState = useEntityListFilterStateManager<SortBy>('order');
+	const entityFilterState = useEntityListFilterStateManager<SortBy>('order', ticketsList);
 
 	const { setPageNumber } = entityFilterState;
 

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -8,6 +8,7 @@ module.exports = [
 		'registry',
 		'rich-text-editor',
 		'styles',
+		'storage',
 		'toaster',
 		'utils',
 	],

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,5 +1,5 @@
 {
 	"name": "eslint-plugin-ee-barista",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"main": "index.js"
 }

--- a/packages/components/src/EntityList/filterBar/filterState/useStateReducer.ts
+++ b/packages/components/src/EntityList/filterBar/filterState/useStateReducer.ts
@@ -1,7 +1,9 @@
+import { useCallback } from 'react';
+
 import type { BasicSortBy, EntityListFilterStateReducer } from './types';
 
-const getReducer = <SortBy = BasicSortBy>(): EntityListFilterStateReducer<SortBy> => {
-	const reducer: EntityListFilterStateReducer<SortBy> = (state, action) => {
+const useStateReducer = <SortBy = BasicSortBy>(): EntityListFilterStateReducer<SortBy> => {
+	return useCallback<EntityListFilterStateReducer<SortBy>>((state, action) => {
 		const { type, perPage, pageNumber, total, searchText, sortBy, view } = action;
 		let sortingEnabled: boolean;
 		switch (type) {
@@ -32,9 +34,7 @@ const getReducer = <SortBy = BasicSortBy>(): EntityListFilterStateReducer<SortBy
 			default:
 				throw new Error('Unexpected action');
 		}
-	};
-
-	return reducer;
+	}, []);
 };
 
-export default getReducer;
+export default useStateReducer;

--- a/packages/services/src/hooks/index.ts
+++ b/packages/services/src/hooks/index.ts
@@ -1,5 +1,4 @@
 export * from './useTimeZoneTime';
-export * from './useStorage';
 
 export { default as useTimeZoneTime } from './useTimeZoneTime';
 export { default as useSiteDateToUtcISO } from './useSiteDateToUtcISO';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
 	"author": "Event Espresso",
-	"name": "@eventespresso/services",
+	"name": "@eventespresso/storage",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/eventespresso/barista.git"
@@ -16,10 +16,7 @@
 	},
 	"sideEffects": false,
 	"dependencies": {
-		"date-fns": "^2.14.0",
-		"date-fns-tz": "^1.0.10",
-		"ramda": "^0.27.0",
-		"react-toastify": "^6.0.6"
+		"react-storage-hooks": "^4.0.1"
 	},
 	"devDependencies": {
 		"@react-workspaces/react-scripts": "3.4.0-alpha-01",
@@ -27,19 +24,16 @@
 		"@testing-library/jest-dom": "^5.10.1",
 		"@testing-library/react": "^10.4.1",
 		"@testing-library/user-event": "^12.0.7",
-		"@types/invariant": "^2.2.33",
 		"@types/jest": "^26.0.1",
 		"@types/node": "^14.0.14",
-		"@types/ramda": "^0.27.6",
 		"@types/react": "^16.9.41",
 		"@types/react-dom": "^16.9.8",
 		"@typescript-eslint/eslint-plugin": "^3.4.0",
 		"@typescript-eslint/parser": "^3.4.0",
 		"react-scripts": "3.4.1",
-		"typescript": "^3.9.5"
+		"typescript": "~3.9.5"
 	},
 	"peerDependencies": {
-		"@chakra-ui/core": "^0.8.0",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1"
 	},
@@ -65,6 +59,5 @@
 			}
 		}
 	},
-	"license": "GPL-3.0",
-	"gitHead": "66fae0230a22c100153cb05f5a624305efc5a8d9"
+	"license": "GPL-3.0"
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,2 @@
+export * from './useSessionStorageReducer';
+export * from './useSessionStorageState';

--- a/packages/storage/src/useSessionStorageReducer.ts
+++ b/packages/storage/src/useSessionStorageReducer.ts
@@ -1,21 +1,18 @@
-import { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { useStorageReducer } from 'react-storage-hooks';
-
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 export function useSessionStorageReducer<S, A>(
 	key: string,
 	reducer: React.Reducer<S, A>,
 	initialState?: S | (() => S)
 ): [any, React.Dispatch<React.SetStateAction<any>>] {
-	const toaster = useSystemNotifications();
 	const [state, dispatch, writeError] = useStorageReducer(sessionStorage, key, reducer, initialState);
 
 	useEffect(() => {
 		if (writeError) {
-			toaster.error({ message: writeError.message });
+			console.error(writeError.name, writeError.message);
 		}
-	}, [toaster, writeError]);
+	}, [writeError]);
 
 	return useMemo(() => [state, dispatch], [state, dispatch]);
 }

--- a/packages/storage/src/useSessionStorageState.ts
+++ b/packages/storage/src/useSessionStorageState.ts
@@ -5,7 +5,7 @@ export function useSessionStorageState<S>(
 	key: string,
 	defaultState?: S | (() => S)
 ): [S, React.Dispatch<React.SetStateAction<S>>] {
-	const [count, setCount, writeError] = useStorageState(sessionStorage, key, defaultState);
+	const [state, setState, writeError] = useStorageState(sessionStorage, key, defaultState);
 
 	useEffect(() => {
 		if (writeError) {
@@ -13,5 +13,5 @@ export function useSessionStorageState<S>(
 		}
 	}, [writeError]);
 
-	return useMemo(() => [count, setCount], [count, setCount]);
+	return useMemo(() => [state, setState], [setState, state]);
 }

--- a/packages/storage/src/useSessionStorageState.ts
+++ b/packages/storage/src/useSessionStorageState.ts
@@ -1,0 +1,17 @@
+import React, { useEffect, useMemo } from 'react';
+import { useStorageState } from 'react-storage-hooks';
+
+export function useSessionStorageState<S>(
+	key: string,
+	defaultState?: S | (() => S)
+): [S, React.Dispatch<React.SetStateAction<S>>] {
+	const [count, setCount, writeError] = useStorageState(sessionStorage, key, defaultState);
+
+	useEffect(() => {
+		if (writeError) {
+			console.error(writeError.name, writeError.message);
+		}
+	}, [writeError]);
+
+	return useMemo(() => [count, setCount], [count, setCount]);
+}

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
This PR:
- Creates `storage` package to for browser storage related hooks
- Updates Entity List filter state to persist `view` of the list
- Improves perf by converting reducer to hook

Closes #267