### PR TITLE
i18n strings not generated sometimes

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -388,7 +388,7 @@ module.exports = function (webpackEnv) {
 								// This is a feature of `babel-loader` for webpack (not Babel itself).
 								// It enables caching results in ./node_modules/.cache/babel-loader/
 								// directory for faster rebuilds.
-								cacheDirectory: true,
+								// cacheDirectory: true,
 								// See #6846 for context on why cacheCompression is disabled
 								cacheCompression: false,
 								compact: isEnvProduction,


### PR DESCRIPTION
This PR disables `cacheDirectory` in `babel-loader` to fix the makpot issue.

Closes #562 