### PR TITLE
Extract Calender components

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 import { __ } from '@eventespresso/i18n';
 
-import { CalendarDateSwitcher, EditDateRangeButton } from '@eventespresso/components';
+import { CalendarDateSwitcher } from '@eventespresso/ee-components';
+import { EditDateRangeButton } from '@eventespresso/components';
 import { getDatetimeStatusTextLabel } from '@eventespresso/helpers';
 import { useDatesListFilterState } from '@eventespresso/edtr-services';
 import { useDatetimeMutator } from '@eventespresso/edtr-services';

--- a/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 import { __ } from '@eventespresso/i18n';
 
-import { CalendarDateSwitcher, EditDateRangeButton } from '@eventespresso/components';
+import { CalendarDateSwitcher } from '@eventespresso/ee-components';
+import { EditDateRangeButton } from '@eventespresso/components';
 import { getTicketStatusTextLabel } from '@eventespresso/helpers';
 import { useTicketMutator, useTicketsListFilterState } from '@eventespresso/edtr-services';
 import { useTimeZoneTime } from '@eventespresso/services';

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -43,7 +43,7 @@ module.exports = {
 							}
 							// TODO use file system to resolve paths
 							const match = path.match(/[\\/]packages[\\/](?<package>[^\\/]+)[\\/]/);
-							if (match && match.groups.package && match.groups.package) {
+							if (match && match.groups && match.groups.package) {
 								const dependency = importSource.split('/')[1];
 								const sourcePkg = match.groups.package;
 

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -1,8 +1,11 @@
 module.exports = [
 	/* LEVEL 1 */ ['constants', 'i18n', 'events', 'ioc', 'toaster'],
 	/* LEVEL 2 */ ['data', 'dates', 'hooks', 'icons', 'registry', 'styles', 'storage', 'utils'],
-	/* LEVEL 3 */ ['adapters', 'rrule-generator', 'rich-text-editor'],
-	/* LEVEL 4 */ ['form', 'predicates', 'services'],
-	/* LEVEL 5 */ ['components', 'edtr-services', 'helpers'],
-	/* LEVEL 6 */ ['tpc'],
+	/* LEVEL 3 */ ['adapters'],
+	/* LEVEL 4 */ ['ui-components'],
+	/* LEVEL 5 */ ['form', 'rrule-generator'],
+	/* LEVEL 6 */ ['predicates', 'services'],
+	/* LEVEL 7 */ ['components'], // TODO remove this level
+	/* LEVEL 7 */ ['ee-components', 'edtr-services', 'helpers'],
+	/* LEVEL 8 */ ['tpc'],
 ];

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -3,7 +3,7 @@ module.exports = [
 	/* LEVEL 2 */ ['data', 'dates', 'hooks', 'icons', 'registry', 'styles', 'storage', 'utils'],
 	/* LEVEL 3 */ ['adapters'],
 	/* LEVEL 4 */ ['ui-components'],
-	/* LEVEL 5 */ ['form', 'rrule-generator'],
+	/* LEVEL 5 */ ['form', 'rrule-generator', 'rich-text-editor'],
 	/* LEVEL 6 */ ['predicates', 'services'],
 	/* LEVEL 7 */ ['components'], // TODO remove this level
 	/* LEVEL 7 */ ['ee-components', 'edtr-services', 'helpers'],

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -3,9 +3,10 @@ module.exports = [
 	/* LEVEL 2 */ ['data', 'dates', 'hooks', 'icons', 'registry', 'styles', 'storage', 'utils'],
 	/* LEVEL 3 */ ['adapters'],
 	/* LEVEL 4 */ ['ui-components'],
-	/* LEVEL 5 */ ['form', 'rrule-generator', 'rich-text-editor'],
-	/* LEVEL 6 */ ['predicates', 'services'],
-	/* LEVEL 7 */ ['components'], // TODO remove this level
-	/* LEVEL 7 */ ['ee-components', 'edtr-services', 'helpers'],
-	/* LEVEL 8 */ ['tpc'],
+	/* LEVEL 5 */ ['rich-text-editor'],
+	/* LEVEL 6 */ ['form', 'rrule-generator'],
+	/* LEVEL 7 */ ['predicates', 'services'],
+	/* LEVEL 8 */ ['components'], // TODO remove this level
+	/* LEVEL 8 */ ['ee-components', 'edtr-services', 'helpers'],
+	/* LEVEL 9 */ ['tpc'],
 ];

--- a/packages/components/src/BiggieCalendarDate/BiggieCalendarDate.tsx
+++ b/packages/components/src/BiggieCalendarDate/BiggieCalendarDate.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback } from 'react';
 import classNames from 'classnames';
-import { parseISO, isValid } from 'date-fns';
+import { parseISO, isValid, format as formatFunc } from 'date-fns';
 
-import { Button } from '../Button';
 import { Calendar } from '@eventespresso/icons';
-
-import { LabelPosition } from '../withLabel';
 import {
 	DAY_ONLY_SHORT_FORMAT,
 	MONTH_ONLY_FULL_FORMAT,
@@ -13,9 +10,10 @@ import {
 	WEEKDAY_ONLY_FULL_FORMAT,
 	YEAR_ONLY_LONG_FORMAT,
 } from '@eventespresso/constants';
-import { useTimeZoneTime } from '@eventespresso/services';
 
-import type { BiggieCalendarDateProps } from './index';
+import { Button } from '../Button';
+import { LabelPosition } from '../withLabel';
+import type { BiggieCalendarDateProps } from './types';
 import './style.scss';
 
 /**
@@ -23,15 +21,15 @@ import './style.scss';
  */
 export const BiggieCalendarDate: React.FC<BiggieCalendarDateProps> = ({
 	date,
-	editButton = {},
+	editButton,
 	footerText,
 	headerText,
 	onEdit = null,
 	showTime = false,
 	timeRange,
+	formatFn: format = formatFunc,
 	...props
 }) => {
-	const { formatForSite: format } = useTimeZoneTime();
 	const onEditHandler = useCallback((event) => onEdit(event), [onEdit]);
 	const dateObject = date instanceof Date ? date : parseISO(date);
 
@@ -46,8 +44,8 @@ export const BiggieCalendarDate: React.FC<BiggieCalendarDateProps> = ({
 			className='ee-edit-calendar-date-btn'
 			onClick={onEditHandler}
 			onKeyPress={onEditHandler}
-			tooltip={editButton.tooltip}
-			labelPosition={editButton.tooltipPosition as LabelPosition}
+			tooltip={editButton?.tooltip}
+			labelPosition={editButton?.tooltipPosition as LabelPosition}
 			icon={Calendar}
 		/>
 	);

--- a/packages/components/src/BiggieCalendarDate/types.ts
+++ b/packages/components/src/BiggieCalendarDate/types.ts
@@ -1,10 +1,6 @@
-import type { CalendarDateProps } from '../types';
+import type { CalendarBaseProps, CalendarDateProps } from '../types';
 
-export interface CommonInputProps<T = Element, V = React.ReactText> {
-	onChangeValue?: (value: V, event?: React.ChangeEvent<T> | React.FormEvent<T>) => void;
-}
-
-export interface BiggieCalendarDateProps extends CalendarDateProps {
+export interface BiggieCalendarDateProps extends CalendarDateProps, CalendarBaseProps {
 	date: Date | string;
 	timeRange?: string;
 }

--- a/packages/components/src/CalendarDateRange/CalendarDateRange.tsx
+++ b/packages/components/src/CalendarDateRange/CalendarDateRange.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import { differenceInCalendarDays, parseISO, isValid } from 'date-fns';
-import { __ } from '@eventespresso/i18n';
+import { differenceInCalendarDays, parseISO, isValid, format as formatFunc } from 'date-fns';
 
-import { useTimeZoneTime } from '@eventespresso/services';
-import { BiggieCalendarDate, MediumCalendarDate } from '../../';
+import { __ } from '@eventespresso/i18n';
 import { TIME_ONLY_12H_SHORT_FORMAT } from '@eventespresso/constants';
 
+import { BiggieCalendarDate, MediumCalendarDate } from '../../';
 import type { CalendarDateRangeProps } from './types';
 import './style.scss';
 
@@ -17,12 +16,11 @@ const CalendarDateRange: React.FC<CalendarDateRangeProps> = ({
 	className = '',
 	endDate,
 	footerText = '',
+	formatFn: format = formatFunc,
 	headerText = '',
 	showTime = true,
 	startDate,
 }) => {
-	const { formatForSite: format } = useTimeZoneTime();
-
 	const startDateObject = startDate instanceof Date ? startDate : parseISO(startDate);
 	const endDateObject = endDate instanceof Date ? endDate : parseISO(endDate);
 

--- a/packages/components/src/CalendarDateRange/types.ts
+++ b/packages/components/src/CalendarDateRange/types.ts
@@ -1,6 +1,6 @@
-import type { CalendarDateProps } from '../types';
+import type { CalendarBaseProps, CalendarDateProps } from '../types';
 
-export interface CalendarDateRangeProps extends CalendarDateProps {
+export interface CalendarDateRangeProps extends CalendarDateProps, CalendarBaseProps {
 	startDate: Date | string;
 	endDate: Date | string;
 }

--- a/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
+++ b/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { parseISO } from 'date-fns';
+import { parseISO, format as formatFunc } from 'date-fns';
 import { __ } from '@eventespresso/i18n';
 
 import { switchTenseForDate } from '@eventespresso/dates';
@@ -11,6 +11,7 @@ import type { CalendarDateSwitcherProps } from './types';
 const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = ({
 	className,
 	displayDate = DisplayStartOrEndDate.start,
+	formatFn = formatFunc,
 	labels,
 	...props
 }) => {
@@ -30,6 +31,7 @@ const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = ({
 			className={className}
 			date={startDate}
 			footerText={footerText}
+			formatFn={formatFn}
 			headerText={headerText || __('starts')}
 			showTime
 		/>
@@ -42,6 +44,7 @@ const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = ({
 					className={className}
 					date={endDate}
 					footerText={footerText}
+					formatFn={formatFn}
 					headerText={headerText || __('ends')}
 					showTime
 				/>
@@ -52,6 +55,7 @@ const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = ({
 					className={className}
 					endDate={endDate}
 					footerText={footerText}
+					formatFn={formatFn}
 					headerText={headerText}
 					showTime
 					startDate={startDate}

--- a/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
+++ b/packages/components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { parseISO, format as formatFunc } from 'date-fns';
+import { parseISO, format } from 'date-fns';
 import { __ } from '@eventespresso/i18n';
 
 import { switchTenseForDate } from '@eventespresso/dates';
@@ -11,7 +11,7 @@ import type { CalendarDateSwitcherProps } from './types';
 const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = ({
 	className,
 	displayDate = DisplayStartOrEndDate.start,
-	formatFn = formatFunc,
+	formatFn = format,
 	labels,
 	...props
 }) => {

--- a/packages/components/src/CalendarDateSwitcher/types.ts
+++ b/packages/components/src/CalendarDateSwitcher/types.ts
@@ -1,3 +1,5 @@
+import { CalendarBaseProps } from '../types';
+
 export interface CalendarDateLabels {
 	header?: string;
 	headerPast?: string;
@@ -7,7 +9,7 @@ export interface CalendarDateLabels {
 	footerFuture?: string;
 }
 
-export interface CalendarDateSwitcherProps {
+export interface CalendarDateSwitcherProps extends CalendarBaseProps {
 	className?: string;
 	displayDate: DisplayStartOrEndDate;
 	endDate: string;

--- a/packages/components/src/CalendarPageDate/CalendarPageDate.tsx
+++ b/packages/components/src/CalendarPageDate/CalendarPageDate.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { parseISO, isValid } from 'date-fns';
+import { parseISO, isValid, format as formatFunc } from 'date-fns';
 
 import { __ } from '@eventespresso/i18n';
-import { useTimeZoneTime } from '@eventespresso/services';
 import {
 	DAY_ONLY_SHORT_FORMAT,
 	MONTH_ONLY_LONG_FORMAT,
 	LOCALIZED_DATE_AND_TIME_FULL_FORMAT,
 } from '@eventespresso/constants';
 
-import { Tooltip } from '../';
+import { Tooltip } from '../Tooltip';
 import { CalendarPageDateProps, CalendarPageSize } from './types';
 import './style.scss';
 
@@ -21,12 +20,11 @@ import './style.scss';
 const CalendarPageDate: React.FC<CalendarPageDateProps> = ({
 	startDate,
 	endDate,
+	formatFn: format = formatFunc,
 	size = CalendarPageSize.SMALL,
 	statusClassName,
 	...otherProps
 }) => {
-	const { formatForSite: format } = useTimeZoneTime();
-
 	const startDateObject = startDate instanceof Date ? startDate : parseISO(startDate);
 	const endDateObject = endDate instanceof Date ? endDate : parseISO(endDate);
 	if (!isValid(startDateObject) && !isValid(endDateObject)) {

--- a/packages/components/src/CalendarPageDate/types.ts
+++ b/packages/components/src/CalendarPageDate/types.ts
@@ -1,3 +1,5 @@
+import { CalendarBaseProps } from '../types';
+
 export enum CalendarPageSize {
 	TINY = 'tiny',
 	SMALL = 'small',
@@ -5,7 +7,7 @@ export enum CalendarPageSize {
 	BIG = 'big',
 }
 
-export interface CalendarPageDateProps {
+export interface CalendarPageDateProps extends CalendarBaseProps {
 	startDate?: Date;
 	endDate?: Date;
 	size?: CalendarPageSize;

--- a/packages/components/src/types.ts
+++ b/packages/components/src/types.ts
@@ -1,5 +1,9 @@
 import React, { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react';
 
+export interface CalendarBaseProps {
+	formatFn?: (date: Date, formatStr: string) => string;
+}
+
 export interface CalendarDateProps {
 	editButton?: EditButtonProps;
 	className?: string;

--- a/packages/ee-components/package.json
+++ b/packages/ee-components/package.json
@@ -1,0 +1,20 @@
+{
+	"author": "Event Espresso",
+	"name": "@eventespresso/ee-components",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/eventespresso/barista.git"
+	},
+	"private": true,
+	"version": "1.0.6",
+	"main": "src/index.ts",
+	"main:src": "src/index.ts",
+	"scripts": {
+		"lint": "eslint ./src/**/*.{ts,tsx} --format=codeframe",
+		"update-deps": "npx ncu -p yarn -u",
+		"lint-fix": "eslint ./src/**/*.{ts,tsx} --fix"
+	},
+	"sideEffects": false,
+	"license": "GPL-3.0",
+	"gitHead": "66fae0230a22c100153cb05f5a624305efc5a8d9"
+}

--- a/packages/ee-components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
+++ b/packages/ee-components/src/CalendarDateSwitcher/CalendarDateSwitcher.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { useTimeZoneTime } from '@eventespresso/services';
+import { CalendarDateSwitcher as CalendarDateSwitcherUI } from '@eventespresso/components';
+
+import type { CalendarDateSwitcherProps } from './types';
+
+const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = (props) => {
+	const { formatForSite } = useTimeZoneTime();
+
+	return <CalendarDateSwitcherUI formatFn={formatForSite} {...props} />;
+};
+
+export default CalendarDateSwitcher;

--- a/packages/ee-components/src/CalendarDateSwitcher/index.ts
+++ b/packages/ee-components/src/CalendarDateSwitcher/index.ts
@@ -1,0 +1,3 @@
+export { default as CalendarDateSwitcher } from './CalendarDateSwitcher';
+
+export * from './types';

--- a/packages/ee-components/src/CalendarDateSwitcher/types.ts
+++ b/packages/ee-components/src/CalendarDateSwitcher/types.ts
@@ -1,0 +1,3 @@
+import { CalendarDateSwitcherProps as CalendarDateSwitcherUIProps } from '@eventespresso/components';
+
+export interface CalendarDateSwitcherProps extends CalendarDateSwitcherUIProps {}

--- a/packages/ee-components/src/index.ts
+++ b/packages/ee-components/src/index.ts
@@ -1,0 +1,1 @@
+export * from './CalendarDateSwitcher';

--- a/packages/ee-components/tsconfig.json
+++ b/packages/ee-components/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
This PR extracts `CalendarDateSwitcher` to `ee-components` and decouples all the Calendar components from `services` package.

See #510 