### PR TITLE
Improve onChange handlers for NumberInput

### DIFF
--- a/packages/adapters/src/NumberInput/NumberInput.tsx
+++ b/packages/adapters/src/NumberInput/NumberInput.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import {
 	NumberInput as ChakraNumberInput,
 	NumberInputField,
@@ -17,14 +18,30 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 	inputFieldProps,
 	inputStepperProps,
 	onChange,
+	onChangeValue,
 	showStepper = true,
 	value,
 	...props
 }) => {
 	const size = inputFieldProps?.size && Number(inputFieldProps?.size);
 
+	const onChangeHandler = useCallback<NumberInputProps['onChange']>(
+		(valueAsString, valueAsNumber) => {
+			onChangeValue?.(valueAsNumber);
+
+			onChange?.(valueAsString, valueAsNumber);
+		},
+		[onChange, onChangeValue]
+	);
+
 	return (
-		<ChakraNumberInput {...props} className={className} isDisabled={isDisabled} onChange={onChange} value={value}>
+		<ChakraNumberInput
+			{...props}
+			className={className}
+			isDisabled={isDisabled}
+			onChange={onChangeHandler}
+			value={value}
+		>
 			<NumberInputField {...inputFieldProps} id={id} size={size} />
 			{showStepper && (
 				<NumberInputStepper {...inputStepperProps}>

--- a/packages/adapters/src/NumberInput/types.ts
+++ b/packages/adapters/src/NumberInput/types.ts
@@ -5,6 +5,8 @@ import type {
 	BoxProps as ChakraBoxProps,
 } from '@chakra-ui/react';
 
+import type { CommonInputProps } from '../types';
+
 type Picked =
 	| 'aria-valuenow'
 	| 'clampValueOnBlur'
@@ -20,7 +22,7 @@ type Picked =
 	| 'step'
 	| 'value';
 
-export interface NumberInputProps extends Pick<ChakraNumberInputProps, Picked> {
+export interface NumberInputProps extends Pick<ChakraNumberInputProps, Picked>, CommonInputProps<HTMLInputElement> {
 	decrementStepperProps?: ChakraBoxProps;
 	inputFieldProps?: ChakraInputProps;
 	inputStepperProps?: ChakraFlexProps;

--- a/packages/form/src/adapters/Number.tsx
+++ b/packages/form/src/adapters/Number.tsx
@@ -2,7 +2,7 @@ import { NumberInput } from '@eventespresso/ui-components';
 import type { FieldRendererProps } from '../types';
 
 const Number: React.FC<FieldRendererProps> = ({ id, input: { onChange, value, ...input }, ...props }) => {
-	return <NumberInput {...props} id={id} inputFieldProps={input} onChange={onChange} value={value} />;
+	return <NumberInput {...props} id={id} inputFieldProps={input} onChangeValue={onChange} value={value} />;
 };
 
 export default Number;

--- a/packages/hooks/src/useOnChange/useOnChange.ts
+++ b/packages/hooks/src/useOnChange/useOnChange.ts
@@ -5,13 +5,9 @@ import type { UseOnChange, UseOnChangeCallback } from './types';
 export const useOnChange = ({ onChange, onChangeValue }: UseOnChange): UseOnChangeCallback => {
 	return useCallback(
 		(event: React.ChangeEvent<HTMLInputElement>) => {
-			if (typeof onChangeValue === 'function') {
-				onChangeValue(event.target.value, event);
-			}
+			onChangeValue?.(event.target.value, event);
 
-			if (typeof onChange === 'function') {
-				onChange(event);
-			}
+			onChange?.(event);
 		},
 		[onChange, onChangeValue]
 	);


### PR DESCRIPTION
This PR fixes the `onChange` handlers for `NumberInput` to make sure a `number` is returned to the consumer instead of a `string`.

Closes #581 