### PR TITLE
Fix REM console warnings

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
@@ -45,7 +45,13 @@ const Actions: React.FC = () => {
 
 	return (
 		<>
-			<BulkActions Checkbox={Checkbox} defaultAction={options[0].value} onApply={onApply} options={options} />
+			<BulkActions
+				Checkbox={Checkbox}
+				defaultAction={options[0].value}
+				id={'ee-bulk-edit-dates-select-input'}
+				onApply={onApply}
+				options={options}
+			/>
 			{isOpen && (
 				<>
 					{action === 'edit-details' && <EditDetails isOpen={true} onClose={onClose} />}

--- a/domains/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
@@ -48,7 +48,7 @@ const Actions: React.FC = () => {
 			<BulkActions
 				Checkbox={Checkbox}
 				defaultAction={options[0].value}
-				id={'ee-bulk-edit-dates-select-input'}
+				id={'ee-bulk-edit-dates-actions'}
 				onApply={onApply}
 				options={options}
 			/>

--- a/domains/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
@@ -66,7 +66,7 @@ const Actions: React.FC = () => {
 			<BulkActions
 				Checkbox={Checkbox}
 				defaultAction=''
-				id={'ee-bulk-edit-tickets-select-input'}
+				id={'ee-bulk-edit-tickets-actions'}
 				onApply={isEditPricesDisabled ? null : onApply}
 				options={options}
 			/>

--- a/domains/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
@@ -65,9 +65,10 @@ const Actions: React.FC = () => {
 		<>
 			<BulkActions
 				Checkbox={Checkbox}
-				options={options}
-				onApply={isEditPricesDisabled ? null : onApply}
 				defaultAction=''
+				id={'ee-bulk-edit-tickets-select-input'}
+				onApply={isEditPricesDisabled ? null : onApply}
+				options={options}
 			/>
 			{isOpen && (
 				<>

--- a/packages/components/src/CurrencyDisplay/index.tsx
+++ b/packages/components/src/CurrencyDisplay/index.tsx
@@ -16,7 +16,7 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({ value, vertica
 	const currency = config?.currency;
 	const sign = currency?.sign;
 	const signB4 = currency?.signB4;
-	const signOutput = value ? <CurrencySign sign={sign} /> : __('free');
+	const signOutput = <CurrencySign sign={sign} />;
 
 	const characters = getCurrencySignCharacterCountClassName(sign);
 	const position = getCurrencySignPositionClassName(signB4);
@@ -31,9 +31,15 @@ export const CurrencyDisplay: React.FC<CurrencyDisplayProps> = ({ value, vertica
 
 	return (
 		<div className={className}>
-			{signB4 && signOutput}
-			<span>{formatAmount(value)}</span>
-			{!signB4 && signOutput}
+			{value ? (
+				<>
+					{signB4 && signOutput}
+					<span>{formatAmount(value)}</span>
+					{!signB4 && signOutput}
+				</>
+			) : (
+				__('free')
+			)}
 		</div>
 	);
 };

--- a/packages/components/src/bulkEdit/BulkActions.tsx
+++ b/packages/components/src/bulkEdit/BulkActions.tsx
@@ -12,6 +12,7 @@ import './styles.scss';
 export interface BulkActionsProps<T extends string = string> {
 	Checkbox?: React.ComponentType<ActionCheckboxProps>;
 	defaultAction?: T;
+	id?: string;
 	onApply: (action: T) => void;
 	options: SelectProps['options'];
 }
@@ -21,6 +22,7 @@ const rootProps = { className: 'ee-bulk-edit-actions__select-wrapper' };
 export const BulkActions = <T extends string>({
 	Checkbox,
 	defaultAction,
+	id,
 	options,
 	onApply,
 }: BulkActionsProps<T>): JSX.Element => {
@@ -40,7 +42,7 @@ export const BulkActions = <T extends string>({
 			<Select
 				aria-label={__('bulk actions')}
 				className='ee-bulk-edit-actions__select'
-				id='ee-bulk-edit-actions-select-input'
+				id={id || 'ee-bulk-edit-actions-select-input'}
 				label={__('bulk actions')}
 				labelPosition={'top-left' as LabelPosition}
 				onChangeValue={setValue}

--- a/packages/components/src/bulkEdit/BulkActions.tsx
+++ b/packages/components/src/bulkEdit/BulkActions.tsx
@@ -12,7 +12,7 @@ import './styles.scss';
 export interface BulkActionsProps<T extends string = string> {
 	Checkbox?: React.ComponentType<ActionCheckboxProps>;
 	defaultAction?: T;
-	id?: string;
+	id: string;
 	onApply: (action: T) => void;
 	options: SelectProps['options'];
 }
@@ -42,7 +42,7 @@ export const BulkActions = <T extends string>({
 			<Select
 				aria-label={__('bulk actions')}
 				className='ee-bulk-edit-actions__select'
-				id={id || 'ee-bulk-edit-actions-select-input'}
+				id={id}
 				label={__('bulk actions')}
 				labelPosition={'top-left' as LabelPosition}
 				onChangeValue={setValue}

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
@@ -8,9 +8,9 @@ import type { Datetime } from '../../types';
 import { useLazyDatetime } from '../../queries';
 
 export const DATETIME_DEFAULTS: Datetime = {
-	id: `temp:${uuidv4()}`,
+	id: '',
 	dbId: 0,
-	cacheId: uuidv4(),
+	cacheId: '',
 	capacity: -1,
 	description: '',
 	endDate: PLUS_TWO_MONTHS.toISOString(),
@@ -49,6 +49,10 @@ const useOptimisticResponse = (): OptimisticResCb => {
 					espressoDatetime = {
 						...espressoDatetime,
 						...DATETIME_DEFAULTS,
+						// make sure the id is generated on each call to make sure
+						// it is unique for each entity created in bulk
+						id: `temp:${uuidv4()}`,
+						cacheId: uuidv4(),
 						...filteredInput,
 					};
 					break;

--- a/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
@@ -9,9 +9,9 @@ import type { Ticket } from '../../';
 import { useLazyTicket } from '../../queries';
 
 export const TICKET_DEFAULTS: Ticket = {
-	id: `temp:${uuidv4()}`,
+	id: '',
 	dbId: 0,
-	cacheId: uuidv4(),
+	cacheId: '',
 	description: '',
 	endDate: PLUS_TWO_MONTHS.toISOString(),
 	isSoldOut: false,
@@ -57,6 +57,9 @@ const useOptimisticResponse = (): OptimisticResCb => {
 					espressoTicket = {
 						...espressoTicket,
 						...TICKET_DEFAULTS,
+						// make sure the id is generated on each call to make sure
+						// it is unique for each entity created in bulk
+						id: `temp:${uuidv4()}`,
 						...filteredInput,
 						prices: null,
 					};


### PR DESCRIPTION
This PR fixes the console warnings on REM form submit caused due to duplicate temporary GUIDs for optimistic responses. It also fixes the price display for free tickets in tableview. Also there were duplicate ids for select inputs for bulk edit, those are also fixed.

Note: There are some more console warnings that are mostly related to Chakra upgrade. We will revisit those warnings after the upgrade.

Closes #513 