### PR TITLE
remove tiny mce conditionally & directly

### DIFF
--- a/domains/eventEditor/src/ui/EventDescription.tsx
+++ b/domains/eventEditor/src/ui/EventDescription.tsx
@@ -9,6 +9,10 @@ import { withFeature } from '@eventespresso/services';
 const EventDescription: React.FC = () => {
 	const event = useEvent();
 
+	// remove tiny mce editor
+	const postdivrich = document.getElementById('postdivrich');
+	postdivrich.remove();
+
 	return (
 		<div className='ee-event-description ee-edtr-section'>
 			<Heading as='h3'>{__('Event Description')}</Heading>

--- a/domains/eventEditor/src/ui/styles.scss
+++ b/domains/eventEditor/src/ui/styles.scss
@@ -5,10 +5,6 @@
 		z-index: 2;
 	}
 
-	#postdivrich {
-		display: none;
-	}
-
 	#ed_toolbar {
 		box-sizing: content-box;
 	}


### PR DESCRIPTION
Seth discovered that the Tiny MCE editor was missing on events if you were not authorized to use the new RTE feature.

Turns out I had removed the div container for the tiny mce editor using some CSS that ALWYAS loaded with the EDTR. Changed things so that the old editor is removed programmatically via vanilla JS only when the new RTE is loaded.