### PR TITLE
Fix validation for DateTimeRangePicker

### DIFF
--- a/packages/ui-components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui-components/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -29,11 +29,7 @@ export const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 	...props
 }) => {
 	const [dates, setDates] = useState(value);
-	const { startDateIsValid, startDateBeforeEndDate, endDateIsValid, endDateAfterStartDate } = useDatePickerValidation(
-		dates[0],
-		dates[1],
-		true
-	);
+	const { startDateBeforeEndDate, endDateAfterStartDate } = useDatePickerValidation(dates[0], dates[1], true);
 
 	const onSave: VoidFunction = useCallback(() => {
 		onChange?.(dates);
@@ -46,7 +42,7 @@ export const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 		'ee-input-base-wrapper'
 	);
 
-	const isDisabled = !startDateIsValid || !endDateIsValid;
+	const isDisabled = !startDateBeforeEndDate || !endDateAfterStartDate;
 
 	const startDateTZ = TimezoneTimeInfo && <TimezoneTimeInfo date={dates[0]} />;
 


### PR DESCRIPTION
This PR fixes the validation for the said component to allow the dates in the past.

Closes #577 