### PR TITLE
Separate Lint, Build and Test into Separate Jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,9 +13,8 @@ jobs:
             - name: Checkout the commit
               uses: actions/checkout@v2
               with:
-                  # To make sure --changedSince for jest works as expected
-                  # 0 for test, 1 otherwise
-                  fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }}
+                  # To make sure all history is fetch for jest --changedSince to work as expected
+                  fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }} # 0 for test, 1 otherwise
 
             # TODO replace this when setup-node action supports LTS alias
             - name: Set up Node

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,8 @@ jobs:
         steps:
             - name: Checkout the commit
               uses: actions/checkout@v2
-              fetch-depth: 0 # To make sure --changedSince for jest works
+              with:
+                  fetch-depth: 0 # To make sure --changedSince for jest works
 
             # TODO replace this when setup-node action supports LTS alias
             - name: Set up Node

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,9 @@ jobs:
             - name: Checkout the commit
               uses: actions/checkout@v2
               with:
-                  fetch-depth: 0 # To make sure --changedSince for jest works
+                  # To make sure --changedSince for jest works as expected
+                  # 0 for test, 1 otherwise
+                  fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }}
 
             # TODO replace this when setup-node action supports LTS alias
             - name: Set up Node

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Set test CLI args
               if: ${{ matrix.task == 'test' }}
-              run: echo "CLI_ARGS=--changedSince ${{ github.base_ref }}" >> $GITHUB_ENV
+              run: echo "CLI_ARGS=--changedSince ${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
             - name: Run ${{ matrix.task }}
               run: yarn ${{ matrix.task }}:ci ${{ env.CLI_ARGS }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,7 @@ jobs:
         steps:
             - name: Checkout the commit
               uses: actions/checkout@v2
+              fetch-depth: 0 # To make sure --changedSince for jest works
 
             # TODO replace this when setup-node action supports LTS alias
             - name: Set up Node

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,5 +31,9 @@ jobs:
               if: steps.cache-deps.outputs.cache-hit != 'true'
               run: yarn install --frozen-lockfile
 
+            - name: Set test CLI args
+              if: ${{ matrix.task == 'test' }}
+              run: echo "CLI_ARGS=--changedSince ${{ github.base_ref }}" >> $GITHUB_ENV
+
             - name: Run ${{ matrix.task }}
-              run: yarn ${{ matrix.task }}:ci
+              run: yarn ${{ matrix.task }}:ci ${{ env.CLI_ARGS }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,8 +19,8 @@ jobs:
               with:
                   node-version: lts/*
 
-            - name: Load Yarn cache
-              id: yarn-cache
+            - name: Cache dependencies
+              id: cache-deps
               uses: actions/cache@v2
               with:
                   path: '**/node_modules'
@@ -28,7 +28,7 @@ jobs:
 
             - name: Install dependencies
               # install deps only if lockfile has changed
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
+              if: steps.cache-deps.outputs.cache-hit != 'true'
               run: yarn install --frozen-lockfile
 
             - name: Run ${{ matrix.task }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,12 +5,11 @@ on: [pull_request]
 jobs:
     build:
         runs-on: ubuntu-latest
-        name: Lint/Build/Test
+        strategy:
+            matrix:
+                task: [lint, build, test]
+        name: ${{ matrix.task }}
         steps:
-            - name: Get Yarn cache path
-              id: yarn-cache
-              run: echo "::set-output name=dir::$(yarn cache dir)"
-
             - name: Checkout the commit
               uses: actions/checkout@v2
 
@@ -21,21 +20,16 @@ jobs:
                   node-version: lts/*
 
             - name: Load Yarn cache
+              id: yarn-cache
               uses: actions/cache@v2
               with:
-                  path: ${{ steps.yarn-cache.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: '**/node_modules'
+                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
             - name: Install dependencies
+              # install deps only if lockfile has changed
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: yarn install --frozen-lockfile
 
-            - name: Check for lints
-              run: yarn lint:ci
-
-            - name: Build all packages
-              run: yarn build:ci
-
-            - name: Run all unit tests
-              run: yarn test-unit:ci
+            - name: Run ${{ matrix.task }}
+              run: yarn ${{ matrix.task }}:ci

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 		"postinstall": "husky install",
 		"start": "node scripts/start.js",
 		"sb": "start-storybook -p 6006",
-		"test-unit": "node scripts/test.js",
-		"test-unit:ci": "FORCE_COLOR=true CI=true yarn test-unit",
+		"test": "node scripts/test.js",
+		"test:ci": "FORCE_COLOR=true CI=true yarn test-unit",
 		"update-deps": "npx ncu -u && yarn workspaces run update-deps"
 	},
 	"lint-staged": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"start": "node scripts/start.js",
 		"sb": "start-storybook -p 6006",
 		"test": "node scripts/test.js",
-		"test:ci": "FORCE_COLOR=true CI=true yarn test-unit",
+		"test:ci": "FORCE_COLOR=true CI=true yarn test",
 		"update-deps": "npx ncu -u && yarn workspaces run update-deps"
 	},
 	"lint-staged": {


### PR DESCRIPTION
This PR separates Lint, Build and Test into separate jobs and improves caching of deps.

Closes #501, #502