### PR TITLE
Start time picker for REM date details

### DIFF
--- a/domains/rem/src/ui/datetimeDetails/types.ts
+++ b/domains/rem/src/ui/datetimeDetails/types.ts
@@ -6,6 +6,7 @@ export interface DatetimeDetailsProps {
 }
 
 export interface DateFormShape extends UpdateDatetimeInput {
+	startTime?: Date;
 	duration?: number;
 	unit?: IntervalType;
 }

--- a/domains/rem/src/ui/datetimeDetails/useDateFormConfig.ts
+++ b/domains/rem/src/ui/datetimeDetails/useDateFormConfig.ts
@@ -1,8 +1,8 @@
 import { pick } from 'ramda';
 import { __ } from '@eventespresso/i18n';
 
-import { intervalsToOptions, DATE_INTERVALS } from '@eventespresso/dates';
-import { ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
+import { intervalsToOptions, DATE_INTERVALS, NOW, setTimeToNoon } from '@eventespresso/dates';
+import { Calendar, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import type { EspressoFormProps } from '@eventespresso/form';
 import { Datetime } from '@eventespresso/edtr-services';
 import { validate } from './formValidation';
@@ -16,6 +16,7 @@ type DateFormConfig = EspressoFormProps<DateFormShape>;
 const onSubmit = () => null;
 
 const DATE_DEFAULTS: DateFormShape = {
+	startTime: setTimeToNoon(NOW),
 	unit: 'days',
 	duration: 1,
 };
@@ -58,6 +59,18 @@ const useDateFormConfig = (datetime: Datetime, config?: Partial<EspressoFormProp
 							name: 'description',
 							label: __('Description'),
 							fieldType: 'rich-text-editor',
+						},
+					],
+				},
+				{
+					name: 'time',
+					icon: Calendar,
+					title: __('Time'),
+					fields: [
+						{
+							name: 'startTime',
+							label: __('Start Time'),
+							fieldType: 'timepicker',
 						},
 					],
 				},

--- a/domains/rem/src/ui/generatedDates/GeneratedDatetimes.tsx
+++ b/domains/rem/src/ui/generatedDates/GeneratedDatetimes.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+
+import { setTimeFromDate } from '@eventespresso/dates';
 
 import GeneratedDatetime from './GeneratedDatetime';
-
 import { GeneratedDatetimesProps } from './types';
 import { useFormState } from '../../data';
 
 const GeneratedDatetimes: React.FC<GeneratedDatetimesProps> = ({ datetimes }) => {
-	const { addExDate, removeRDate, removeExDate } = useFormState();
+	const { addExDate, removeRDate, removeExDate, dateDetails } = useFormState();
+
+	const setStartTime = useMemo(() => setTimeFromDate(dateDetails?.startTime), [dateDetails?.startTime]);
 
 	return (
 		<ul className={'ee-generated-datetime__list'}>
@@ -19,7 +22,7 @@ const GeneratedDatetimes: React.FC<GeneratedDatetimesProps> = ({ datetimes }) =>
 
 				return (
 					<GeneratedDatetime
-						date={date}
+						date={setStartTime(date)}
 						key={ISOStr}
 						ISOStr={ISOStr}
 						number={index + 1}

--- a/packages/dates/src/styles.scss
+++ b/packages/dates/src/styles.scss
@@ -93,7 +93,7 @@
     box-sizing: border-box;
 	color: var(--ee-default-text-color);
     font-size: var(--ee-font-size-small);
-    width: calc(var(--ee-icon-button-size) * 9 + 2px);
+    // width: calc(var(--ee-icon-button-size) * 9 + 2px);
 
 	&__navigation {
 		height: var(--ee-font-size-default);

--- a/packages/dates/src/utils/misc.ts
+++ b/packages/dates/src/utils/misc.ts
@@ -1,6 +1,6 @@
 import { pipe } from 'ramda';
 import { __ } from '@eventespresso/i18n';
-import { parseISO, toDate } from 'date-fns';
+import { getHours, getMinutes, getSeconds, parseISO, toDate } from 'date-fns';
 import { setHours, setMinutes, setSeconds, setYear, setMonth, setDate } from 'date-fns/fp';
 
 import type { OptionsType } from '@eventespresso/adapters';
@@ -56,6 +56,16 @@ export const setTimeToZeroHour = (date: Date): Date => pipe(setHours(0), setMinu
  * Sets the time of the date object to noon
  */
 export const setTimeToNoon = (date: Date): Date => pipe(setHours(12), setMinutes(0), setSeconds(0))(date);
+
+/**
+ * Sets the time of the date object to from the given time object
+ */
+export const setTimeFromDate = (time: Date) => (date: Date): Date => {
+	const hours = getHours(time);
+	const minutes = getMinutes(time);
+	const seconds = getSeconds(time);
+	return pipe(setHours(hours), setMinutes(minutes), setSeconds(seconds))(date);
+};
 
 /**
  * Sets the date, month and year of the date object to those of today


### PR DESCRIPTION
This PR adds a start time picker in date details steps and uses that time on Generated dates step and for form submission.

Closes #327 