### PR TITLE
fix event desc toolbar

### DIFF
--- a/domains/eventEditor/src/ui/styles.scss
+++ b/domains/eventEditor/src/ui/styles.scss
@@ -6,6 +6,10 @@
 		z-index: 2;
 	}
 
+	#ed_toolbar {
+		box-sizing: content-box;
+	}
+
 	#ee-event-editor {
 		position: relative;
 		z-index: 2;


### PR DESCRIPTION
fixes this issue that Garth keeps seeing:

![image (4)](https://user-images.githubusercontent.com/1751030/99735252-21b74380-2a79-11eb-82d2-f1d40cdc7c82.png)
