### PR TITLE
Centralize normalization of mutation inputs

### DIFF
--- a/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { OperationVariables } from 'apollo-client';
+import type { OperationVariables } from 'apollo-client';
 
 import type { MutationType, MutationInput } from '@eventespresso/data';
 import { KeysOfType, normalizeNumericFields } from '@eventespresso/utils';

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
@@ -1,10 +1,21 @@
 import { useCallback } from 'react';
 import { OperationVariables } from 'apollo-client';
 
-import { MutationType, MutationInput } from '@eventespresso/data';
+import type { MutationType, MutationInput } from '@eventespresso/data';
+import { KeysOfType, normalizeNumericFields } from '@eventespresso/utils';
+
 import { useEventId } from '../../queries/events';
+import { DatetimeBaseInput } from './types';
 
 type MutationVariablesCb = (mutationType: MutationType, input: MutationInput) => OperationVariables;
+
+const numericFields: Array<KeysOfType<DatetimeBaseInput, number>> = [
+	'capacity',
+	'eventId',
+	'order',
+	'reserved',
+	'sold',
+];
 
 const useMutationVariables = (): MutationVariablesCb => {
 	const eventId = useEventId();
@@ -20,8 +31,11 @@ const useMutationVariables = (): MutationVariablesCb => {
 				mutationInput.eventId = eventId; // required for createDatetime
 			}
 
+			// normalize numeric fields
+			const normalizedInput = normalizeNumericFields(numericFields, mutationInput);
+
 			return {
-				input: mutationInput,
+				input: normalizedInput,
 			};
 		},
 		[eventId]

--- a/packages/edtr-services/src/apollo/mutations/prices/useMutationHandler.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/useMutationHandler.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
-import { OperationVariables } from 'apollo-client';
 
+import useMutationVariables from './useMutationVariables';
 import useOnCreatePrice from './useOnCreatePrice';
 import useOnDeletePrice from './useOnDeletePrice';
 import useOnUpdatePrice from './useOnUpdatePrice';
 import type { MutationHandler, MutationUpdater } from '../types';
-import { MutationType, MutationInput } from '@eventespresso/data';
+import { MutationType } from '@eventespresso/data';
 import { PricesList, Price } from '../../';
 import { DEFAULT_PRICE_LIST_DATA as DEFAULT_LIST_DATA, usePriceQueryOptions } from '../../queries';
 import type { PriceCommonInput } from './types';
@@ -18,17 +18,7 @@ const useMutationHandler = (): MH => {
 	const onCreatePrice = useOnCreatePrice();
 	const onUpdatePrice = useOnUpdatePrice();
 	const onDeletePrice = useOnDeletePrice();
-
-	const createVariables = useCallback((mutationType: MutationType, input: MutationInput): OperationVariables => {
-		const mutationInput: MutationInput = {
-			clientMutationId: `${mutationType}_PRICE`,
-			...input,
-		};
-
-		return {
-			input: mutationInput,
-		};
-	}, []);
+	const getMutationVariables = useMutationVariables();
 
 	const onUpdate = useCallback<MutationUpdater<Price, PriceCommonInput>>(
 		({ cache, entity: price, input, mutationType }) => {
@@ -59,11 +49,11 @@ const useMutationHandler = (): MH => {
 
 	const mutator = useCallback<MH>(
 		(mutationType, input) => {
-			const variables = createVariables(mutationType, input);
+			const variables = getMutationVariables(mutationType, input);
 
 			return { variables, onUpdate };
 		},
-		[createVariables, onUpdate]
+		[getMutationVariables, onUpdate]
 	);
 
 	return mutator;

--- a/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { OperationVariables } from 'apollo-client';
+import type { OperationVariables } from 'apollo-client';
 
 import type { MutationType, MutationInput } from '@eventespresso/data';
 import { KeysOfType, normalizeNumericFields } from '@eventespresso/utils';

--- a/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
@@ -4,27 +4,16 @@ import { OperationVariables } from 'apollo-client';
 import type { MutationType, MutationInput } from '@eventespresso/data';
 import { KeysOfType, normalizeNumericFields } from '@eventespresso/utils';
 
-import { TicketBaseInput } from './types';
+import { PriceBaseInput } from './types';
 
 type MutationVariablesCb = (mutationType: MutationType, input: MutationInput) => OperationVariables;
 
-const numericFields: Array<KeysOfType<TicketBaseInput, number>> = [
-	'max',
-	'min',
-	'order',
-	'price',
-	'quantity',
-	'reserved',
-	'row',
-	'sold',
-	'uses',
-	'wpUser',
-];
+const numericFields: Array<KeysOfType<PriceBaseInput, number>> = ['amount', 'order', 'overrides', 'wpUser'];
 
 const useMutationVariables = (): MutationVariablesCb => {
 	return useCallback<MutationVariablesCb>((mutationType, input) => {
 		const mutationInput: MutationInput = {
-			clientMutationId: `${mutationType}_TICKET`,
+			clientMutationId: `${mutationType}_PRICE`,
 			...input,
 		};
 

--- a/packages/edtr-services/src/apollo/mutations/tickets/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useMutationVariables.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { OperationVariables } from 'apollo-client';
+import type { OperationVariables } from 'apollo-client';
 
 import type { MutationType, MutationInput } from '@eventespresso/data';
 import { KeysOfType, normalizeNumericFields } from '@eventespresso/utils';

--- a/packages/tpc/src/fields/TicketPriceField.tsx
+++ b/packages/tpc/src/fields/TicketPriceField.tsx
@@ -19,7 +19,9 @@ const TicketPriceField: React.FC<TicketPriceFieldProps> = (props) => {
 
 	const parse: BFP['parse'] = useCallback((price) => parsedAmount(price), []);
 
-	const setValue: BFP['setValue'] = useCallback((value) => updateTicketPrice(value), [updateTicketPrice]);
+	const setValue: BFP['setValue'] = useCallback((value) => updateTicketPrice(parsedAmount(value)), [
+		updateTicketPrice,
+	]);
 
 	return (
 		<MoneyInputWithConfig disabled={props.disabled}>

--- a/packages/utils/src/predicates/index.ts
+++ b/packages/utils/src/predicates/index.ts
@@ -1,1 +1,18 @@
-export { default as removeNullAndUndefined } from './removeNullAndUndefined';
+import { clone, compose, filter, has, isNil, not } from 'ramda';
+
+import { AnyObject } from '../types';
+
+export const removeNullAndUndefined = <T>(filterable: AnyObject<T>): AnyObject<T> => {
+	return filter<T>(compose(not, isNil), filterable);
+};
+
+export const normalizeNumericFields = (numericFields: Array<string>, object: AnyObject) => {
+	const output = clone(object);
+
+	for (const field of numericFields) {
+		if (has(field, output)) {
+			output[field] = Number(output[field]);
+		}
+	}
+	return output;
+};

--- a/packages/utils/src/predicates/removeNullAndUndefined/index.ts
+++ b/packages/utils/src/predicates/removeNullAndUndefined/index.ts
@@ -1,7 +1,0 @@
-import { filter, compose, not, isNil } from 'ramda';
-
-type Obj = { [key: string]: any };
-
-const removeNullAndUndefined = <T>(filterable: T[] | Obj): T[] | Obj => filter(compose(not, isNil), filterable);
-
-export default removeNullAndUndefined;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -19,3 +19,7 @@ export interface Disclosure {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 export type OmitFirstFromArray<T extends any[]> = T extends [infer A, ...infer R] ? R : never;
+
+export type KeysOfType<Obj, Type> = {
+	[K in keyof Obj]: Obj[K] extends Type ? K : never;
+}[keyof Obj];


### PR DESCRIPTION
This PR centralizes normalization of mutation inputs to make sure that numeric fields are parsed as numbers before being sent to the server.

Closes #591 