### PR TITLE
Fix stale entities in REM optimistic responses

### DIFF
--- a/packages/components/src/EntityList/EntityCardList.tsx
+++ b/packages/components/src/EntityList/EntityCardList.tsx
@@ -4,8 +4,10 @@ import type { EntityCardListProps } from './types';
 import { Entity } from '@eventespresso/data';
 
 const EntityCardList = <E extends Entity>({ EntityCard, entityIds }: EntityCardListProps<E>): JSX.Element => {
+	// key to make sure the list is refreshed after optimistic responses
+	const key = entityIds.join(':');
 	return (
-		<div className='ee-entity-list__card-view'>
+		<div className='ee-entity-list__card-view' key={key}>
 			{entityIds.map((entityId) => (
 				<EntityCard id={entityId} key={entityId} />
 			))}

--- a/packages/components/src/EntityList/EntityTable.tsx
+++ b/packages/components/src/EntityList/EntityTable.tsx
@@ -49,12 +49,15 @@ const EntityTable = <FS extends ELFSM>({
 		tableCaption,
 	});
 	const onDragEnd = filterState.sortingEnabled ? onSort : null;
+	// key to make sure the list is refreshed after optimistic responses
+	const key = entityIds.join(':');
 
 	return (
 		<ResponsiveTable
 			bodyRows={bodyRows}
 			className={className}
 			headerRows={headerRows}
+			key={key}
 			metaData={metaData}
 			onDragEnd={onDragEnd}
 		/>


### PR DESCRIPTION
This PR fixes the issue of state optimistic responses that remain in the entity list after complete REM submission.

Closes #440 