### PR TITLE
Card details registry

### DIFF
--- a/domains/eventEditor/src/hooks/entityCardDetails/index.ts
+++ b/domains/eventEditor/src/hooks/entityCardDetails/index.ts
@@ -1,0 +1,1 @@
+export { default as useEntityCardDetailsItems } from './useEntityCardDetailsItems';

--- a/domains/eventEditor/src/hooks/entityCardDetails/useEntityCardDetailsItems.ts
+++ b/domains/eventEditor/src/hooks/entityCardDetails/useEntityCardDetailsItems.ts
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+
+import { Entity } from '@eventespresso/data';
+import { EntityActionsSubscription, EntityCardDetailsRegistry } from '@eventespresso/registry';
+import { domain } from '@eventespresso/edtr-services';
+import { useMemoStringify } from '@eventespresso/hooks';
+
+const { getSubscriptions } = new EntityActionsSubscription(domain);
+
+const useEntityCardDetailsItems = <E extends Entity, T extends string>(
+	entityType: T,
+	entity: E,
+	filterByEntityType = true
+): Array<React.ReactNode> => {
+	const registry = useMemo(() => new EntityCardDetailsRegistry({ domain, entityType, entityId: entity.id }), [
+		entity.id,
+		entityType,
+	]);
+
+	const { generateElements } = registry;
+
+	const subscriptions = getSubscriptions({ entityType: filterByEntityType ? entityType : null });
+
+	Object.values(subscriptions).forEach(({ callback }) => {
+		callback({ entityType, entity, registry });
+	});
+
+	// it should only change if subscriptions change
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	return useMemoStringify(generateElements(), Object.keys(subscriptions));
+};
+
+export default useEntityCardDetailsItems;

--- a/domains/eventEditor/src/hooks/index.ts
+++ b/domains/eventEditor/src/hooks/index.ts
@@ -2,4 +2,6 @@ export { default as useEditorInitialization } from './useEditorInitialization';
 
 export * from './entityActionsMenu';
 
+export * from './entityCardDetails';
+
 export * from './newEntityOptions';

--- a/domains/eventEditor/src/ui/datetimes/datesList/cardView/Details.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/cardView/Details.tsx
@@ -8,6 +8,7 @@ import { getAdminUrl, useDatetimeMutator, useEventId } from '@eventespresso/edtr
 
 import DateDetailsPanel from './DateDetailsPanel';
 import { EditableName } from '../editable';
+import useDateCardDetailsItems from '../../hooks/useDateCardDetailsItems';
 
 import type { DateItemProps } from '../types';
 
@@ -29,6 +30,8 @@ const Details: React.FC<DateItemProps> = ({ entity: datetime }) => {
 		[updateEntity]
 	);
 
+	const detailsItems = useDateCardDetailsItems(datetime);
+
 	return (
 		<>
 			<EditableName className='entity-card-details__name' entity={datetime} />
@@ -40,6 +43,8 @@ const Details: React.FC<DateItemProps> = ({ entity: datetime }) => {
 				title={__('Edit description')}
 				tooltip={__('edit description…')}
 			/>
+
+			{detailsItems}
 
 			<DateDetailsPanel adminUrl={adminUrl} entity={datetime} eventId={eventId} />
 		</>

--- a/domains/eventEditor/src/ui/datetimes/hooks/useDateCardDetailsItems.ts
+++ b/domains/eventEditor/src/ui/datetimes/hooks/useDateCardDetailsItems.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import type { Datetime } from '@eventespresso/edtr-services';
+import { useEntityCardDetailsItems } from '@edtrHooks/index';
+
+const useDateCardDetailsItems = (datetime: Datetime): Array<React.ReactNode> => {
+	return useEntityCardDetailsItems('datetime', datetime);
+};
+
+export default useDateCardDetailsItems;

--- a/domains/rem/src/ui/RecurrenceTag.tsx
+++ b/domains/rem/src/ui/RecurrenceTag.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import type { Datetime } from '@eventespresso/edtr-services';
+import { useDateRecurrence } from '../services/apollo';
+
+type RecurrenceTagProps = {
+	datetime: Datetime;
+};
+
+const RecurrenceTag: React.FC<RecurrenceTagProps> = ({ datetime }) => {
+	const dateRecurrence = useDateRecurrence(datetime?.id);
+	if (!dateRecurrence) {
+		return null;
+	}
+	// TODO use `getRRuleText()` here
+	return <div>{dateRecurrence?.rRule}</div>;
+};
+
+export default RecurrenceTag;

--- a/domains/rem/src/ui/index.tsx
+++ b/domains/rem/src/ui/index.tsx
@@ -1,18 +1,23 @@
+import React from 'react';
+
 import type { NewEntitySubscriptionCb, ModalSubscriptionCb } from '@eventespresso/registry';
 import {
 	NewEntitySubscription,
 	ModalSubscription,
 	FilterBarUISubscription,
 	FilterBarUISubscriptionCb,
+	EntityActionsSubscription,
+	EntityActionsSubscriptionCb,
 } from '@eventespresso/registry';
 import { domain, datesList } from '@eventespresso/edtr-services';
-import type { DatetimesFilterStateManager } from '@eventespresso/edtr-services';
+import type { DatetimesFilterStateManager, Datetime } from '@eventespresso/edtr-services';
 
 import RemButton from './RemButton';
 import RemInit from './RemInit';
 import Container from './Modal/Container';
 import { RemGlobalModals } from '../types';
 import { RecurrenceControl } from './filterBar';
+import RecurrenceTag from './RecurrenceTag';
 
 // Register new entity option
 const newEntitySubscription = new NewEntitySubscription(domain);
@@ -44,3 +49,18 @@ const datesListFilterBar: DatesListFilterBarCallback = ({ registry }) => {
 };
 
 filterBar.subscribe(datesListFilterBar, { listId: datesList });
+
+// Register datetime card details item.
+const entityActions = new EntityActionsSubscription(domain);
+const datesActionHandler: EntityActionsSubscriptionCb<Datetime, 'datetime'> = ({ entityType, entity, registry }) => {
+	// although this is not needed
+	if (entityType !== 'datetime') {
+		return;
+	}
+
+	const { registerElement: registerMenuItem } = registry;
+
+	registerMenuItem('recurrenceTag', () => <RecurrenceTag datetime={entity} />);
+};
+
+entityActions.subscribe(datesActionHandler, { entityType: 'datetime' });

--- a/packages/registry/src/entityCardDetails/EntityCardDetailsRegistry.ts
+++ b/packages/registry/src/entityCardDetails/EntityCardDetailsRegistry.ts
@@ -1,0 +1,20 @@
+import { UIRegistry, ElementProps } from '../subscription';
+import type { EntityCardDetailsOptions } from './types';
+import { serviceName as service } from './constants';
+
+/**
+ * D: Domain name e.g. "eventEditor"
+ * ET: Entity Type: The current entity type e.g. "datetime", "ticket"
+ * EP: Element Props: The props of the component that's registerd by the consumer
+ */
+class EntityCardDetailsRegistry<
+	D extends string,
+	ET extends string,
+	EP extends ElementProps = ElementProps
+> extends UIRegistry<EP, D, typeof service> {
+	constructor({ domain, entityType }: EntityCardDetailsOptions<D, ET>) {
+		super({ domain, service, path: [entityType] });
+	}
+}
+
+export default EntityCardDetailsRegistry;

--- a/packages/registry/src/entityCardDetails/EntityCardDetailsSubscription.ts
+++ b/packages/registry/src/entityCardDetails/EntityCardDetailsSubscription.ts
@@ -1,0 +1,24 @@
+import { filterSubscriptionsByOption, SubscriptionManager } from '../subscription';
+import type { EntityCardDetailsSubscriptionInterface } from './types';
+import { serviceName as service } from './constants';
+
+type EASI = EntityCardDetailsSubscriptionInterface;
+
+/**
+ * D: Domain name e.g. "eventEditor"
+ */
+class EntityCardDetailsSubscription<D extends string> implements EASI {
+	private subscriptionManager: SubscriptionManager<D, typeof service>;
+
+	constructor(domain: D) {
+		this.subscriptionManager = new SubscriptionManager<D, typeof service>({ domain, service });
+	}
+
+	subscribe: EASI['subscribe'] = (...args) => this.subscriptionManager.subscribe(...args);
+
+	getSubscriptions: EASI['getSubscriptions'] = (args) => {
+		return filterSubscriptionsByOption(this.subscriptionManager.getSubscriptions, 'entityType', args?.entityType);
+	};
+}
+
+export default EntityCardDetailsSubscription;

--- a/packages/registry/src/entityCardDetails/constants.ts
+++ b/packages/registry/src/entityCardDetails/constants.ts
@@ -1,0 +1,1 @@
+export const serviceName = 'entityCardDetails';

--- a/packages/registry/src/entityCardDetails/index.ts
+++ b/packages/registry/src/entityCardDetails/index.ts
@@ -1,0 +1,5 @@
+export { default as EntityCardDetailsSubscription } from './EntityCardDetailsSubscription';
+
+export { default as EntityCardDetailsRegistry } from './EntityCardDetailsRegistry';
+
+export * from './types';

--- a/packages/registry/src/entityCardDetails/types.ts
+++ b/packages/registry/src/entityCardDetails/types.ts
@@ -1,0 +1,52 @@
+import type React from 'react';
+import type { Entity } from '@eventespresso/data';
+import type { BaseSubscriptionOptions, Subscriptions, ElementProps, UIRegistryInterface } from '../subscription';
+
+export interface EntityCardDetailsSubscriptionsOptions<T extends string> {
+	entityType?: T; // to limit the subscription only to specific entityType
+}
+
+export interface EntityCardDetailsSubscriptionCbArgs<E extends Entity, T extends string, EP extends ElementProps>
+	extends EntityCardDetailsSubscriptionsOptions<T> {
+	entity: E;
+	registry: EntityCardDetailsRegistry<EP>;
+}
+
+export interface EntityCardDetailsSubscriptionInterface {
+	subscribe: EntityCardDetailsSubscribeFn;
+	getSubscriptions: <E extends Entity, T extends string, EP extends ElementProps>(
+		options?: EntityCardDetailsSubscriptionsOptions<T>
+	) => Subscriptions<EntityCardDetailsSubscriptionCbArgs<E, T, EP>, EntityCardDetailsSubscriptionsOptions<T>>;
+}
+
+export type EntityCardDetailsSubscribeFn = <E extends Entity, T extends string, EP extends ElementProps>(
+	cb: EntityCardDetailsSubscriptionCb<E, T, EP>,
+	options?: EntityCardDetailsSubscriptionsOptions<T>
+) => VoidFunction;
+
+export type EntityCardDetailsSubscriptionCb<
+	E extends Entity,
+	T extends string,
+	EP extends ElementProps = ElementProps
+> = (args: EntityCardDetailsSubscriptionCbArgs<E, T, EP>) => void;
+
+/* UI related types */
+export interface EntityCardDetailsOptions<D extends string, ET extends string> extends BaseSubscriptionOptions<D> {
+	entityType: ET;
+	entityId: string;
+}
+
+export type EntityCardDetailsRegistryHook = <D extends string, ET extends string, EP extends ElementProps>(
+	options: EntityCardDetailsOptions<D, ET>
+) => EntityCardDetailsRegistry<EP>;
+
+export type EntityCardDetailsRegistry<EP extends ElementProps> = UIRegistryInterface<EP>;
+
+export interface CardDetailsComponentProps<E extends Entity> {
+	entity: E;
+	[key: string]: any;
+}
+
+export type EntityCardDetailsItems = {
+	[key: string]: React.ComponentType;
+};

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1,4 +1,5 @@
 export * from './entityActionsMenu';
+export * from './entityCardDetails';
 export * from './filterBar';
 export * from './modals';
 export * from './newEntityOptions';


### PR DESCRIPTION
This PR adds a registry for card details items to allow REM or any other addons to register their UI elements for cards.

Closes #350 