### PR TITLE
Soften TAM Error Messages

### DIFF
--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/ErrorMessage.tsx
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/ErrorMessage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 import { __ } from '@eventespresso/i18n';
 
 import { Banner } from '@eventespresso/ui-components';
@@ -11,27 +12,27 @@ interface ErrorMessageProps {
 const ErrorMessage: React.FC<ErrorMessageProps> = ({ asAlert = true, dataState }) => {
 	const { hasOrphanDates, hasOrphanTickets } = dataState;
 
-	let errorMessage = null;
+	let message = '';
 
 	if (hasOrphanTickets()) {
-		errorMessage = __(
-			'Tickets must always have at least one date assigned to them but one or more of the tickets below does not have any. Please correct the assignments for the highlighted cells.'
+		message = __(
+			'Tickets must always have at least one date assigned to them but one or more of the tickets below does not have any. \nPlease correct the assignments for the highlighted cells.'
 		);
 	} else if (hasOrphanDates()) {
-		errorMessage = __(
-			'Event Dates must always have at least one Ticket assigned to them but one or more of the Event Dates below does not have any. Please correct the assignments for the highlighted cells.'
+		message = __(
+			'Event Dates must always have at least one Ticket assigned to them but one or more of the Event Dates below does not have any. \nPlease correct the assignments for the highlighted cells.'
 		);
 	}
 
-	if (!errorMessage) {
+	if (!message) {
 		return null;
 	}
 
 	if (asAlert) {
-		return <Banner description={errorMessage} status='error' title={__('Error')} />;
+		return <Banner description={message} status={'info'} title={__('Please Update Assignments')} />;
 	}
 
-	return errorMessage;
+	return <span>{message}</span>;
 };
 
 export default ErrorMessage;

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/table/getRelationIcon/styles.scss
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/table/getRelationIcon/styles.scss
@@ -3,9 +3,11 @@
 .ee-ticket-assignments-manager {
 	.ee-legend-item dt,
 	.ee-tam-relation-btn {
-		border-radius: var(--ee-border-radius-default);
 		background-color: var(--ee-color-grey-14);
 		border-color: var(--ee-color-grey-14);
+		border-radius: var(--ee-border-radius-default);
+		border-style: solid;
+		border-width: var(--ee-border-width);
 		cursor: pointer;
 		padding: 0;
 
@@ -38,6 +40,8 @@
 		.ee-tam-relation-btn {
 			background-color: var(--ee-color-accent);
 			border-color: var(--ee-color-accent);
+
+			@extend .ee-error-pulse;
 
 			&:focus {
 				border-color: var(--ee-color-accent-high-contrast);

--- a/packages/styles/src/_effects.scss
+++ b/packages/styles/src/_effects.scss
@@ -22,6 +22,23 @@ $animation: (
 	}
 }
 
+@keyframes ee-error-pulse {
+	0% {
+		background-color: var(--ee-color-accent-low-contrast);
+	}
+	50% {
+		background-color: var(--ee-color-accent-high-contrast);
+	}
+	100% {
+		background-color: var(--ee-color-accent-low-contrast);
+	}
+}
+
+.ee-error-pulse {
+	animation: ee-error-pulse 3s infinite;
+	@include reduce-motion('animation');
+}
+
 @keyframes ee-fade-in-opacity {
 	0% {
 		opacity: 0;

--- a/packages/styles/src/variables/_base-colors.scss
+++ b/packages/styles/src/variables/_base-colors.scss
@@ -96,13 +96,13 @@ $dark-green: (
 );
 
 $hot-pink: (
-	default: #de5882,
+	default: #be3862,
 	super-high-contrast: #9e1842,
-	high-contrast: #be3862,
-	low-contrast: #fe78a2,
-	super-low-contrast: #ff98c2,
+	high-contrast: #ae2852,
+	low-contrast: #ce4872,
+	super-low-contrast: #de5882,
 	text-on: $white,
-	text-on-super-high-contrast: #ffecff,
+	text-on-super-high-contrast: $white,
 	text-on-high-contrast: $white,
 	text-on-low-contrast: #3d0000,
 	text-on-super-low-contrast: #5e0021,

--- a/packages/styles/src/variables/_colors.scss
+++ b/packages/styles/src/variables/_colors.scss
@@ -3,7 +3,7 @@
 @import '../functions';
 @import 'base-colors';
 
-$accent: map.get($hot-pink, 'high-contrast') !default;
+$accent: map.get($hot-pink, 'default') !default;
 $primary: map.get($blue, 'default') !default;
 $secondary: map.get($green, 'default') !default;
 
@@ -37,9 +37,9 @@ $primary-colors: (
 $secondary-colors: (
 	default: $secondary,
 	super-high-contrast: map.get($green, 'super-high-contrast'),
-	secondary-high-contrast: map.get($green, 'high-contrast'),
-	secondary-low-contrast: map.get($green, 'low-contrast'),
-	secondary-super-low-contrast: map.get($green, 'super-low-contrast'),
+	high-contrast: map.get($green, 'high-contrast'),
+	low-contrast: map.get($green, 'low-contrast'),
+	super-low-contrast: map.get($green, 'super-low-contrast'),
 	text-on: map.get($green, 'text-on'),
 	text-on-super-high-contrast: map.get($green, 'text-on-super-high-contrast'),
 	text-on-high-contrast: map.get($green, 'text-on-high-contrast'),

--- a/packages/ui-components/src/Banner/style.scss
+++ b/packages/ui-components/src/Banner/style.scss
@@ -38,6 +38,7 @@
 			color: var(--ee-default-text-color);
 			font-size: var(--ee-font-size-default);
 			margin-bottom: var(--ee-margin-small);
+			white-space: break-spaces;
 		}
 	}
 }


### PR DESCRIPTION
closes #597

This PR:

- changes the TAM notifications for missing assignments to info alerts instead of error alerts
- changes the label from "Error" to "Please Update Assignments"
- adds a background color pulse effect for "errors"
- fixes some of the css var names and values for colors 