### PR TITLE
Fix new single date/ticket modal details

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Container.tsx
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/Container.tsx
@@ -9,7 +9,9 @@ import Content from './Content';
 import { EntityEditModalData } from '@edtrUI/types';
 
 const Container: React.FC = () => {
-	const { getData, isOpen, close: closeModal } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_DATE);
+	const { getData, isOpen, close: closeModal, setData } = useGlobalModal<EntityEditModalData>(
+		EdtrGlobalModals.EDIT_DATE
+	);
 	const { close: closePopover } = useGlobalModal(EdtrGlobalModals.NEW_DATE_POPOVER);
 	const datetime = useDatetimeItem({ id: getData()?.entityId });
 	const event = useEvent();
@@ -22,7 +24,9 @@ const Container: React.FC = () => {
 	const onClose = useCallback(() => {
 		closeModal();
 		closePopover();
-	}, [closeModal, closePopover]);
+		// reset the global modal data
+		setData({ entityId: null });
+	}, [closeModal, closePopover, setData]);
 
 	return <EditModalContainer component={Content} entity={datetime} title={title} isOpen={isOpen} onClose={onClose} />;
 };

--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __, sprintf } from '@eventespresso/i18n';
 
 import { useEvent, useTicketItem, EdtrGlobalModals } from '@eventespresso/edtr-services';
@@ -9,7 +9,9 @@ import Content from './Content';
 import { EntityEditModalData } from '@edtrUI/types';
 
 const Container: React.FC = () => {
-	const { getData, isOpen, close: onClose } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_TICKET);
+	const { getData, isOpen, close: closeModal, setData } = useGlobalModal<EntityEditModalData>(
+		EdtrGlobalModals.EDIT_TICKET
+	);
 	const ticket = useTicketItem({ id: getData()?.entityId });
 	const event = useEvent();
 
@@ -17,6 +19,12 @@ const Container: React.FC = () => {
 
 	// add event name to the title
 	title = event?.name ? `${event.name}: ${title}` : title;
+
+	const onClose = useCallback(() => {
+		closeModal();
+		// reset the global modal data
+		setData({ entityId: null });
+	}, [closeModal, setData]);
 
 	return <EditModalContainer component={Content} entity={ticket} title={title} isOpen={isOpen} onClose={onClose} />;
 };


### PR DESCRIPTION
This PR fixes the issue of old details being populated when adding a new date or ticket. 

Closes #340 