### PR TITLE
Fix invalid DOM warning

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/editable/EditableName.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/editable/EditableName.tsx
@@ -35,7 +35,7 @@ const EditableName: React.FC<EditableNameProps> = ({ className, entity: datetime
 			fitText={view === 'card'}
 			lineCount={lineCount}
 			onChangeValue={onChangeName}
-			tag={view === 'table' ? 'p' : 'h4'}
+			tag={view === 'table' ? 'div' : 'h4'}
 			tooltip={tooltip}
 			value={dateName}
 		/>

--- a/domains/eventEditor/src/ui/tickets/ticketsList/editable/EditableName.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/editable/EditableName.tsx
@@ -35,7 +35,7 @@ const EditableName: React.FC<Partial<EditableNameProps>> = ({ className, entity:
 			fitText={view === 'card'}
 			lineCount={lineCount}
 			onChangeValue={onChangeName}
-			tag={view === 'table' ? 'p' : 'h4'}
+			tag={view === 'table' ? 'div' : 'h4'}
 			tooltip={tooltip}
 			value={ticketName}
 		/>


### PR DESCRIPTION
This PR fixed the invalid DOM warning in inline edit input preview by using `<div />` instead of `<p />`.

Closes #273 