### PR TITLE
Eslint React Perf

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
 		"plugin:prettier/recommended",
 		"plugin:@typescript-eslint/recommended",
 		"plugin:jsx-a11y/recommended",
+		"plugin:react-perf/recommended",
 		"react-app"
 	],
 	"globals": {
@@ -26,7 +27,7 @@
 		"ecmaVersion": 2018,
 		"sourceType": "module"
 	},
-	"plugins": ["react-hooks", "jsx-a11y", "ee-barista"],
+	"plugins": ["react-hooks", "jsx-a11y", "ee-barista", "react-perf"],
 	"rules": {
 		"@typescript-eslint/ban-ts-comment": "off",
 		"@typescript-eslint/ban-ts-ignore": "off",
@@ -42,7 +43,6 @@
 		"react-hooks/exhaustive-deps": "error",
 		"react-hooks/rules-of-hooks": "error",
 		"react/display-name": "off",
-		"react/jsx-no-bind": "error",
 		"react/prop-types": "off",
 		"react/static-property-placement": "off"
 	},

--- a/domains/blocks/src/components/AvatarImage.tsx
+++ b/domains/blocks/src/components/AvatarImage.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 
@@ -11,10 +11,13 @@ interface AvatarImageProps {
 }
 
 const AvatarImage: React.FC<AvatarImageProps> = ({ className = 'contact', url, altText, height = 32, width = 32 }) => {
-	const style: CSSProperties = {
-		height,
-		width,
-	};
+	const style = useMemo<CSSProperties>(
+		() => ({
+			height,
+			width,
+		}),
+		[height, width]
+	);
 	return url ? (
 		<div className={className + '-image-wrap-div'}>
 			<img

--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/ContentBody.tsx
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/ContentBody.tsx
@@ -10,6 +10,7 @@ import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManage
 import DateFormSteps from './DateFormSteps';
 import useDataListener from './useDataListener';
 
+const subscription = { submitting: true, hasValidationErrors: true, hasSubmitErrors: true };
 /**
  * This component is inside both RFF and TAM contexts, so we can use all of their features
  */
@@ -21,8 +22,6 @@ const ContentBody: React.FC = ({ children }) => {
 	const { hasOrphanEntities } = useTAMDataState();
 
 	const isSubmitDisabled = hasOrphanEntities();
-
-	const subscription = { submitting: true, hasValidationErrors: true, hasSubmitErrors: true };
 
 	return (
 		<FormSpy subscription={subscription}>

--- a/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateDetailsPanel.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateDetailsPanel.tsx
@@ -1,41 +1,43 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { __ } from '@eventespresso/i18n';
 
 import { EntityDetailsPanel, EntityDetailsPanelSold } from '@eventespresso/components';
 import DateRegistrationsLink from '../../DateRegistrationsLink';
 import DateCapacity from './DateCapacity';
-import { getPropsAreEqual } from '@eventespresso/utils';
 import type { DateItemProps } from '../types';
 
 const DateDetailsPanel: React.FC<DateItemProps> = ({ adminUrl, entity: datetime, eventId }) => {
-	const details = [
-		{
-			id: 'ee-event-date-sold',
-			label: __('sold'),
-			value: (
-				<EntityDetailsPanelSold
-					adminUrl={adminUrl}
-					dbId={datetime.dbId}
-					eventId={eventId}
-					sold={datetime.sold}
-					type='date'
-				/>
-			),
-		},
-		{
-			id: 'ee-event-date-capacity',
-			label: __('capacity'),
-			value: <DateCapacity entity={datetime} />,
-		},
-		{
-			id: 'ee-event-date-registrations',
-			className: 'ee-has-tooltip',
-			label: __('reg list'),
-			value: <DateRegistrationsLink datetime={datetime} />,
-		},
-	];
+	const details = useMemo(
+		() => [
+			{
+				id: 'ee-event-date-sold',
+				label: __('sold'),
+				value: (
+					<EntityDetailsPanelSold
+						adminUrl={adminUrl}
+						dbId={datetime.dbId}
+						eventId={eventId}
+						sold={datetime.sold}
+						type='date'
+					/>
+				),
+			},
+			{
+				id: 'ee-event-date-capacity',
+				label: __('capacity'),
+				value: <DateCapacity entity={datetime} />,
+			},
+			{
+				id: 'ee-event-date-registrations',
+				className: 'ee-has-tooltip',
+				label: __('reg list'),
+				value: <DateRegistrationsLink datetime={datetime} />,
+			},
+		],
+		[adminUrl, datetime, eventId]
+	);
 
 	return <EntityDetailsPanel details={details} className='ee-editor-date-details-sold-rsrvd-cap-div' />;
 };
 
-export default React.memo(DateDetailsPanel, getPropsAreEqual(['entity', 'cacheId']));
+export default DateDetailsPanel;

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/filters/controls/DatesByMonthControl.tsx
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/filters/controls/DatesByMonthControl.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { __ } from '@eventespresso/i18n';
 
 import { useDatetimes } from '@eventespresso/edtr-services';
@@ -16,7 +16,9 @@ const DatesByMonthControl: React.FC<DatesByMonthControlProps> = React.memo(({ da
 	const yearMonth = datesByMonth.join(':');
 
 	// Add all dates option at the top, "0:0" to match the "year:month" format
-	const monthsListWithAllDates = [{ value: '0:0', label: __('All Dates') }, ...monthsList];
+	const monthsListWithAllDates = useMemo(() => [{ value: '0:0', label: __('All Dates') }, ...monthsList], [
+		monthsList,
+	]);
 
 	return (
 		<SelectInput

--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/ContentBody.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/ContentBody.tsx
@@ -49,7 +49,7 @@ const ContentBody: React.FC = ({ children }) => {
 									<Next
 										buttonText={__('Skip prices - assign dates')}
 										isDisabled={isSaveDisabled}
-										// eslint-disable-next-line react/jsx-no-bind
+										// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 										onClick={() => goto(2)}
 										skippable
 									/>
@@ -77,7 +77,7 @@ const ContentBody: React.FC = ({ children }) => {
 								<ButtonRow>
 									<Previous
 										buttonText={__('Ticket details')}
-										// eslint-disable-next-line react/jsx-no-bind
+										// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 										onClick={() => goto(0)}
 										skippable
 									/>

--- a/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketDetailsPanel.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketDetailsPanel.tsx
@@ -1,40 +1,42 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { __ } from '@eventespresso/i18n';
 
 import TicketRegistrationsLink from '../../TicketRegistrationsLink';
 import { EntityDetailsPanel, EntityDetailsPanelSold } from '@eventespresso/components';
 import TicketQuantity from './TicketQuantity';
-import { getPropsAreEqual } from '@eventespresso/utils';
 import type { TicketItemProps } from '../types';
 
-const TicketDetailsPanel: React.FC<TicketItemProps> = React.memo(({ adminUrl, entity: ticket, eventId }) => {
-	const details = [
-		{
-			id: 'ee-ticket-sold',
-			label: __('sold'),
-			value: (
-				<EntityDetailsPanelSold
-					adminUrl={adminUrl}
-					dbId={ticket.dbId}
-					eventId={eventId}
-					sold={ticket.sold}
-					type='ticket'
-				/>
-			),
-		},
-		{
-			id: 'ee-ticket-qty',
-			label: __('quantity'),
-			value: <TicketQuantity entity={ticket} />,
-		},
-		{
-			id: 'ee-ticket-registrations',
-			label: __('reg list'),
-			value: <TicketRegistrationsLink ticket={ticket} />,
-		},
-	];
+const TicketDetailsPanel: React.FC<TicketItemProps> = ({ adminUrl, entity: ticket, eventId }) => {
+	const details = useMemo(
+		() => [
+			{
+				id: 'ee-ticket-sold',
+				label: __('sold'),
+				value: (
+					<EntityDetailsPanelSold
+						adminUrl={adminUrl}
+						dbId={ticket.dbId}
+						eventId={eventId}
+						sold={ticket.sold}
+						type='ticket'
+					/>
+				),
+			},
+			{
+				id: 'ee-ticket-qty',
+				label: __('quantity'),
+				value: <TicketQuantity entity={ticket} />,
+			},
+			{
+				id: 'ee-ticket-registrations',
+				label: __('reg list'),
+				value: <TicketRegistrationsLink ticket={ticket} />,
+			},
+		],
+		[adminUrl, eventId, ticket]
+	);
 
 	return <EntityDetailsPanel details={details} className='ee-editor-ticket-details-sold-rsrvd-qty-div' />;
-});
+};
 
-export default React.memo(TicketDetailsPanel, getPropsAreEqual(['entity', 'cacheId']));
+export default TicketDetailsPanel;

--- a/domains/eventEditor/src/ui/tickets/ticketsList/newTicketOptions/OptionsPopover.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/newTicketOptions/OptionsPopover.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-
+const style = { margin: '5px', border: '1px solid red' };
 const OptionsPopover: React.FC = ({ children }) => {
 	// TODO convert this to modal
-	return <div style={{ margin: '5px', border: '1px solid red' }}>{children}</div>;
+	return <div style={style}>{children}</div>;
 };
 
 export default OptionsPopover;

--- a/domains/rem/src/ui/recurrence/PatternEditor.tsx
+++ b/domains/rem/src/ui/recurrence/PatternEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDisclosure } from '@chakra-ui/hooks';
 import { __ } from '@eventespresso/i18n';
 
@@ -23,6 +23,8 @@ const PatternEditor: React.FC = () => {
 	// We need to show rRule even after coming back from next steps
 	// isOpen is reset on each mount (step), exRule still remains in REM state
 	const showExRule = exRule || isOpen;
+
+	const debugData = useMemo(() => ({ rRule, exRule }), [exRule, rRule]);
 
 	return (
 		<>
@@ -59,7 +61,7 @@ const PatternEditor: React.FC = () => {
 					type='exclusion'
 				/>
 			)}
-			<DebugInfo data={{ rRule, exRule }} />
+			<DebugInfo data={debugData} />
 		</>
 	);
 };

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-react": "7.20.0",
 		"eslint-plugin-react-hooks": "^4.0.4",
+		"eslint-plugin-react-perf": "^3.2.4",
 		"file-loader": "6.0.0",
 		"fs-extra": "^9.0.1",
 		"html-webpack-plugin": "4.3.0",

--- a/packages/adapters/src/InlineEdit/InlineEdit.tsx
+++ b/packages/adapters/src/InlineEdit/InlineEdit.tsx
@@ -49,6 +49,7 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 			value={currentValue}
 		>
 			{({ isEditing, onCancel, onRequestEdit }) => {
+				// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 				const onCancelEdit = () => {
 					onCancel();
 					// reset current value to what it was earlier
@@ -64,12 +65,7 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 							value={currentValue}
 						/>
 
-						<InlineEditInput
-							inputType={inputType}
-							setValue={setCurrentValue}
-							// eslint-disable-next-line react/jsx-no-bind
-							onCancel={onCancelEdit}
-						/>
+						<InlineEditInput inputType={inputType} setValue={setCurrentValue} onCancel={onCancelEdit} />
 					</>
 				);
 			}}

--- a/packages/adapters/src/Pagination/Pagination.tsx
+++ b/packages/adapters/src/Pagination/Pagination.tsx
@@ -11,6 +11,8 @@ import defaultItemRender from './ItemRender';
 import type { PaginationProps } from './types';
 import PerPage from './PerPage';
 
+const DEFAULT_PER_PAGE_OPTIONS = ['2', '6', '12', '24', '48'];
+
 const Pagination: React.FC<PaginationProps> = ({
 	defaultPageNumber = 1,
 	defaultPerPage,
@@ -20,7 +22,7 @@ const Pagination: React.FC<PaginationProps> = ({
 	onChangePerPage,
 	pageNumber,
 	perPage,
-	perPageOptions = ['2', '6', '12', '24', '48'],
+	perPageOptions = DEFAULT_PER_PAGE_OPTIONS,
 	showPerPageChanger,
 	total,
 	...props

--- a/packages/components/src/EspressoTable/ResponsiveTable.tsx
+++ b/packages/components/src/EspressoTable/ResponsiveTable.tsx
@@ -16,12 +16,14 @@ import './style/laptop-style.scss';
 import './style/tablet-style.scss';
 import './style/phone-style.scss';
 
+const EMPTY_ARRAY = [];
+
 const ResponsiveTable: React.FC<ResponsiveTableProps> = ({
-	bodyRows = [],
-	className = {},
-	footerRows = [],
-	headerRows = [],
-	metaData = {},
+	bodyRows = EMPTY_ARRAY,
+	className,
+	footerRows = EMPTY_ARRAY,
+	headerRows = EMPTY_ARRAY,
+	metaData,
 	onBeforeDragStart,
 	onDragEnd,
 	onDragStart,
@@ -30,11 +32,11 @@ const ResponsiveTable: React.FC<ResponsiveTableProps> = ({
 }) => {
 	const primaryHeader = headerRows.find((row) => row.primary === true);
 	const instanceId = props.instanceId || uuidv4();
-	const isScrollable = !!metaData.isScrollable;
-	const hasRowHeaders = !!metaData.hasRowHeaders;
+	const isScrollable = !!metaData?.isScrollable;
+	const hasRowHeaders = !!metaData?.hasRowHeaders;
 
 	const tableClassName = classNames(
-		className.tableClassName,
+		className?.tableClassName,
 		`ee-rspnsv-table-column-count-${primaryHeader.cells.length}`,
 		hasRowHeaders && 'ee-rspnsv-table-has-row-headers'
 	);
@@ -46,16 +48,16 @@ const ResponsiveTable: React.FC<ResponsiveTableProps> = ({
 	);
 
 	const cssClasses = useMemoStringify({
-		headerClassName: className.headerClassName || '',
-		headerRowClassName: className.headerRowClassName || '',
-		headerThClassName: className.headerThClassName || '',
-		bodyClassName: className.bodyClassName || '',
-		bodyRowClassName: className.bodyRowClassName || '',
-		bodyThClassName: className.bodyThClassName || '',
-		bodyTdClassName: className.bodyTdClassName || '',
-		footerClassName: className.footerClassName || '',
-		footerRowClassName: className.footerRowClassName || '',
-		footerThClassName: className.footerThClassName || '',
+		headerClassName: className?.headerClassName || '',
+		headerRowClassName: className?.headerRowClassName || '',
+		headerThClassName: className?.headerThClassName || '',
+		bodyClassName: className?.bodyClassName || '',
+		bodyRowClassName: className?.bodyRowClassName || '',
+		bodyThClassName: className?.bodyThClassName || '',
+		bodyTdClassName: className?.bodyTdClassName || '',
+		footerClassName: className?.footerClassName || '',
+		footerRowClassName: className?.footerRowClassName || '',
+		footerThClassName: className?.footerThClassName || '',
 		tableClassName,
 	});
 

--- a/packages/components/src/EspressoTable/Table.tsx
+++ b/packages/components/src/EspressoTable/Table.tsx
@@ -1,22 +1,27 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 
-import { Box } from '@eventespresso/adapters';
+import { Box, BoxProps } from '@eventespresso/adapters';
 import type { TableProps } from './types';
+
+const overflowX: BoxProps['overflowX'] = { sm: 'auto', md: 'visible' };
 
 const Table: React.FC<TableProps> = ({ captionID = '', captionText = '', children, tableId = '', ...props }) => {
 	const className = classNames(props.className, 'ee-rspnsv-table');
-	const tableProps: React.HTMLAttributes<HTMLElement> = {
-		...props,
-		className,
-		id: tableId,
-	};
+	const tableProps = useMemo<React.HTMLAttributes<HTMLElement>>(
+		() => ({
+			...props,
+			className,
+			id: tableId,
+		}),
+		[className, props, tableId]
+	);
 
 	return (
 		<Box
 			aria-labelledby={captionID}
 			className='ee-rspnsv-table__inner-wrapper'
-			overflowX={{ sm: 'auto', md: 'visible' }}
+			overflowX={overflowX}
 			role='region'
 			tabIndex={0}
 		>

--- a/packages/components/src/EspressoTable/TableBody.tsx
+++ b/packages/components/src/EspressoTable/TableBody.tsx
@@ -102,6 +102,7 @@ const TableBody: React.FC<TableBodyProps> = ({
 		>
 			<Droppable droppableId={`${tableId}-droppable`}>
 				{({ innerRef, droppableProps, placeholder }, { isDraggingOver }) => {
+					// eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
 					const style = {
 						border: isDraggingOver ? '1px solid lightgreen' : 'none',
 						borderSpacing: isDraggingOver ? '2px' : '0',

--- a/packages/components/src/EspressoTable/TableRow.tsx
+++ b/packages/components/src/EspressoTable/TableRow.tsx
@@ -41,6 +41,7 @@ const TableRow: React.FC<BodyRow> = ({
 						ref={innerRef}
 						id={id}
 						className={css}
+						// eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
 						style={{
 							...draggableProps.style,
 							border: isDragging ? '1px solid var(--ee-color-bright-blue)' : 'none',

--- a/packages/components/src/ItemCount/index.tsx
+++ b/packages/components/src/ItemCount/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 
 import { Badge, BadgeProps, Tooltip } from '@eventespresso/adapters';
@@ -27,7 +27,7 @@ export const ItemCount: React.FC<ItemCountProps> = ({
 		'ee-item-count--has-items': count > 0,
 		'ee-item-count--no-items': count === 0 && emphasizeZero,
 	});
-	const offset = props.offset || [-8, -4];
+	const offset = useMemo(() => props.offset || [-8, -4], [props.offset]);
 	const value = count === 0 && typeof zeroCountChar !== 'undefined' ? zeroCountChar : count;
 	const countNode = (
 		<Tooltip placement='top' tooltip={title}>
@@ -35,9 +35,11 @@ export const ItemCount: React.FC<ItemCountProps> = ({
 		</Tooltip>
 	);
 
+	const style = useMemo(() => ({ right: `${offset[0]}px`, top: `${offset[1]}px` }), [offset]);
+
 	return (
 		<div className='ee-item-count__wrapper'>
-			<Badge {...props} className={className} style={{ right: `${offset[0]}px`, top: `${offset[1]}px` }}>
+			<Badge {...props} className={className} style={style}>
 				{countNode}
 			</Badge>
 			{children}

--- a/packages/components/src/Legend/Legend.tsx
+++ b/packages/components/src/Legend/Legend.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { is } from 'ramda';
 
 import { Icon } from '@eventespresso/icons';
@@ -24,19 +24,23 @@ const Legend: React.FC<LegendProps> = ({ direction, legendConfig }) => {
 		};
 	});
 
-	const swatchesSource = swatches
-		? Object.entries(swatches).map(([swatchClassName, description]) => {
-				const colorSwatchClassName = 'ee-status-background-color-' + swatchClassName;
+	const swatchesSource = useMemo(
+		() =>
+			swatches
+				? Object.entries(swatches).map(([swatchClassName, description]) => {
+						const colorSwatchClassName = 'ee-status-background-color-' + swatchClassName;
 
-				return {
-					className: 'ee-legend-item',
-					description,
-					term: <ColorSwatch className={colorSwatchClassName} label={description} />,
-				};
-		  })
-		: [];
+						return {
+							className: 'ee-legend-item',
+							description,
+							term: <ColorSwatch className={colorSwatchClassName} label={description} />,
+						};
+				  })
+				: [],
+		[swatches]
+	);
 
-	const dataSource = [...iconsSource, ...swatchesSource];
+	const dataSource = useMemo(() => [...iconsSource, ...swatchesSource], [iconsSource, swatchesSource]);
 
 	return <DescriptionList direction={direction} dataSource={dataSource} />;
 };

--- a/packages/components/src/Legend/ToggleLegendButton.tsx
+++ b/packages/components/src/Legend/ToggleLegendButton.tsx
@@ -18,6 +18,7 @@ const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({
 		transform: `rotate(${showLegend ? 0 : 180}deg)`,
 	});
 
+	// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 	const icon = () => (
 		<animated.div style={iconProps}>
 			<CompassFilled />
@@ -31,7 +32,6 @@ const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({
 			active={showLegend}
 			buttonSize={ButtonSize.SMALLER}
 			className={className}
-			// eslint-disable-next-line react/jsx-no-bind
 			icon={icon}
 			noHorizontalMargin={noHorizontalMargin}
 			onClick={toggleLegend}

--- a/packages/form/src/renderers/FormRenderer.tsx
+++ b/packages/form/src/renderers/FormRenderer.tsx
@@ -9,11 +9,13 @@ import RenderSections from '../RenderSections';
 import DebugInfo from '../../../components/src/DebugInfo/DebugInfo'; // to avoid circular dependency, also since it's used only in dev
 import { formPropsAreEqual } from '../utils';
 
+const EMPTY_ARRAY = [];
+
 const FormRenderer: React.FC<FormRendererProps> = (props) => {
 	const {
 		submitting,
-		sections = [],
-		fields = [],
+		sections = EMPTY_ARRAY,
+		fields = EMPTY_ARRAY,
 		submitButton,
 		resetButton,
 		formWrapper: FormWrapper,

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -15,6 +15,11 @@
 	},
 	"main": "src/index.ts",
 	"main:src": "src/index.ts",
+	"scripts": {
+		"test": "react-scripts test",
+		"lint": "eslint ./src/**/*.{ts,tsx} --format=codeframe",
+		"lint-fix": "eslint ./src/**/*.{ts,tsx} --fix"
+	},
 	"sideEffects": false,
 	"dependencies": {
 		"draft-convert": "^2.1.10",

--- a/packages/rich-text-editor/src/components/index.tsx
+++ b/packages/rich-text-editor/src/components/index.tsx
@@ -14,7 +14,17 @@ import './style.scss';
 
 const { hasCommandModifier } = KeyBindingUtil;
 
-type SyntheticKeyboardEvent = React.KeyboardEvent<{ any }>;
+type SyntheticKeyboardEvent = React.KeyboardEvent<any>;
+
+// Custom overrides for "code" style.
+const styleMap = {
+	CODE: {
+		backgroundColor: 'rgba(0, 0, 0, 0.05)',
+		fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
+		fontSize: 16,
+		padding: 2,
+	},
+};
 
 export class RichTextEditor extends React.Component<RichTextEditorProps, RichTextEditorState> {
 	focus: () => void;
@@ -106,16 +116,6 @@ export class RichTextEditor extends React.Component<RichTextEditorProps, RichTex
 				className += ' rich-text-editor--hidePlaceholder';
 			}
 		}
-
-		// Custom overrides for "code" style.
-		const styleMap = {
-			CODE: {
-				backgroundColor: 'rgba(0, 0, 0, 0.05)',
-				fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
-				fontSize: 16,
-				padding: 2,
-			},
-		};
 
 		return (
 			<div className='rich-text-editor-root'>

--- a/packages/tpc/src/buttons/taxes/RemoveTaxesButton.tsx
+++ b/packages/tpc/src/buttons/taxes/RemoveTaxesButton.tsx
@@ -4,11 +4,10 @@ import { __ } from '@eventespresso/i18n';
 import { ConfirmDelete } from '@eventespresso/components';
 import { useRemoveAllTaxes } from '../../hooks';
 
+const buttonProps = {
+	buttonText: __('Remove taxes'),
+};
 const RemoveTaxesButton: React.FC = () => {
-	const buttonProps = {
-		buttonText: __('Remove taxes'),
-	};
-
 	const message = __("Are you sure you want to remove all of this ticket's taxes?");
 
 	const removeAllTaxes = useRemoveAllTaxes();

--- a/packages/tpc/src/components/table/useFooterRowGenerator.tsx
+++ b/packages/tpc/src/components/table/useFooterRowGenerator.tsx
@@ -49,10 +49,10 @@ const useFooterRowGenerator = (): FooterRowGenerator => {
 					<TicketPriceField
 						component='input'
 						disabled={!reverseCalculate}
-						// eslint-disable-next-line react/jsx-no-bind
+						// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 						format={(price) => formatAmount(price) ?? ''}
 						formatOnBlur
-						// eslint-disable-next-line react/jsx-no-bind
+						// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 						parse={(price) => parsedAmount(price)}
 						type='number'
 					/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9880,6 +9880,11 @@ eslint-plugin-react-hooks@^4.0.4:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz#2eb53731d11c95826ef7a7272303eabb5c9a271e"
   integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
 
+eslint-plugin-react-perf@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.2.4.tgz#dc41ab92dfff9515cc71d847ccf29309de7a720d"
+  integrity sha512-C7IAms700T0OOGPlsczgTKL2Siw2HjuZkJYYJzCsZ6wHb9/SO78/NeFRo6tUTvB68dL1h0rH6XpirtjpL3GYqg==
+
 eslint-plugin-react@7.18.0:
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz#2317831284d005b30aff8afb7c4e906f13fa8e7e"


### PR DESCRIPTION
While reading more about eslint `react/jsx-no-bind` rule, I discovered a better alternative ([`eslint-plugin-react-perf`](https://github.com/cvazac/eslint-plugin-react-perf)) which also covers checking of object literals in JSX props. It will be a huge performance boost for our code, because object literals in props is the main reason for re-renders.
So this PR adds the package and its recommended rules to ESLint config.