### PR TITLE
Fix form package usage

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -62,6 +62,7 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 			onSubmit: onSubmitFrom,
 			decorators,
 			initialValues,
+			subscription: {},
 			validate,
 			layout: 'horizontal',
 			debugFields: ['values', 'errors'],

--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/Container.tsx
@@ -17,8 +17,8 @@ const Container: React.FC = () => {
 
 	let title = ticket?.dbId
 		? sprintf(
-				/* translators: %d ticket id */
-				__('Edit ticket %d'),
+				/* translators: %s ticket id */
+				__('Edit ticket %s'),
 				`#${ticket.dbId}`
 		  )
 		: __('New Ticket Details');

--- a/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -74,6 +74,7 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 			...config,
 			onSubmit: onSubmitFrom,
 			decorators,
+			subscription: {},
 			initialValues,
 			validate,
 			layout: 'horizontal',

--- a/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
+++ b/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
@@ -111,6 +111,7 @@ const useTicketFormConfig = (ticket?: RemTicket | Ticket, config?: Partial<Ticke
 			...config,
 			initialValues,
 			onSubmit: config?.onSubmit,
+			subscription: {},
 			validate,
 			layout: 'horizontal',
 			debugFields: ['values', 'errors'],

--- a/domains/rem/src/ui/datetimeDetails/useDateFormConfig.ts
+++ b/domains/rem/src/ui/datetimeDetails/useDateFormConfig.ts
@@ -40,6 +40,7 @@ const useDateFormConfig = (datetime: Datetime, config?: Partial<EspressoFormProp
 			...config,
 			onSubmit,
 			initialValues,
+			subscription: {},
 			validate,
 			debugFields: ['values', 'errors'],
 			sections: [

--- a/packages/form/src/renderers/FormRenderer.tsx
+++ b/packages/form/src/renderers/FormRenderer.tsx
@@ -7,7 +7,6 @@ import Submit from '../Submit';
 import RenderFields from '../RenderFields';
 import RenderSections from '../RenderSections';
 import DebugInfo from '../../../components/src/DebugInfo/DebugInfo'; // to avoid circular dependency, also since it's used only in dev
-import { formPropsAreEqual } from '../utils';
 
 const EMPTY_ARRAY = [];
 
@@ -55,4 +54,4 @@ const FormRenderer: React.FC<FormRendererProps> = (props) => {
 
 	return formOutput;
 };
-export default React.memo(FormRenderer, formPropsAreEqual);
+export default FormRenderer;


### PR DESCRIPTION
This package improves the form package usage by removing use of `React.memo` for `FormRenderer` component. It does so by making use of the RFF `subscription` prop.

Closes #428 