### PR TITLE
Fix HOCs

### DIFF
--- a/packages/adapters/src/Button/Button.tsx
+++ b/packages/adapters/src/Button/Button.tsx
@@ -3,15 +3,15 @@ import { Button as ChakraButton } from '@chakra-ui/core';
 
 import type { ButtonProps } from './types';
 
-type ButtonType = React.ComponentType<ButtonProps>;
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ children, buttonText, icon, ...props }, ref) => {
+		const leftIcon = icon && icon;
+		const text = children || buttonText;
 
-export const Button = React.forwardRef<ButtonType, ButtonProps>(({ children, buttonText, icon, ...props }, ref) => {
-	const leftIcon = icon && icon;
-	const text = children || buttonText;
-
-	return (
-		<ChakraButton {...props} leftIcon={leftIcon} ref={ref}>
-			{text && <span>{text}</span>}
-		</ChakraButton>
-	);
-});
+		return (
+			<ChakraButton {...props} leftIcon={leftIcon} ref={ref}>
+				{text && <span>{text}</span>}
+			</ChakraButton>
+		);
+	}
+);

--- a/packages/adapters/src/Button/IconButton.tsx
+++ b/packages/adapters/src/Button/IconButton.tsx
@@ -3,9 +3,7 @@ import { IconButton as ChakraIconButton } from '@chakra-ui/core';
 
 import type { IconButtonProps } from './types';
 
-type ButtonType = React.ComponentType<IconButtonProps>;
-
-export const IconButton: React.FC<IconButtonProps> = React.forwardRef<ButtonType, IconButtonProps>(
+export const IconButton: React.FC<IconButtonProps> = React.forwardRef<HTMLButtonElement, IconButtonProps>(
 	({ variant = 'unstyled', ...props }, ref) => {
 		return <ChakraIconButton {...props} ref={ref} variant={variant} />;
 	}

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -9,15 +9,13 @@ import type { ButtonProps } from './types';
 
 import './style.scss';
 
-type BtnType = React.ComponentType<ButtonProps>;
-
 /**
  * Button wrapper for adding styles
  *
  * forwardRef to be able to accept
  * onMouseEnter, onMouseLeave, onFocus, onClick events from parent
  */
-const Button = forwardRef<typeof ButtonAdapter, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	(
 		{
 			active,
@@ -62,6 +60,4 @@ const Button = forwardRef<typeof ButtonAdapter, ButtonProps>(
 	}
 );
 
-// Since withLabel and withTooltip accept only a component type
-// Lets cast it
-export default withLabel(withTooltip(Button as BtnType) as BtnType);
+export default withLabel(withTooltip(Button));

--- a/packages/components/src/Button/IconButton/index.tsx
+++ b/packages/components/src/Button/IconButton/index.tsx
@@ -9,16 +9,14 @@ import type { IconButtonProps } from './types';
 
 import './style.scss';
 
-type BtnType = React.ComponentType<IconButtonProps>;
-
 export const iconBtnClassName = 'ee-btn-base ee-icon-button';
 
-const IconButton = forwardRef<typeof IconButtonAdapter, IconButtonProps>(
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
 	(
 		{ borderless, buttonType = ButtonType.DEFAULT, color, icon, noMargin, onClick, size = 'default', ...props },
 		ref
 	) => {
-		const ariaLabel = props['aria-label'] || props.label || props.tooltip;
+		const ariaLabel = props['aria-label'];
 		const className = classNames(
 			iconBtnClassName,
 			props.className,
@@ -43,4 +41,4 @@ const IconButton = forwardRef<typeof IconButtonAdapter, IconButtonProps>(
 	}
 );
 
-export default withLabel(withTooltip(IconButton as BtnType) as BtnType);
+export default withLabel(withTooltip(IconButton));

--- a/packages/components/src/Button/IconButton/types.ts
+++ b/packages/components/src/Button/IconButton/types.ts
@@ -1,12 +1,8 @@
-import type { Size, withLabelProps, withTooltipProps } from '../../../';
+import type { Size } from '../../../';
 import type { ButtonType } from '../types';
 import type { IconButtonProps as IconButtonAdapterProps } from '@eventespresso/adapters';
 
-export interface IconButtonProps
-	extends Size,
-		Omit<IconButtonAdapterProps, 'aria-label' | 'size'>,
-		Partial<withLabelProps>,
-		Partial<withTooltipProps> {
+export interface IconButtonProps extends Size, Omit<IconButtonAdapterProps, 'aria-label' | 'size'> {
 	'aria-label'?: string;
 	borderless?: boolean;
 	buttonType?: ButtonType;

--- a/packages/components/src/Button/Link/index.stories.tsx
+++ b/packages/components/src/Button/Link/index.stories.tsx
@@ -3,7 +3,6 @@ import type { Story, Meta } from '@storybook/react/types-6-0';
 
 import { Groups } from '@eventespresso/icons';
 import { Link } from './';
-import type { LinkProps } from '../types';
 
 export default {
 	argTypes: {},
@@ -11,7 +10,7 @@ export default {
 	title: 'Components/Button/Link',
 } as Meta;
 
-type LinkStory = Story<LinkProps>;
+type LinkStory = Story<React.ComponentProps<typeof Link>>;
 
 const Template: LinkStory = (args) => (
 	<Link {...args} href='https://eventespresso.com/'>

--- a/packages/components/src/Button/Link/index.tsx
+++ b/packages/components/src/Button/Link/index.tsx
@@ -1,44 +1,35 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
-import { Tooltip } from '../../';
 import type { LinkProps } from '../types';
+import { withTooltip } from '../../withTooltip';
 
 import '../style.scss';
 import './style.scss';
 
-export const Link: React.FC<LinkProps> = ({
-	children,
-	href,
-	icon,
-	target = '_blank',
-	tooltip,
-	tooltipProps,
-	...props
-}) => {
-	const className = classNames(
-		props.className,
-		'ee-btn-base',
-		'ee-icon-button',
-		'ee-link',
-		!icon && 'ee-link--no-icon'
-	);
+const PlainLink = forwardRef<HTMLAnchorElement, LinkProps>(
+	({ children, href, icon, target = '_blank', ...props }, ref) => {
+		const className = classNames(
+			props.className,
+			'ee-btn-base',
+			'ee-icon-button',
+			'ee-link',
+			!icon && 'ee-link--no-icon'
+		);
 
-	const label = tooltip && tooltip;
-
-	const link = (
-		<a aria-label={label} className={className} href={href} rel='noopener noreferrer' target={target}>
-			{icon ? icon : children}
-		</a>
-	);
-
-	if (tooltip) {
 		return (
-			<Tooltip tooltip={tooltip} {...tooltipProps}>
-				{link}
-			</Tooltip>
+			<a
+				aria-label={props['aria-label']}
+				className={className}
+				href={href}
+				rel='noopener noreferrer'
+				target={target}
+				ref={ref}
+			>
+				{icon ? icon : children}
+			</a>
 		);
 	}
+);
 
-	return link;
-};
+export const Link = withTooltip(PlainLink);

--- a/packages/components/src/Button/types.ts
+++ b/packages/components/src/Button/types.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { Size, withLabelProps, withTooltipProps } from '../../';
+import type { Size } from '../../';
 import type {
 	ButtonProps as ButtonAdapterProps,
 	ButtonGroupProps as ButtonGroupAdapterProps,
@@ -15,11 +15,7 @@ export enum ButtonType {
 	SECONDARY = 'secondary',
 }
 
-export interface ButtonProps
-	extends Omit<ButtonAdapterProps, 'size'>,
-		Size,
-		Partial<withLabelProps>,
-		Partial<withTooltipProps> {
+export interface ButtonProps extends Omit<ButtonAdapterProps, 'size'>, Size {
 	active?: boolean;
 	buttonType?: ButtonType | 'accent' | 'default' | 'minimal' | 'primary' | 'secondary';
 	className?: string;
@@ -31,7 +27,7 @@ export interface ButtonProps
 }
 export interface ButtonGroupProps extends Omit<ButtonGroupAdapterProps, 'size'>, Size {}
 
-export interface LinkProps extends Partial<withTooltipProps> {
+export interface LinkProps extends Omit<ButtonAdapterProps, 'icon'> {
 	target?: '_blank' | '_parent' | '_self' | '_top';
 	className?: string;
 	href: string;

--- a/packages/components/src/DropdownMenu/types.ts
+++ b/packages/components/src/DropdownMenu/types.ts
@@ -1,6 +1,7 @@
 import type { MenuProps, MenuItemProps, MenuToggleProps, MenuListProps } from '@eventespresso/adapters';
-import type { withTooltipProps } from '../../';
 import type { IconName } from '@eventespresso/icons';
+import type { IconButton } from '../Button';
+import type { WithTooltipProps } from '../withTooltip';
 
 export interface DropdownMenuProps extends Omit<MenuProps, 'isOpen'> {
 	className?: string;
@@ -13,7 +14,9 @@ export interface DropdownMenuItemProps extends MenuItemProps {
 	title?: string;
 }
 
-export interface DropdownToggleProps extends MenuToggleProps, withTooltipProps {
+export interface DropdownToggleProps
+	extends MenuToggleProps,
+		Pick<React.ComponentProps<typeof IconButton>, keyof WithTooltipProps> {
 	borderless?: boolean;
 	icon?: IconName;
 	isOpen?: boolean;

--- a/packages/components/src/EntityList/RegistrationsLink/index.tsx
+++ b/packages/components/src/EntityList/RegistrationsLink/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { Groups } from '@eventespresso/icons';
-import { Link, LinkProps } from '../../..';
+import { Link } from '../../..';
 
 import './style.scss';
 
-const RegistrationsLink: React.FC<LinkProps> = ({ href, ...props }) => {
+const RegistrationsLink: React.FC<React.ComponentProps<typeof Link>> = ({ href, ...props }) => {
 	return <Link {...props} className='ee-editor-details-reg-url-link' href={href} icon={<Groups />} />;
 };
 

--- a/packages/components/src/SearchInput/SearchInput.tsx
+++ b/packages/components/src/SearchInput/SearchInput.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { TextInput, TextInputProps } from '@eventespresso/adapters';
-import { withLabel, withLabelProps } from '../withLabel';
-import type { withTooltipProps } from '../withTooltip';
+import { withLabel } from '../withLabel';
 
-interface SearchInputProps extends TextInputProps, Partial<withLabelProps>, Partial<withTooltipProps> {
+interface SearchInputProps extends TextInputProps {
 	searchText: string;
 	setSearchText: (text?: string) => void;
 }

--- a/packages/components/src/Select/types.ts
+++ b/packages/components/src/Select/types.ts
@@ -1,7 +1,6 @@
 import type { SelectProps as AdapterSelectProps } from '@eventespresso/adapters';
-import type { withLabelProps, withTooltipProps } from '../../';
 
-export interface SelectProps extends AdapterSelectProps, Partial<withLabelProps>, Partial<withTooltipProps> {
+export interface SelectProps extends AdapterSelectProps {
 	onSubmit?: VoidFunction;
 	type?: 'inline';
 }

--- a/packages/components/src/Stepper/buttons/Next.tsx
+++ b/packages/components/src/Stepper/buttons/Next.tsx
@@ -1,10 +1,10 @@
 import React, { memo } from 'react';
 import { __ } from '@eventespresso/i18n';
 
-import { Button, ButtonProps, ButtonType } from '../../../';
+import { Button, ButtonType } from '../../../';
 import { ChevronDoubleRight, ChevronRight } from '@eventespresso/icons';
 
-interface Props extends ButtonProps {
+interface Props extends React.ComponentProps<typeof Button> {
 	skippable?: boolean;
 }
 

--- a/packages/components/src/Stepper/buttons/Previous.tsx
+++ b/packages/components/src/Stepper/buttons/Previous.tsx
@@ -1,10 +1,10 @@
 import React, { memo } from 'react';
 import { __ } from '@eventespresso/i18n';
 
-import { Button, ButtonProps } from '../../../';
+import { Button } from '../../../';
 import { ChevronDoubleLeft, ChevronLeft } from '@eventespresso/icons';
 
-interface Props extends ButtonProps {
+interface Props extends React.ComponentProps<typeof Button> {
 	skippable?: boolean;
 }
 

--- a/packages/components/src/Switch/types.ts
+++ b/packages/components/src/Switch/types.ts
@@ -1,5 +1,3 @@
 import type { SwitchProps as SwitchAdapterProps } from '@eventespresso/adapters';
-import type { withLabelProps } from '../withLabel';
-import type { withDebounceProps } from '../withDebounce';
 
-export interface SwitchProps extends Partial<withLabelProps>, SwitchAdapterProps, withDebounceProps {}
+export interface SwitchProps extends SwitchAdapterProps {}

--- a/packages/components/src/Tag/types.ts
+++ b/packages/components/src/Tag/types.ts
@@ -1,6 +1,6 @@
-import type { Colors, withTooltipProps } from '../';
+import type { Colors, WithTooltipProps } from '../';
 
-export interface TagProps extends Colors, withTooltipProps {
+export interface TagProps extends Colors, WithTooltipProps {
 	className?: string;
 	icon?: JSX.Element;
 }

--- a/packages/components/src/withLabel/types.ts
+++ b/packages/components/src/withLabel/types.ts
@@ -14,7 +14,7 @@ export enum LabelPosition {
 	LEFT_TOP = 'left-top',
 }
 
-export interface withLabelProps {
+export interface WithLabelProps {
 	id?: string;
 	label?: string;
 	labelClassName?: string;

--- a/packages/components/src/withLabel/withLabel.tsx
+++ b/packages/components/src/withLabel/withLabel.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import type { AnyObject } from '@eventespresso/utils';
 import { LabelPosition } from './types';
-import type { withLabelProps } from './types';
+import type { WithLabelProps } from './types';
 import type { ForwardRefComponent } from '../types';
 import './style.scss';
 
-const withLabel = <P extends withLabelProps>(
+const withLabel = <P extends AnyObject>(
 	WrappedComponent: React.ComponentType<P>,
 	LabelTag: React.ElementType = 'label'
-): ForwardRefComponent<P, typeof WrappedComponent> => {
+): ForwardRefComponent<P & WithLabelProps, typeof WrappedComponent> => {
 	type Ref = React.Ref<typeof WrappedComponent>;
-	type refProps = { forwardedRef: Ref };
+	type RefProps = { forwardedRef: Ref };
 
-	const WithLabel: React.FC<P & refProps> = ({
+	const WithLabel: React.FC<P & WithLabelProps & RefProps> = ({
 		forwardedRef,
 		label,
 		labelClassName,

--- a/packages/components/src/withTooltip/types.ts
+++ b/packages/components/src/withTooltip/types.ts
@@ -1,6 +1,6 @@
 import type { TooltipProps } from '@eventespresso/adapters';
 
-export interface withTooltipProps {
+export interface WithTooltipProps {
 	buttonText?: React.ReactNode;
 	showTooltipOnMobile?: boolean;
 	tooltip?: string;

--- a/packages/components/src/withTooltip/withTooltip.tsx
+++ b/packages/components/src/withTooltip/withTooltip.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import type { AnyObject } from '@eventespresso/utils';
 import { Tooltip } from '../';
 import type { TooltipProps } from '@eventespresso/adapters';
-import type { withTooltipProps } from './types';
+import type { WithTooltipProps } from './types';
 import type { ForwardRefComponent } from '../types';
 
 import './style.scss';
 
-const withTooltip = <P extends withTooltipProps>(
-	WrappedComponent: React.ComponentType<P>
-): ForwardRefComponent<P, typeof WrappedComponent> => {
+const withTooltip = <P extends AnyObject>(
+	WrappedComponent: React.ComponentType<P & WithTooltipProps>
+): ForwardRefComponent<P & WithTooltipProps, typeof WrappedComponent> => {
 	// Define ref type
 	type Ref = React.Ref<typeof WrappedComponent>;
-	type refProps = { forwardedRef: Ref };
-	const WithTooltip: React.ComponentType<P & refProps> = ({
+	type RefProps = { forwardedRef: Ref };
+	const WithTooltip: React.ComponentType<P & WithTooltipProps & RefProps> = ({
 		forwardedRef,
 		showTooltipOnMobile = false,
 		tooltip,
@@ -39,6 +40,7 @@ const withTooltip = <P extends withTooltipProps>(
 			toolTipped = (
 				<div className='ee-mobile-help-text__btn-wrap'>
 					<WrappedComponent
+						aria-label={tooltip}
 						{...(props as P)}
 						ref={forwardedRef}
 						tooltip={tooltip}
@@ -50,8 +52,8 @@ const withTooltip = <P extends withTooltipProps>(
 		} else {
 			toolTipped = (
 				<WrappedComponent
-					{...(props as P)}
 					aria-label={tooltip}
+					{...(props as P)}
 					ref={forwardedRef}
 					tooltip={tooltip}
 					tooltipProps={tooltipProps}


### PR DESCRIPTION
This PR fixes the issue of EDTR crash due to `withDebounce` HOC bug to always expect `onChangeValue` prop. It also improves and simplifies the types for all the HOCs and their consumers.

Closes #495 