### PR TITLE
Fix TAM validations

### DIFF
--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/ModalContainer.tsx
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/ModalContainer.tsx
@@ -1,19 +1,36 @@
 import React, { useMemo, useCallback } from 'react';
 import { sprintf, __ } from '@eventespresso/i18n';
+import { pick } from 'ramda';
 
 import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
+import { useRelations } from '@eventespresso/services';
+import { useConfirmationDialog } from '@eventespresso/components';
 
 import TicketAssignmentsManagerModal from './TicketAssignmentsManagerModal';
 import { withContext } from '../context';
 import { useOnSubmitAssignments } from '../data';
 import type { TAMModalProps } from '../context';
 import type { BaseProps } from '../types';
+import { TAM_ENTITIES } from '../constants';
 
 const ModalContainer: React.FC = () => {
-	const { getData, isOpen, close: onClose } = useGlobalModal<BaseProps>(EdtrGlobalModals.TAM);
+	const { getData, isOpen, close: onClose, openWithData } = useGlobalModal<BaseProps>(EdtrGlobalModals.TAM);
+	const { getData: getRelationalData } = useRelations();
 
 	const submitAssignments = useOnSubmitAssignments();
+
+	const reOpenTamModal = useCallback(() => {
+		openWithData({ assignmentType: 'forAll' });
+	}, [openWithData]);
+
+	const { confirmationDialog, onOpen: showAlert } = useConfirmationDialog({
+		message: __(
+			'There seem to be some dates/tickets which have no tickets/dates assigned. Do you want to fix them now?'
+		),
+		title: __('Alert!'),
+		onConfirm: reOpenTamModal,
+	});
 
 	const { assignmentType, entity } = getData();
 
@@ -21,15 +38,15 @@ const ModalContainer: React.FC = () => {
 
 	if (assignmentType === 'forDate') {
 		title = sprintf(
-			/* translators: %d entity id, %s entity name */
-			__('Ticket Assignment Manager for Datetime: %1$d - %2$s'),
+			/* translators: 1 entity id, 2 entity name */
+			__('Ticket Assignment Manager for Datetime: %1$s - %2$s'),
 			String(entity.dbId),
 			entity.name
 		);
 	} else if (assignmentType === 'forTicket') {
 		title = sprintf(
-			/* translators: %d entity id, %s entity name */
-			__('Ticket Assignment Manager for Ticket: %1$d - %2$s'),
+			/* translators: 1 entity id, 2 entity name */
+			__('Ticket Assignment Manager for Ticket: %1$s - %2$s'),
 			String(entity.dbId),
 			entity.name
 		);
@@ -42,23 +59,47 @@ const ModalContainer: React.FC = () => {
 		title,
 	]);
 
+	const hasOrphanEntities = useCallback(() => {
+		// simplify the data for loop
+		const data = Object.entries(pick(TAM_ENTITIES, getRelationalData()));
+		for (const [, entityRelations] of data) {
+			for (const [, relations] of Object.entries(entityRelations)) {
+				const tamRelations = pick(TAM_ENTITIES, relations);
+				// flatten the relations
+				const relatedIds = Object.values(tamRelations).flat();
+				if (!relatedIds.length) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}, [getRelationalData]);
+
 	const onSubmit = useCallback<TAMModalProps['onSubmit']>(
-		(data) => {
+		async (data) => {
 			// close the moal
 			onClose();
 			// submit TAM data
-			submitAssignments(data);
+			await submitAssignments(data);
+			if (hasOrphanEntities()) {
+				showAlert();
+			}
 		},
-		[onClose, submitAssignments]
+		[hasOrphanEntities, onClose, showAlert, submitAssignments]
 	);
 
 	if (!isOpen) {
-		return null;
+		return <>{confirmationDialog}</>;
 	}
 
 	const Component = withContext(TicketAssignmentsManagerModal, contextProps);
 
-	return <Component title={title} onCloseModal={onClose} onSubmit={onSubmit} />;
+	return (
+		<>
+			<Component title={title} onCloseModal={onClose} onSubmit={onSubmit} />
+			{confirmationDialog}
+		</>
+	);
 };
 
 export default ModalContainer;

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/useInvalidDataAlert.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/useInvalidDataAlert.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import { pick } from 'ramda';
+
+import { useRelations } from '@eventespresso/services';
+
+import { TAM_ENTITIES } from '../constants';
+
+const useInvalidDataAlert = (showAlert: VoidFunction): VoidFunction => {
+	const { getData } = useRelations();
+	const [validateData, setValidateData] = useState(false);
+
+	const checkForInvalidData = useCallback(() => setValidateData(true), []);
+
+	const hasOrphanEntities = useCallback(() => {
+		// simplify the data for loop
+		const data = Object.entries(pick(TAM_ENTITIES, getData()));
+		for (const [, entityRelations] of data) {
+			for (const [, relations] of Object.entries(entityRelations)) {
+				const tamRelations = pick(TAM_ENTITIES, relations);
+				// flatten the relations
+				const relatedIds = Object.values(tamRelations).flat();
+				if (!relatedIds.length) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}, [getData]);
+
+	useEffect(() => {
+		if (validateData && hasOrphanEntities()) {
+			showAlert();
+			setValidateData(false);
+		}
+	}, [hasOrphanEntities, showAlert, validateData]);
+
+	return checkForInvalidData;
+};
+
+export default useInvalidDataAlert;

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/constants.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/constants.ts
@@ -1,0 +1,3 @@
+import { TAMRelationalData } from './types';
+
+export const TAM_ENTITIES: Array<keyof TAMRelationalData> = ['datetimes', 'tickets'];

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useAssignmentManager.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useAssignmentManager.ts
@@ -1,12 +1,12 @@
+import { useCallback, useMemo } from 'react';
 import { pick, map, mapObjIndexed, isEmpty } from 'ramda';
 
 import { useRelationsManager, RelationFunctionProps } from '@eventespresso/services';
-import { AssignmentManager, TAMRelationalData } from '../types';
-import { useCallback, useMemo } from 'react';
+
+import { AssignmentManager } from '../types';
+import { TAM_ENTITIES } from '../constants';
 
 type AM = AssignmentManager;
-
-const relationsToPick: Array<keyof TAMRelationalData> = ['datetimes', 'tickets'];
 
 /**
  * A wrapper for relations manager.
@@ -131,7 +131,7 @@ const useAssignmentManager = (): AM => {
 		// Now loop through all the relational entities
 		return map((relation) => {
 			// pick only TAM relations, i.e. filter out tickets to prices relations
-			return pick(relationsToPick, relation);
+			return pick(TAM_ENTITIES, relation);
 		}, relationalEntityToUse);
 	}, []);
 
@@ -141,7 +141,7 @@ const useAssignmentManager = (): AM => {
 	const initialize = useCallback<AM['initialize']>(
 		({ data, assignmentType, entity }) => {
 			// pick only datetimes and tickets from relational data
-			let newData = pick(relationsToPick, data);
+			let newData = pick(TAM_ENTITIES, data);
 
 			// Remove other relations from newData
 			newData = mapObjIndexed((relationalEntity, entityType) => {

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
@@ -30,9 +30,27 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 		orphanEntities.datetimes,
 	]);
 
-	const hasOrphanTickets = useCallback(() => orphanEntities.tickets.length > 0, [orphanEntities.tickets]);
+	const hasOrphanEntitiesOfType = useCallback(
+		(entityType: keyof typeof orphanEntities) => {
+			if (
+				// if TAM is for a date, lets not worry about tickets and vice versa
+				(entityType === 'tickets' && props.assignmentType === 'forDate') ||
+				(entityType === 'datetimes' && props.assignmentType === 'forTicket')
+			) {
+				return false;
+			}
+			// if TAM is for a particular date/ticket, we should worry only about that particular date/ticket
+			if (props.assignmentType !== 'forAll') {
+				return orphanEntities[entityType]?.includes(props.entity?.id);
+			}
+			return orphanEntities[entityType]?.length > 0;
+		},
+		[orphanEntities, props.assignmentType, props.entity?.id]
+	);
 
-	const hasOrphanDates = useCallback(() => orphanEntities.datetimes.length > 0, [orphanEntities.datetimes]);
+	const hasOrphanTickets = useCallback(() => hasOrphanEntitiesOfType('tickets'), [hasOrphanEntitiesOfType]);
+
+	const hasOrphanDates = useCallback(() => hasOrphanEntitiesOfType('datetimes'), [hasOrphanEntitiesOfType]);
 
 	const hasOrphanEntities = useCallback(() => hasOrphanTickets() || hasOrphanDates(), [
 		hasOrphanDates,

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useFilteredDatetimes.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useFilteredDatetimes.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import type { Datetime } from '@eventespresso/edtr-services';
-import { isTrashed, inYearAndMonth } from '@eventespresso/predicates';
+import { notTrashed, inYearAndMonth } from '@eventespresso/predicates';
 import { useFilterState } from '../filters';
 
 const useFilteredDatetimes = (allDates: Array<Datetime>): Array<Datetime> => {
@@ -17,7 +17,7 @@ const useFilteredDatetimes = (allDates: Array<Datetime>): Array<Datetime> => {
 	]);
 
 	return useMemo(() => {
-		return showTrashedDates ? datetimes : datetimes.filter((datetime) => !isTrashed(datetime));
+		return showTrashedDates ? datetimes : notTrashed(datetimes);
 	}, [datetimes, showTrashedDates]);
 };
 

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useFilteredTickets.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useFilteredTickets.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { isTrashed, isExpired } from '@eventespresso/predicates';
+import { isExpired, notTrashed } from '@eventespresso/predicates';
 import type { Ticket } from '@eventespresso/edtr-services';
 import { useFilterState } from '../filters';
 
@@ -14,7 +14,7 @@ const useFilteredTickets = (allTickets: Array<Ticket>): Array<Ticket> => {
 		}
 
 		if (!showTrashedTickets) {
-			tickets = tickets.filter((ticket) => !isTrashed(ticket));
+			tickets = notTrashed(tickets);
 		}
 
 		return tickets;

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useOnSubmitAssignments.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useOnSubmitAssignments.ts
@@ -51,7 +51,7 @@ const useOnSubmitAssignments = (): Callback => {
 				}
 				uniqueInputs.push({ id, quantity });
 			});
-			bulkEditTickets({ uniqueInputs });
+			await bulkEditTickets({ uniqueInputs });
 		},
 		[allDates, allTickets, bulkEditTickets, getExistingData]
 	);

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useValidation.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useValidation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { mapObjIndexed, pickBy, isEmpty } from 'ramda';
 
 import { AssignmentManager, TAMPossibleRelation, TAMRelationalData, TAMRelationalEntity } from '../types';
@@ -33,7 +33,7 @@ const useValidation = (assignmentManager: AssignmentManager): TAMPossibleRelatio
 		setValidationData(newTAMData);
 	}, [TAMData]);
 
-	return useMemo(() => validationData, [validationData]);
+	return validationData;
 };
 
 export default useValidation;

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import classNames from 'classnames';
 
 import { SwitchChecked, SwitchUnchecked } from '@eventespresso/icons';
 import { isLeftKey, isRightKey } from '@eventespresso/utils';
-import { useOnChange } from '@eventespresso/hooks';
 import { withLabel } from '../withLabel';
 import type { SwitchProps } from './types';
 
@@ -22,14 +21,19 @@ const Switch: React.FC<SwitchProps> = ({
 	onChange,
 	onChangeValue,
 	onFocus,
-	value,
 	...props
 }) => {
 	const [innerChecked, setInnerChecked] = useState<boolean>(checked || defaultChecked);
 	const [hasFocus, setHasFocus] = useState<boolean>(false);
 	const ref = useRef<HTMLInputElement>();
-	const onChangeHandlerArg = useMemo(() => ({ onChange, onChangeValue }), [onChange, onChangeValue]);
-	const onChangeHandler = useOnChange(onChangeHandlerArg);
+
+	const onChangeHandler = useCallback<SwitchProps['onChange']>(
+		(event) => {
+			onChangeValue?.(event.target.checked, event);
+			onChange?.(event);
+		},
+		[onChange, onChangeValue]
+	);
 
 	const className = classNames(
 		'ee-switch',
@@ -108,7 +112,6 @@ const Switch: React.FC<SwitchProps> = ({
 				onFocus={handleFocus}
 				ref={ref}
 				type='checkbox'
-				value={value}
 			/>
 		</div>
 	);

--- a/packages/components/src/Switch/types.ts
+++ b/packages/components/src/Switch/types.ts
@@ -13,7 +13,7 @@ export interface SwitchProps
 	'aria-describedby'?: string;
 	'aria-labelledby'?: string;
 	'aria-label'?: string;
-	checked: boolean;
+	checked?: boolean;
 	className?: string;
 	defaultChecked?: boolean;
 	disabled?: boolean;


### PR DESCRIPTION
This PR fixes the TAM validations when modifying relations for a single date or ticket. It also adds an alert after submit if there are dates or tickets without corresponding relations.

Here is the final logic for TAM validations:
- When TAM is opened for a single date/ticket, validations are enforced only for that date/ticket i.e. if the user does not assign a date/ticket to that entity, it won't let the user submit the data.
- When TAM is opened for all dates and tickets, validations are enforced for all dates and tickets
- When the user submits the form, if there are any dates/tickets without corresponding relations, an alert is shown to the user whether they want to fix it.

Closes #456 

![demo](https://user-images.githubusercontent.com/18226415/100880568-e4b86b80-34d2-11eb-81c5-f108e4c2da2a.gif)
