### PR TITLE
Unit tests for edtr-services hooks

### DIFF
--- a/packages/edtr-services/src/apollo/queries/datetimes/test/useRelatedDatetimes.test.ts
+++ b/packages/edtr-services/src/apollo/queries/datetimes/test/useRelatedDatetimes.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useRelatedDatetimes from '../useRelatedDatetimes';
+import { ApolloMockedProvider } from '../../../../context/test';
+import { nodes as datetimes } from './data';
+import useInitDatetimeTestCache from './useInitDatetimeTestCache';
+import { nodes as tickets } from '../../tickets/test/data';
+import { actWait } from '@eventespresso/utils/src/test';
+
+describe('useRelatedDatetimes', () => {
+	const wrapper = ApolloMockedProvider();
+	it('returns empty array for unrelated entity types', async () => {
+		const { result } = renderHook(() => useRelatedDatetimes({ entity: 'priceTypes', entityId: '' }), { wrapper });
+
+		await actWait();
+
+		expect(result.current).toEqual([]);
+	});
+
+	it('returns empty array for null or undefined entity types', async () => {
+		for (const value of [null, undefined]) {
+			const { result } = renderHook(() => useRelatedDatetimes({ entity: value, entityId: value }), {
+				wrapper,
+			});
+
+			await actWait();
+
+			expect(result.current).toEqual([]);
+		}
+	});
+
+	it('returns related datetimes for a given ticket', async () => {
+		const { result } = renderHook(
+			() => {
+				useInitDatetimeTestCache();
+				return useRelatedDatetimes({ entity: 'tickets', entityId: tickets[0].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(result.current).toEqual([datetimes[0]]);
+
+		const { result: anotherResult } = renderHook(
+			() => {
+				useInitDatetimeTestCache();
+				return useRelatedDatetimes({ entity: 'tickets', entityId: tickets[1].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(anotherResult.current).toEqual([datetimes[0], datetimes[1]]);
+	});
+});

--- a/packages/edtr-services/src/apollo/queries/prices/test/useRelatedPrices.test.ts
+++ b/packages/edtr-services/src/apollo/queries/prices/test/useRelatedPrices.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useRelatedPrices from '../useRelatedPrices';
+import { ApolloMockedProvider } from '../../../../context/test';
+import { nodes as prices } from './data';
+import useInitPriceTestCache from './useInitPriceTestCache';
+import { nodes as tickets } from '../../tickets/test/data';
+import { actWait } from '@eventespresso/utils/src/test';
+
+describe('useRelatedPrices', () => {
+	const wrapper = ApolloMockedProvider();
+	it('returns empty array for unrelated entity types', async () => {
+		const { result } = renderHook(() => useRelatedPrices({ entity: 'priceTypes', entityId: '' }), { wrapper });
+
+		await actWait();
+
+		expect(result.current).toEqual([]);
+	});
+
+	it('returns empty array for null or undefined entity types', async () => {
+		for (const value of [null, undefined]) {
+			const { result } = renderHook(() => useRelatedPrices({ entity: value, entityId: value }), {
+				wrapper,
+			});
+
+			await actWait();
+
+			expect(result.current).toEqual([]);
+		}
+	});
+
+	it('returns related prices for a given ticket', async () => {
+		const { result } = renderHook(
+			() => {
+				useInitPriceTestCache();
+				return useRelatedPrices({ entity: 'tickets', entityId: tickets[0].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(result.current).toEqual([prices[0], prices[2]]);
+
+		const { result: anotherResult } = renderHook(
+			() => {
+				useInitPriceTestCache();
+				return useRelatedPrices({ entity: 'tickets', entityId: tickets[1].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(anotherResult.current).toEqual([prices[1]]);
+	});
+});

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useRelatedTickets.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useRelatedTickets.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useRelatedTickets from '../useRelatedTickets';
+import { ApolloMockedProvider } from '../../../../context/test';
+import { nodes as tickets } from './data';
+import useInitTicketTestCache from './useInitTicketTestCache';
+import { nodes as datetimes } from '../../datetimes/test/data';
+import { nodes as prices } from '../../prices/test/data';
+import { actWait } from '@eventespresso/utils/src/test';
+
+describe('useRelatedTickets', () => {
+	const wrapper = ApolloMockedProvider();
+	it('returns empty array for unrelated entity types', async () => {
+		const { result } = renderHook(() => useRelatedTickets({ entity: 'priceTypes', entityId: '' }), { wrapper });
+
+		await actWait();
+
+		expect(result.current).toEqual([]);
+	});
+
+	it('returns empty array for null or undefined entity types', async () => {
+		for (const value of [null, undefined]) {
+			const { result } = renderHook(() => useRelatedTickets({ entity: value, entityId: value }), {
+				wrapper,
+			});
+
+			await actWait();
+
+			expect(result.current).toEqual([]);
+		}
+	});
+
+	it('returns related tickets for a given datetime', async () => {
+		const { result } = renderHook(
+			() => {
+				useInitTicketTestCache();
+				return useRelatedTickets({ entity: 'datetimes', entityId: datetimes[0].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(result.current).toEqual([tickets[0], tickets[1]]);
+
+		const { result: anotherResult } = renderHook(
+			() => {
+				useInitTicketTestCache();
+				return useRelatedTickets({ entity: 'datetimes', entityId: datetimes[1].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(anotherResult.current).toEqual([tickets[1]]);
+	});
+
+	it('returns related tickets for a given price', async () => {
+		const { result } = renderHook(
+			() => {
+				useInitTicketTestCache();
+				return useRelatedTickets({ entity: 'prices', entityId: prices[0].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(result.current).toEqual([tickets[0]]);
+
+		const { result: anotherResult } = renderHook(
+			() => {
+				useInitTicketTestCache();
+				return useRelatedTickets({ entity: 'prices', entityId: prices[1].id });
+			},
+			{ wrapper }
+		);
+		await actWait();
+
+		expect(anotherResult.current).toEqual([tickets[1]]);
+	});
+});

--- a/packages/edtr-services/src/hooks/edtrState/test/useEdtrStateManager.test.ts
+++ b/packages/edtr-services/src/hooks/edtrState/test/useEdtrStateManager.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useEdtrStateManager from '../useEdtrStateManager';
+
+const EMPTY_VALUES = [null, undefined];
+
+describe('useEdtrStateManager', () => {
+	it('checks types for state values', () => {
+		const { result } = renderHook(() => useEdtrStateManager());
+
+		expect(typeof result.current.visibleDatetimeIds).toBe('object');
+		expect(typeof result.current.visibleTicketIds).toBe('object');
+		expect(typeof result.current.pricesPollInterval).toBe('number');
+	});
+
+	it('checks for the default state', () => {
+		const { result } = renderHook(() => useEdtrStateManager());
+
+		expect(result.current.visibleDatetimeIds).toEqual([]);
+		expect(result.current.visibleTicketIds).toEqual([]);
+		expect(result.current.pricesPollInterval).toBe(0);
+	});
+
+	test('checks for updated state', () => {
+		const { result } = renderHook(() => useEdtrStateManager());
+
+		// before the update
+		expect(result.current.visibleDatetimeIds).toEqual([]);
+		act(() => {
+			result.current.setVisibleDatetimeIds(['xyz', 'abc']);
+		});
+		// after the update
+		expect(result.current.visibleDatetimeIds).toEqual(['xyz', 'abc']);
+
+		// edge cases
+		[...EMPTY_VALUES, []].forEach((value) => {
+			act(() => {
+				result.current.setVisibleDatetimeIds(value);
+			});
+			expect(result.current.visibleDatetimeIds).toEqual(value);
+		});
+
+		// before the update
+		expect(result.current.visibleTicketIds).toEqual([]);
+		act(() => {
+			result.current.setVisibleTicketIds(['xyz', 'abc']);
+		});
+		// after the update
+		expect(result.current.visibleTicketIds).toEqual(['xyz', 'abc']);
+
+		// edge cases
+		[...EMPTY_VALUES, []].forEach((value) => {
+			act(() => {
+				result.current.setVisibleTicketIds(value);
+			});
+			expect(result.current.visibleTicketIds).toEqual(value);
+		});
+
+		// before the update
+		expect(result.current.pricesPollInterval).toBe(0);
+		act(() => {
+			result.current.setPricesPollInterval(3);
+		});
+		// after the update
+		expect(result.current.pricesPollInterval).toBe(3);
+
+		// edge cases
+		[...EMPTY_VALUES, 0, 100].forEach((value) => {
+			act(() => {
+				result.current.setPricesPollInterval(value);
+			});
+			expect(result.current.pricesPollInterval).toBe(value);
+		});
+	});
+});


### PR DESCRIPTION
This PR adds unit tests for
- `packages/edtr-services/src/apollo/queries/datetimes/useRelatedDatetimes.ts`
- `packages/edtr-services/src/apollo/queries/prices/useRelatedPrices.ts`
- `packages/edtr-services/src/apollo/queries/tickets/useRelatedTickets.ts`
- `packages/edtr-services/src/hooks/edtrState/useEdtrStateManager.ts`

See #96 