### PR TITLE
Fix Inline Edit Input CSS Class Asignments

### DIFF
--- a/packages/adapters/src/InlineEdit/InlineEdit.tsx
+++ b/packages/adapters/src/InlineEdit/InlineEdit.tsx
@@ -44,12 +44,12 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 		}
 	}, [currentValue, onChangeValue]);
 
-	const className = classNames('ee-inline-edit', inputClassName && inputClassName);
+	const className = classNames('ee-inline-edit', inputClassName);
 
 	return (
 		<ChakraEditable
 			{...props}
-			className={className}
+			className={previewClassName}
 			onChange={setCurrentValue}
 			onSubmit={onSubmitHandler}
 			placeholder={placeholder}
@@ -67,7 +67,7 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 					<>
 						<InlineEditPreview
 							{...props}
-							className={previewClassName}
+							className={className}
 							isEditing={isEditing}
 							onRequestEdit={onRequestEdit}
 							Preview={Preview}

--- a/packages/adapters/src/InlineEdit/InlineEdit.tsx
+++ b/packages/adapters/src/InlineEdit/InlineEdit.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { Editable as ChakraEditable } from '@chakra-ui/core';
 
 import { usePrevious, useIfMounted } from '@eventespresso/hooks';
@@ -7,11 +8,14 @@ import InlineEditPreview from './InlineEditPreview';
 import type { InlineEditProps } from './types';
 
 const InlineEdit: React.FC<InlineEditProps> = ({
+	inputClassName,
 	defaultValue,
 	inputType,
 	onChangeValue,
 	value,
 	placeholder = '',
+	Preview,
+	previewClassName,
 	...props
 }) => {
 	const [currentValue, setCurrentValue] = useState(defaultValue || value);
@@ -40,9 +44,12 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 		}
 	}, [currentValue, onChangeValue]);
 
+	const className = classNames('ee-inline-edit', inputClassName && inputClassName);
+
 	return (
 		<ChakraEditable
 			{...props}
+			className={className}
 			onChange={setCurrentValue}
 			onSubmit={onSubmitHandler}
 			placeholder={placeholder}
@@ -60,11 +67,12 @@ const InlineEdit: React.FC<InlineEditProps> = ({
 					<>
 						<InlineEditPreview
 							{...props}
+							className={previewClassName}
 							isEditing={isEditing}
 							onRequestEdit={onRequestEdit}
+							Preview={Preview}
 							value={currentValue}
 						/>
-
 						<InlineEditInput inputType={inputType} setValue={setCurrentValue} onCancel={onCancelEdit} />
 					</>
 				);

--- a/packages/adapters/src/InlineEdit/InlineEditInput.tsx
+++ b/packages/adapters/src/InlineEdit/InlineEditInput.tsx
@@ -13,14 +13,14 @@ const insertStrAt = (str: string, subStr: string, pos: number): string => {
 };
 
 const InlineEditInput: React.FC<InlineEditInputProps> = ({ inputType, onCancel, setValue }) => {
-	const className = `ee-input-base ee-input ee-input-inline`;
+	const className = 'ee-input-base ee-input ee-inline-edit--editing';
 
 	if (inputType === 'textarea') {
 		// Since Chakra has no editable textarea yet
 		// we will use this hack
 		const textareaProps: PseudoBoxProps = {
 			as: 'textarea',
-			className: 'ee-input-base ee-textarea',
+			className: 'ee-input-base ee-textarea ee-inline-edit--editing',
 			// pass our own onKeyDown handler for a11y
 			onKeyDown: (e) => {
 				if (e.keyCode === ENTER) {

--- a/packages/adapters/src/InlineEdit/types.ts
+++ b/packages/adapters/src/InlineEdit/types.ts
@@ -6,9 +6,11 @@ import type { CommonInputProps } from '../types';
 export type InputType = 'heading' | 'number' | 'textarea' | 'text';
 
 export interface InlineEditProps extends Partial<ChakraEditableProps>, CommonInputProps<HTMLInputElement> {
+	inputClassName?: string;
 	inputType?: InputType;
 	lineCount?: number;
 	Preview?: React.ComponentType<InlineEditPreviewProps>;
+	previewClassName?: string;
 }
 
 export interface InlineEditPreviewProps

--- a/packages/components/src/BiggieCalendarDate/style.scss
+++ b/packages/components/src/BiggieCalendarDate/style.scss
@@ -33,9 +33,9 @@
 			letter-spacing: var(--ee-letter-spacing-font-size-tiny);
 		}
 
-		&__weekday,
-		&__time {
-			line-height: var(--ee-font-size-huge);
+		&__weekday {
+			line-height: var(--ee-font-size-bigger);
+    		margin-top: var(--ee-margin-nano);
 		}
 
 		&__month {
@@ -61,6 +61,10 @@
 			line-height: var(--ee-font-size-big);
 			left: var(--ee-padding-nano);
 			position: relative;
+		}
+
+		&__time {
+			line-height: var(--ee-font-size-huge);
 		}
 	}
 

--- a/packages/components/src/EntityCard/styles.scss
+++ b/packages/components/src/EntityCard/styles.scss
@@ -30,7 +30,7 @@
 
 		&__details-wrapper {
 			box-sizing: border-box;
-			padding: var(--ee-padding-tiny) var(--ee-padding-small);
+			padding: var(--ee-padding-micro);
 			width: calc(100% - var(--ee-sidebar-width) - var(--ee-menu-width));
 		}
 
@@ -43,7 +43,7 @@
 			font-family: var(--ee-admin-font-family);
 			height: 100%;
 			line-height: calc(var(--ee-line-height-modifier) * 0.875);
-			justify-content: space-between;
+			justify-content: flex-start;
 			text-align: center;
 			width: 100%;
 
@@ -58,7 +58,7 @@
 					font-weight: bold;
 					letter-spacing: var(--ee-letter-spacing-font-size-huge);
 					line-height: calc(var(--ee-line-height-modifier) * 0.75);
-					margin: 0 0 var(--ee-margin-smaller);
+					margin: 0;
 					text-align: center;
 					width: 100%;
 					.ee-input-inline {
@@ -101,6 +101,10 @@
 						}
 					}
 				}
+			}
+
+			.ee-entity-details-panel {
+				margin: auto 0 0;
 			}
 		}
 

--- a/packages/components/src/EntityCard/styles.scss
+++ b/packages/components/src/EntityCard/styles.scss
@@ -61,9 +61,6 @@
 					margin: 0;
 					text-align: center;
 					width: 100%;
-					.ee-input-inline {
-						margin: calc(var(--ee-margin-tiny) * -1) 0 0;
-					}
 				}
 
 				&__description {
@@ -74,13 +71,6 @@
 					text-align: center;
 					width: 100%;
 					z-index: 1;
-					textarea {
-						background-color: white;
-						margin: calc(var(--ee-margin-tiny) * -1) 0 0;
-						position: absolute;
-						right: 0;
-						top: 0;
-					}
 				}
 
 				&__price {

--- a/packages/components/src/InlineEditInput/InlineEditInfinity.tsx
+++ b/packages/components/src/InlineEditInput/InlineEditInfinity.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import classNames from 'classnames';
 
 import { isInfinite, parseInfinity } from '@eventespresso/utils';
 import { InlineEdit } from '@eventespresso/adapters';
@@ -11,7 +10,6 @@ import './style.scss';
 
 const InlineEditInfinity: React.FC<TextProps> = ({ className, onChangeValue, value, ...props }) => {
 	const isInfinity = isInfinite(value);
-	const inputClassName = classNames('ee-inline-edit', 'ee-inline-edit__infinity', className && className);
 
 	const onChangeHandler = useCallback<TextProps['onChangeValue']>(
 		(val) => {
@@ -27,10 +25,11 @@ const InlineEditInfinity: React.FC<TextProps> = ({ className, onChangeValue, val
 		<InlineEdit
 			placeholder=''
 			{...props}
-			className={inputClassName}
+			inputClassName={'ee-inline-edit__infinity'}
 			inputType='number'
 			onChangeValue={onChangeHandler}
 			Preview={InlineEditInfinityPreview}
+			previewClassName={className}
 			value={isInfinity ? '' : value}
 		/>
 	);

--- a/packages/components/src/InlineEditInput/InlineEditText.tsx
+++ b/packages/components/src/InlineEditInput/InlineEditText.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 
 import { InlineEdit } from '@eventespresso/adapters';
 import Preview from './Preview';
@@ -8,10 +7,16 @@ import type { TextProps } from './types';
 import './style.scss';
 
 const InlineEditText: React.FC<TextProps> = ({ className, tag: as, ...props }) => {
-	const inputClassName = classNames('ee-inline-edit', 'ee-inline-edit__text', className && className);
-
 	return (
-		<InlineEdit placeholder='' {...props} as={as} className={inputClassName} inputType='text' Preview={Preview} />
+		<InlineEdit
+			placeholder=''
+			{...props}
+			as={as}
+			inputClassName={'ee-inline-edit__text'}
+			inputType='text'
+			Preview={Preview}
+			previewClassName={className}
+		/>
 	);
 };
 

--- a/packages/components/src/InlineEditInput/InlineEditTextArea.tsx
+++ b/packages/components/src/InlineEditInput/InlineEditTextArea.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 
 import { InlineEdit } from '@eventespresso/adapters';
 import Preview from './Preview';
@@ -8,15 +7,15 @@ import type { TextAreaProps } from './types';
 import './style.scss';
 
 const InlineEditTextArea: React.FC<TextAreaProps> = ({ className, lineCount = 3, ...props }) => {
-	const inputClassName = classNames('ee-inline-edit', 'ee-inline-edit__textarea', className && className);
 	return (
 		<InlineEdit
 			placeholder=''
 			{...props}
-			className={inputClassName}
+			inputClassName={'ee-inline-edit__textarea'}
 			lineCount={lineCount}
 			inputType='textarea'
 			Preview={Preview}
+			previewClassName={className}
 		/>
 	);
 };

--- a/packages/components/src/InlineEditInput/Preview.tsx
+++ b/packages/components/src/InlineEditInput/Preview.tsx
@@ -26,7 +26,7 @@ const Preview: React.FC<PreviewProps> = ({
 
 	const icon = isDisabled ? null : <Edit className='ee-inline-edit__edit-icon' />;
 
-	const previewClassName = classNames('ee-inline-edit__preview-wrapper', className);
+	const previewClassName = classNames('ee-inline-edit__preview', className);
 
 	let textInput: string | JSX.Element = value;
 

--- a/packages/components/src/InlineEditInput/Preview.tsx
+++ b/packages/components/src/InlineEditInput/Preview.tsx
@@ -26,7 +26,7 @@ const Preview: React.FC<PreviewProps> = ({
 
 	const icon = isDisabled ? null : <Edit className='ee-inline-edit__edit-icon' />;
 
-	const previewClassName = classNames('ee-inline-edit__preview-wrapper', className && className);
+	const previewClassName = classNames('ee-inline-edit__preview-wrapper', className);
 
 	let textInput: string | JSX.Element = value;
 

--- a/packages/components/src/InlineEditInput/style.scss
+++ b/packages/components/src/InlineEditInput/style.scss
@@ -45,8 +45,4 @@
 			z-index: 99;
 		}
 	}
-
-	.ee-edit-inline {
-		margin: var(--ee-margin-smaller);
-	}
 }

--- a/packages/components/src/InlineEditInput/style.scss
+++ b/packages/components/src/InlineEditInput/style.scss
@@ -45,4 +45,8 @@
 			z-index: 99;
 		}
 	}
+
+	.ee-edit-inline {
+		margin: var(--ee-margin-smaller);
+	}
 }

--- a/packages/components/src/InlineEditInput/style.scss
+++ b/packages/components/src/InlineEditInput/style.scss
@@ -33,7 +33,7 @@
 		color: var(--ee-default-text-color-super-low-contrast);
 	}
 
-	&__preview-wrapper {
+	&__preview {
 		svg.ee-svg {
 			background-color: transparent;
 			color: var(--ee-default-text-color-super-low-contrast);

--- a/packages/components/src/RichTextEditorModal/index.tsx
+++ b/packages/components/src/RichTextEditorModal/index.tsx
@@ -22,7 +22,7 @@ export const RichTextEditorModal: React.FC<RichTextEditorModalProps> = ({
 	const { isOpen, onOpen, onClose } = useDisclosure();
 
 	const hasChanges = text !== props.text;
-	const previewClassName = classNames('ee-inline-edit__preview-wrapper', className && className);
+	const previewClassName = classNames('ee-inline-edit__preview', className && className);
 
 	const onChange = useCallback(
 		(newText: string): void => {
@@ -68,7 +68,7 @@ export const RichTextEditorModal: React.FC<RichTextEditorModalProps> = ({
 			>
 				<RichTextEditor onChange={onChange} value={text} />
 			</ModalWithAlert>
-			<div className='ee-rich-text-editor__preview-wrapper'>
+			<div className='ee-rich-text-editor__preview'>
 				<TabbableText
 					className={previewClassName}
 					icon={<Edit className={'ee-inline-edit__edit-icon'} />}

--- a/packages/components/src/TabbableText/index.tsx
+++ b/packages/components/src/TabbableText/index.tsx
@@ -13,7 +13,7 @@ export const TabbableText: React.FC<TabbableTextProps> = ({ className, icon, onC
 	const text = props.text || tooltip;
 	// don't display tooltip if it is being used as placeholder
 	tooltip = text === tooltip ? '' : tooltip;
-	const textClassName = classNames('ee-tabbable-text', className, { 'is-disabled': isDisabled });
+	const textClassName = classNames('ee-tabbable-text', className, isDisabled && 'is-disabled');
 
 	const onKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {

--- a/packages/components/src/TabbableText/index.tsx
+++ b/packages/components/src/TabbableText/index.tsx
@@ -8,12 +8,12 @@ import type { TabbableTextProps } from './types';
 
 import './style.scss';
 
-export const TabbableText: React.FC<TabbableTextProps> = ({ icon, onClick, isDisabled, ...props }) => {
+export const TabbableText: React.FC<TabbableTextProps> = ({ className, icon, onClick, isDisabled, ...props }) => {
 	let tooltip = props.tooltip || __('Click to edit…');
 	const text = props.text || tooltip;
 	// don't display tooltip if it is being used as placeholder
 	tooltip = text === tooltip ? '' : tooltip;
-	const className = classNames('ee-tabbable-text', props.className, { 'is-disabled': isDisabled });
+	const textClassName = classNames('ee-tabbable-text', className, { 'is-disabled': isDisabled });
 
 	const onKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
@@ -29,7 +29,7 @@ export const TabbableText: React.FC<TabbableTextProps> = ({ icon, onClick, isDis
 		<Tooltip tooltip={tooltip}>
 			<div
 				aria-label={props.tooltip}
-				className={className}
+				className={textClassName}
 				onClick={onClick}
 				onKeyDown={onKeyDown}
 				role={isDisabled ? null : 'button'}


### PR DESCRIPTION
Currently, the css class names assigned to an inline edit component get applied to both the wrapping HTML tag as well as the inner div. So for example, the resulting DOM for the Ticket Name heading looks something like this:

```html 
<h4 class="ee-inline-edit ee-inline-edit__text entity-card-details__name">
    <div class="ee-tabbable-text ee-inline-edit__preview-wrapper ee-inline-edit ee-inline-edit__text entity-card-details__name">
		<!-- html -->
    </div>
</h4>
```

which has the `ee-inline-edit ee-inline-edit__text entity-card-details__name` classes applied to both the `h4` tag and the `div` just within it.

This causes layout issues because any margin or padding or whatever essentially gets applied twice.

This PR fixes the issue by only applying the `ee-inline-edit` type classes to the inner div, and the `entity-card-details` type classes to the preview DOM tag. 

So now the DOM will look something like this:

```html
<h4 class="entity-card-details__name">
    <div class="ee-tabbable-text ee-inline-edit__preview-wrapper ee-inline-edit ee-inline-edit__text">
		<!-- html -->
    </div>
</h4>
```

I've also improved some other layout styles for the entity cards.