### PR TITLE
Only Remove Previous Production Build Assets

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -89,7 +89,8 @@ cd $CLONE_DIR
 
 # clean the assets path.
 echo "Clean up assets path..."
-rm -rf $ASSETS_PATH/*
+rm -rf $ASSETS_PATH/static/*
+rm -f $ASSETS_PATH/asset-manifest.json
 
 # Make sure the directory exists
 mkdir -p $ASSETS_PATH


### PR DESCRIPTION
Currently our barista deployment process completely nukes everything in the `/assets/` folder, which has been fine for the projects worked on so far, but causes problems for add-ons that already have assets in that folder. 

As you can see in the following commit: https://github.com/eventespresso/eea-wpuser-integration/commit/47a54b889943808a60e595447e496f143a5120b4
several existing legacy assets for the WP User Integration add-on were removed despite those assets still being needed for other functionality.

This PR changes the logic in `tools/deploy.sh` to **only** delete content in the `/assets/static/` folder as well as the `/assets/asset-manifest.json` file. There may be other assets that need to be deleted as well and/or there may be a better way to do this. Please feel free to change how this works.