### PR TITLE
Deploy WP User assets

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -46,3 +46,9 @@ jobs:
             # Deploy the built assets to REM assets/dist
             - name: Deploy to REM
               run: source tools/deploy.sh "eea-recurring-events-manager"
+            # Build WP User domain without packages
+            - name: Build wpUser
+              run: yarn build:wpUser
+            # Deploy the built assets to WP User assets/dist
+            - name: Deploy to WP User
+              run: source tools/deploy.sh "eea-wpuser-integration"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"build:cra": "node scripts/build.js",
 		"build:packages": "yarn build:cra",
 		"build:rem": "yarn build:cra --domains \"rem\" --packages \"rrule-generator\"",
+		"build:wpUser": "yarn build:cra --domains \"wpUser\" --skip-all-packages",
 		"build-storybook": "BUILD_POT=false build-storybook",
 		"chromatic": "chromatic",
 		"deploy": "FORCE_COLOR=true lerna run deploy",


### PR DESCRIPTION
This PR updates the deployment workflow to deploy WP User assets to the corresponding repo.

See #474 