### PR TITLE
Improve package/domain dependencies

### DIFF
--- a/domains/blocks/src/components/RegStatusControl.tsx
+++ b/domains/blocks/src/components/RegStatusControl.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@eventespresso/i18n';
 
-import { regStatusOptions as statusOptions } from '@eventespresso/predicates';
-import type { SelectControlProps } from './types';
 import type { RegistrationStatus } from '@eventespresso/data';
+import type { SelectControlProps } from './types';
+// imprort by absolute path to avoid loading the whole package
+import statusOptions from '../../../../packages/predicates/src/registration/statusOptions';
 
 interface RegStatusControlProps extends SelectControlProps {
 	setStatus?: (order: RegistrationStatus) => void;

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -1,6 +1,7 @@
 module.exports = [
 	/* LEVEL 1 */ [
 		'constants',
+		'data',
 		'dates',
 		'hooks',
 		'icons',
@@ -12,7 +13,7 @@ module.exports = [
 		'toaster',
 		'utils',
 	],
-	/* LEVEL 2 */ ['adapters', 'config', 'data', 'rrule-generator'],
+	/* LEVEL 2 */ ['adapters', 'config', 'rrule-generator'],
 	/* LEVEL 3 */ ['form', 'predicates', 'services'],
 	/* LEVEL 4 */ ['components', 'edtr-services', 'helpers'],
 	/* LEVEL 5 */ ['tpc'],

--- a/lib/Barista.php
+++ b/lib/Barista.php
@@ -243,7 +243,7 @@ class Barista
 
 	public function addInlineData() {
 		wp_add_inline_script(
-			'eventespresso-hooks',
+			'eventespresso-i18n',
 			sprintf('var baristaAssetsUrl = "%s";', $this->url('build/')),
 			'before'
 		);

--- a/packages/data/src/queries/currentUser/useCurrentUser.ts
+++ b/packages/data/src/queries/currentUser/useCurrentUser.ts
@@ -1,4 +1,5 @@
-import { useMemoStringify } from '@eventespresso/hooks';
+import { useMemo } from 'react';
+
 import type { CurrentUserProps, Viewer } from '@eventespresso/services';
 
 import useCurrentUserQueryOptions from './useCurrentUserQueryOptions';
@@ -11,7 +12,10 @@ const useCurrentUser = (): CurrentUserProps => {
 	const options = useCurrentUserQueryOptions();
 	const { data } = useCacheQuery<Viewer>(options);
 
-	return useMemoStringify(data?.viewer);
+	const dataStr = JSON.stringify(data?.viewer);
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	return useMemo(() => data?.viewer, [dataStr]);
 };
 
 export default useCurrentUser;

--- a/packages/data/src/queries/currentUser/useFetchCurrentUser.ts
+++ b/packages/data/src/queries/currentUser/useFetchCurrentUser.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@apollo/react-hooks';
 
-import { useSystemNotifications } from '@eventespresso/toaster';
-import { GET_CURRENT_USER } from '.';
+import { GET_CURRENT_USER } from './';
 import type { FetchQueryResult } from '../types';
 import type { Viewer } from '@eventespresso/services';
 
 const useFetchCurrentUser = (): FetchQueryResult<Viewer> => {
-	const toaster = useSystemNotifications();
-
 	const result = useQuery<Viewer>(GET_CURRENT_USER, {
 		// only display error, not loading or success
 		onError: (error): void => {
-			toaster.error({ message: error.message });
+			console.error(error.message);
 		},
 	});
 

--- a/packages/data/src/queries/generalSettings/useFetchGeneralSettings.ts
+++ b/packages/data/src/queries/generalSettings/useFetchGeneralSettings.ts
@@ -1,17 +1,14 @@
 import { useQuery } from '@apollo/react-hooks';
 
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { GET_GENERAL_SETTINGS } from '.';
 import type { FetchQueryResult } from '../types';
 import type { GeneralSettingsData } from '@eventespresso/services';
 
 const useFetchGeneralSettings = (): FetchQueryResult<GeneralSettingsData> => {
-	const toaster = useSystemNotifications();
-
 	const result = useQuery<GeneralSettingsData>(GET_GENERAL_SETTINGS, {
 		// only display error, not loading or success
 		onError: (error): void => {
-			toaster.error({ message: error.message });
+			console.error(error.message);
 		},
 	});
 

--- a/packages/data/src/queries/generalSettings/useGeneralSettings.ts
+++ b/packages/data/src/queries/generalSettings/useGeneralSettings.ts
@@ -1,4 +1,5 @@
-import { useMemoStringify } from '@eventespresso/hooks';
+import { useMemo } from 'react';
+
 import type { GeneralSettings, GeneralSettingsData } from '@eventespresso/services';
 
 import useGeneralSettingsQueryOptions from './useGeneralSettingsQueryOptions';
@@ -11,7 +12,10 @@ const useGeneralSettings = (): GeneralSettings => {
 	const options = useGeneralSettingsQueryOptions();
 	const { data } = useCacheQuery<GeneralSettingsData>(options);
 
-	return useMemoStringify(data?.generalSettings);
+	const dataStr = JSON.stringify(data?.generalSettings);
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	return useMemo(() => data?.generalSettings, [dataStr]);
 };
 
 export default useGeneralSettings;

--- a/packages/predicates/src/registration/statusOptions.ts
+++ b/packages/predicates/src/registration/statusOptions.ts
@@ -30,3 +30,5 @@ export const regStatusOptions = [
 		label: __('Wait List'),
 	},
 ];
+
+export default regStatusOptions;


### PR DESCRIPTION
This package reduces the dependencies for `data` package and `blocks` domain.
For `data` package the main dependency was `toaster` as mentioned in the related issue. For now the PR changes toaster to use `console.error` instead of `toaster.error`. An efficient mechanism to handle it will be tracked in #276 

The main improvement this PR makes is for `blocks` domain. From all our packages, `blocks` domain only needs `data` package, but since `data` was dependent upon other packages, it caused a whole lot of unused assets to be loaded for `blocks` domain. Another dependency for blocks which caused the similar issue was `predicates` package. This PR changes that single import to a direct import to avoid package dependency.

Closes #53 

Assets loaded in blocks domain **BEFORE this PR**

![image](https://user-images.githubusercontent.com/18226415/93780147-6bd0a400-fc45-11ea-99a2-6abb2f25ec5d.png)



Assets loaded in blocks domain **AFTER this PR**

![image](https://user-images.githubusercontent.com/18226415/93780171-73904880-fc45-11ea-9c64-91d6cb8b0cdd.png)


