### PR TITLE
Fix isRTL and Next/Previous components

### DIFF
--- a/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/ContentBody.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/multiStep/ContentBody.tsx
@@ -54,7 +54,7 @@ const ContentBody: React.FC = ({ children }) => {
 										isDisabled={isSaveDisabled}
 										// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 										onClick={() => goto(2)}
-										skippable
+										skipsSteps
 									/>
 								</ButtonRow>
 							</>
@@ -82,7 +82,7 @@ const ContentBody: React.FC = ({ children }) => {
 										buttonText={__('Ticket details')}
 										// eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
 										onClick={() => goto(0)}
-										skippable
+										skipsSteps
 									/>
 									<Previous onClick={prev} />
 									<Submit onClick={form.submit} isDisabled={isSubmitDisabled} />

--- a/packages/adapters/src/Button/Button.tsx
+++ b/packages/adapters/src/Button/Button.tsx
@@ -9,7 +9,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		const text = children || buttonText;
 
 		return (
-			<ChakraButton {...props} leftIcon={leftIcon} ref={ref}>
+			<ChakraButton leftIcon={leftIcon} {...props} ref={ref}>
 				{text && <span>{text}</span>}
 			</ChakraButton>
 		);

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -10,7 +10,7 @@ export const TEXT_DOMAIN = 'event_espresso';
 // create i18n instance with translation data and text domain
 const i18n = createI18n(i18nData, TEXT_DOMAIN);
 
-export const { setLocaleData, isRTL } = i18n;
+export const { setLocaleData } = i18n;
 
 export const __ = (text: string): string => {
 	return i18n.__(text, TEXT_DOMAIN);
@@ -27,5 +27,7 @@ export const _nx = (single: string, plural: string, number: number, context: str
 export const _x = (single: string, context: string): string => {
 	return i18n._x(single, context, TEXT_DOMAIN);
 };
+
+export const isRTL = (): boolean => document.documentElement.dir === 'rtl';
 
 export { sprintf } from '@wordpress/i18n';

--- a/packages/ui-components/src/Stepper/buttons/Next.tsx
+++ b/packages/ui-components/src/Stepper/buttons/Next.tsx
@@ -1,17 +1,15 @@
-import { __, isRTL } from '@eventespresso/i18n';
+import { __ } from '@eventespresso/i18n';
 
-import { ChevronDoubleLeft, ChevronDoubleRight, ChevronLeft, ChevronRight } from '@eventespresso/icons';
 import { Button, ButtonType } from '../../../';
+import { StepperButtonProps } from './types';
+import { getStepperIconComponent } from '../utils';
 
-interface Props extends React.ComponentProps<typeof Button> {
-	skippable?: boolean;
-}
-
-const Next: React.FC<Props> = ({ isDisabled, onClick, skippable, ...props }) => {
+const Next: React.FC<StepperButtonProps> = ({ isDisabled, onClick, skipsSteps, ...props }) => {
 	const buttonText = props.buttonText || __('Next');
 	const buttonType = props.buttonType || ButtonType.PRIMARY;
-	const leftIcon = isRTL() && skippable ? <ChevronDoubleLeft size='smaller' /> : <ChevronLeft size='smaller' />;
-	const rightIcon = !isRTL() && skippable ? <ChevronDoubleRight size='smaller' /> : <ChevronRight size='smaller' />;
+
+	const IconComponent = getStepperIconComponent({ skipsSteps });
+	const rightIcon = <IconComponent size='smaller' />;
 
 	return (
 		<Button
@@ -19,7 +17,6 @@ const Next: React.FC<Props> = ({ isDisabled, onClick, skippable, ...props }) => 
 			buttonText={buttonText}
 			buttonType={buttonType}
 			isDisabled={isDisabled}
-			leftIcon={leftIcon}
 			onClick={onClick}
 			rightIcon={rightIcon}
 		/>

--- a/packages/ui-components/src/Stepper/buttons/Previous.tsx
+++ b/packages/ui-components/src/Stepper/buttons/Previous.tsx
@@ -1,15 +1,14 @@
 import { __ } from '@eventespresso/i18n';
 
-import { ChevronDoubleLeft, ChevronLeft } from '@eventespresso/icons';
 import { Button } from '../../../';
+import { getStepperIconComponent } from '../utils';
+import { StepperButtonProps } from './types';
 
-interface Props extends React.ComponentProps<typeof Button> {
-	skippable?: boolean;
-}
-
-const Previous: React.FC<Props> = ({ isDisabled, onClick, skippable, ...props }) => {
+const Previous: React.FC<StepperButtonProps> = ({ isDisabled, onClick, skipsSteps, ...props }) => {
 	const buttonText = props.buttonText || __('Previous');
-	const leftIcon = skippable ? <ChevronDoubleLeft size='smaller' /> : <ChevronLeft size='smaller' />;
+
+	const IconComponent = getStepperIconComponent({ skipsSteps, isNext: false });
+	const leftIcon = <IconComponent size='smaller' />;
 
 	return <Button {...props} buttonText={buttonText} isDisabled={isDisabled} leftIcon={leftIcon} onClick={onClick} />;
 };

--- a/packages/ui-components/src/Stepper/buttons/types.ts
+++ b/packages/ui-components/src/Stepper/buttons/types.ts
@@ -1,0 +1,5 @@
+import { Button } from '../../../';
+
+export interface StepperButtonProps extends React.ComponentProps<typeof Button> {
+	skipsSteps?: boolean;
+}

--- a/packages/ui-components/src/Stepper/utils.ts
+++ b/packages/ui-components/src/Stepper/utils.ts
@@ -1,0 +1,20 @@
+import { isRTL as getRTL } from '@eventespresso/i18n';
+import { ChevronDoubleLeft, ChevronDoubleRight, ChevronLeft, ChevronRight } from '@eventespresso/icons';
+
+export const getStepperIconComponent = ({ skipsSteps = false, isNext = true }): typeof ChevronLeft => {
+	const isRTL = getRTL();
+
+	switch (true) {
+		case isRTL && skipsSteps:
+			return isNext ? ChevronDoubleLeft : ChevronDoubleRight;
+
+		case isRTL && !skipsSteps:
+			return isNext ? ChevronLeft : ChevronRight;
+
+		case !isRTL && skipsSteps:
+			return isNext ? ChevronDoubleRight : ChevronDoubleLeft;
+
+		default:
+			return isNext ? ChevronRight : ChevronLeft;
+	}
+};


### PR DESCRIPTION
This PR fixes the issue with `isRTL` which returned `false` regardless. After thorough investigation, I realized that the actual `isRTL` from `wp.i18n` is not reliable and consistent and completely abstracts the logic for RTL detection.
It also fixes the bug with `Previous` component for which the icon did not work before.

Closes #567 

LTR
![image](https://user-images.githubusercontent.com/18226415/103412818-fc9c1180-4b9c-11eb-8259-c034d3cfd494.png)

RTL
![image](https://user-images.githubusercontent.com/18226415/103412823-0160c580-4b9d-11eb-841b-3e7ea830f6a1.png)
