### PR TITLE
Update REM DOM data path

### DIFF
--- a/domains/rem/src/services/apollo/initialization/useCacheRehydrationData.ts
+++ b/domains/rem/src/services/apollo/initialization/useCacheRehydrationData.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import type { RemDomData } from '../../../types';
 
 const useCacheRehydrationData = (): RemDomData => {
-	return useMemo(() => window?.eventEspressoData?.rem || {}, []);
+	return useMemo(() => window?.eventEspressoData?.remEditorData || {}, []);
 };
 
 export default useCacheRehydrationData;

--- a/types/global.ts
+++ b/types/global.ts
@@ -8,7 +8,7 @@ import type { EventEspressoDomData } from '@eventespresso/services';
  */
 export interface EventEspressoData extends EventEspressoDomData {
 	eventEditor?: EventEditorData;
-	rem?: RemDomData;
+	remEditorData?: RemDomData;
 	wpPluginsPage?: WpPluginsPageData;
 }
 


### PR DESCRIPTION
This PR updates the REM DOM data path as set in [rem/pull/34](https://github.com/eventespresso/eea-recurring-events-manager/pull/34)