### PR TITLE
Fix start time in REM generated dates

### DIFF
--- a/domains/rem/src/ui/generatedDates/GeneratedDatetime.tsx
+++ b/domains/rem/src/ui/generatedDates/GeneratedDatetime.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import { CloseCircleFilled, PlusCircleFilled, Repeat, Trash } from '@eventespresso/icons';
 import { IconButton } from '@eventespresso/components';
-import { useTimeZoneTime } from '@eventespresso/services';
 import { DateType, GeneratedDatetimeProps } from './types';
 import { getBgClassName, formatDate, iconClassMap, tooltipMap } from './utils';
 
@@ -20,12 +19,10 @@ export const iconMap: { [key in DateType]: React.ReactNode } = {
 };
 
 const GeneratedDatetime: React.FC<GeneratedDatetimeProps> = ({ date, ISOStr, type, toggleExDate }) => {
-	const { formatForSite } = useTimeZoneTime();
-
 	const bgClassName = getBgClassName(type);
 	const className = classNames('ee-generated-datetime__body', bgClassName);
 
-	const gDateLabel = formatDate(date, formatForSite);
+	const gDateLabel = formatDate(date);
 
 	const onClickTrash = useCallback(() => toggleExDate(ISOStr), [toggleExDate, ISOStr]);
 

--- a/domains/rem/src/ui/generatedDates/Warning.tsx
+++ b/domains/rem/src/ui/generatedDates/Warning.tsx
@@ -27,7 +27,7 @@ const Warning: React.FC<WarningProps> = ({ datetimes }) => {
 			warning = __('The number of Event Dates has been capped at 5 for YEARLY recurrence patterns');
 			break;
 		case freq === 'MONTHLY':
-			warning = __('The number of Event Dates has been capped at 36 for MONTHLY recurrence patterns (2 years)');
+			warning = __('The number of Event Dates has been capped at 36 for MONTHLY recurrence patterns (3 years)');
 			break;
 		case freq === 'WEEKLY':
 			warning = __('The number of Event Dates has been capped at 52 for WEEKLY recurrence patterns (1 year)');

--- a/domains/rem/src/ui/generatedDates/utils.ts
+++ b/domains/rem/src/ui/generatedDates/utils.ts
@@ -1,10 +1,15 @@
 import { __, sprintf } from '@eventespresso/i18n';
+import { format } from 'date-fns';
 
 import { LOCALIZED_DATE_FULL_FORMAT, TIME_ONLY_12H_SHORT_FORMAT } from '@eventespresso/constants';
-import type { TimeZoneTime } from '@eventespresso/services';
 import type { DateType } from './types';
 
-export const formatDate = (date: Date, format: TimeZoneTime['formatForSite']): string => {
+/**
+ * Formats the date in date and time format.
+ * It is assumed that the date that comes from rrle-generator is in site timezone,
+ * so no conversion to site timezone is needed.
+ */
+export const formatDate = (date: Date): string => {
 	return `${format(date, LOCALIZED_DATE_FULL_FORMAT)} ${format(date, TIME_ONLY_12H_SHORT_FORMAT)}`;
 };
 

--- a/packages/dates/src/DatePicker.tsx
+++ b/packages/dates/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import ReactDatePicker from 'react-datepicker';
 import * as locales from 'date-fns/locale';
 
@@ -10,7 +10,7 @@ import './styles.scss';
 export const DatePicker: React.FC<DatePickerProps> = ({ inputValue, locale, onChange, value, ...props }) => {
 	// get locale object from date-fns
 	// we need to change "en_US" to "enUS"
-	const datefnsLocale = locales?.[locale?.replace(/-_/, '')] ?? locales.enUS;
+	const datefnsLocale = useMemo(() => locales?.[locale?.replace(/-_/, '')] ?? locales.enUS, [locale]);
 
 	return (
 		<ReactDatePicker onChange={onChange} selected={value} value={inputValue} locale={datefnsLocale} {...props} />

--- a/packages/dates/src/DateRangePicker.tsx
+++ b/packages/dates/src/DateRangePicker.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import classNames from 'classnames';
 import { __ } from '@eventespresso/i18n';
-import { isOnOrAfterToday, isOnOrAfterDate, isOnOrBeforeDate } from './utils';
 
-import { DateRangePickerProps } from './types';
+import type { DateRangePickerProps } from './types';
 import { DatePicker } from './DatePicker';
 import { DateTimePicker } from './DateTimePicker';
 import { DateRangePickerLegend } from './DateRangePickerLegend';
+import { isOnOrAfterToday, isOnOrAfterDate, isOnOrBeforeDate } from './utils';
 
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 	className,

--- a/packages/dates/src/DateTimePicker.tsx
+++ b/packages/dates/src/DateTimePicker.tsx
@@ -3,7 +3,8 @@ import { __ } from '@eventespresso/i18n';
 
 import { DatePickerProps } from './types';
 import { DatePicker } from './DatePicker';
+import { DEFAULT_DATETIME_FORMAT } from './constants';
 
 export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
-	return <DatePicker showTimeSelect timeCaption={__('time')} {...props} />;
+	return <DatePicker showTimeSelect timeCaption={__('time')} dateFormat={DEFAULT_DATETIME_FORMAT} {...props} />;
 };

--- a/packages/dates/src/constants.ts
+++ b/packages/dates/src/constants.ts
@@ -1,1 +1,3 @@
 export const NOW = new Date();
+
+export const DEFAULT_DATETIME_FORMAT = 'MMM d, yyyy h:mm aa'; // Aug 19, 2020 3:11 PM


### PR DESCRIPTION
This PR:
- Adds default datetime format to `DateTimePicker` in `dates` package
- Removes the date conversion to site timezone on generated dates step in REM
- Thus fixes the wrong start time shown in REM dates

Closes #305 

![demo](https://user-images.githubusercontent.com/18226415/94528919-af836900-0256-11eb-9601-27146cd1b4ab.gif)
