### PR TITLE
Color picker component

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -25,6 +25,7 @@
 		"framer-motion": "^3.1.1",
 		"rc-pagination": "^3.1.3",
 		"react-beautiful-dnd": "^13.0.0",
+		"react-colorful": "^4.4.4",
 		"react-dotdotdot": "^1.3.1"
 	},
 	"license": "GPL-3.0",

--- a/packages/adapters/src/ColorPicker/ColorPicker.tsx
+++ b/packages/adapters/src/ColorPicker/ColorPicker.tsx
@@ -1,0 +1,11 @@
+import { HexColorPicker } from 'react-colorful';
+import classNames from 'classnames';
+import 'react-colorful/dist/index.css';
+
+import { ColorPickerProps } from './types';
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, ...props }) => {
+	const className = classNames('ee-color-picker', props.className);
+
+	return <HexColorPicker className={className} color={color} onChange={onChange} />;
+};

--- a/packages/adapters/src/ColorPicker/index.ts
+++ b/packages/adapters/src/ColorPicker/index.ts
@@ -1,0 +1,2 @@
+export * from './ColorPicker';
+export * from './types';

--- a/packages/adapters/src/ColorPicker/types.ts
+++ b/packages/adapters/src/ColorPicker/types.ts
@@ -1,0 +1,5 @@
+export interface ColorPickerProps {
+	className?: string;
+	color?: string;
+	onChange: (color: string) => void;
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -5,6 +5,7 @@ export * from './Button';
 export * from './Checkbox';
 export * from './CheckboxGroup';
 export * from './Collapse';
+export * from './ColorPicker';
 export * from './Divider';
 export * from './dnd';
 export * from './Dotdotdot';

--- a/packages/ui-components/src/ColorPicker/ColorPicker.tsx
+++ b/packages/ui-components/src/ColorPicker/ColorPicker.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 
+import { __ } from '@eventespresso/i18n';
 import { ColorPicker as ColorPickerAdapter } from '@eventespresso/adapters';
 import { useIfMounted } from '@eventespresso/hooks';
 
+import { Button, ButtonType } from '../Button';
 import { ColorSwatches } from './ColorSwatches';
 import { ColorPickerProps } from './types';
 import { BLACK_COLOR } from './constants';
@@ -14,6 +16,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, defaultColor, o
 	const className = classNames('ee-color-picker', props.className);
 
 	const [internalValue, setInternalValue] = useState(defaultColor || BLACK_COLOR);
+	const [showCustomColor, setShowCustomColor] = useState(false);
 
 	const onChangeColor = useCallback<ColorPickerProps['onChange']>(
 		(newValue) => {
@@ -36,10 +39,26 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, defaultColor, o
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [color]);
 
+	const onClickCustomColor = useCallback(() => setShowCustomColor(true), []);
+
 	return (
 		<div className={className}>
 			<ColorSwatches color={internalValue} onChange={onChangeColor} className='ee-color-picker__swatches' />
-			<ColorPickerAdapter className='ee-color-picker__control' color={internalValue} onChange={onChangeColor} />
+
+			{showCustomColor ? (
+				<ColorPickerAdapter
+					className='ee-color-picker__control'
+					color={internalValue}
+					onChange={onChangeColor}
+				/>
+			) : (
+				<Button
+					buttonText={__('Custom color')}
+					buttonType={ButtonType.MINIMAL}
+					onClick={onClickCustomColor}
+					size='small'
+				/>
+			)}
 		</div>
 	);
 };

--- a/packages/ui-components/src/ColorPicker/ColorPicker.tsx
+++ b/packages/ui-components/src/ColorPicker/ColorPicker.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+import classNames from 'classnames';
+
+import { ColorPicker as ColorPickerAdapter } from '@eventespresso/adapters';
+import { useIfMounted } from '@eventespresso/hooks';
+
+import { ColorSwatches } from './ColorSwatches';
+import { ColorPickerProps } from './types';
+import { BLACK_COLOR } from './constants';
+
+import './color-picker.scss';
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({ color, defaultColor, onChange, ...props }) => {
+	const className = classNames('ee-color-picker', props.className);
+
+	const [internalValue, setInternalValue] = useState(defaultColor || BLACK_COLOR);
+
+	const onChangeColor = useCallback<ColorPickerProps['onChange']>(
+		(newValue) => {
+			if (newValue !== internalValue) {
+				onChange?.(newValue);
+				setInternalValue(newValue);
+			}
+		},
+		[internalValue, onChange]
+	);
+
+	const ifMounted = useIfMounted();
+	// if the value changes from the consumer
+	useEffect(() => {
+		ifMounted(() => {
+			if (typeof color !== 'undefined') {
+				setInternalValue(color);
+			}
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [color]);
+
+	return (
+		<div className={className}>
+			<ColorSwatches color={internalValue} onChange={onChangeColor} className='ee-color-picker__swatches' />
+			<ColorPickerAdapter className='ee-color-picker__control' color={internalValue} onChange={onChangeColor} />
+		</div>
+	);
+};

--- a/packages/ui-components/src/ColorPicker/ColorSwatches.tsx
+++ b/packages/ui-components/src/ColorPicker/ColorSwatches.tsx
@@ -1,0 +1,27 @@
+import classNames from 'classnames';
+
+import Swatch from './Swatch';
+import { ColorPickerProps } from './types';
+import { PRESET_COLORS } from './constants';
+
+import './swatches.scss';
+
+export const ColorSwatches: React.FC<ColorPickerProps> = ({ color, onChange, ...props }) => {
+	const className = classNames('ee-color-swatches', props.className);
+
+	return (
+		<div className={className}>
+			{PRESET_COLORS.map(({ name, color: presetColor }) => {
+				return (
+					<Swatch
+						color={presetColor}
+						isSelected={color === presetColor}
+						key={presetColor}
+						name={name}
+						onSelect={onChange}
+					/>
+				);
+			})}
+		</div>
+	);
+};

--- a/packages/ui-components/src/ColorPicker/Swatch.tsx
+++ b/packages/ui-components/src/ColorPicker/Swatch.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from 'react';
+import classNames from 'classnames';
+
+import { sprintf, __ } from '@eventespresso/i18n';
+
+import { SwatchProps } from './types';
+
+const Swatch: React.FC<SwatchProps> = ({ color, onSelect, isSelected, name, ...props }) => {
+	const className = classNames('ee-color-swatches__swatch', props.className, { 'is-selected': isSelected });
+
+	const style = useMemo(() => ({ background: color }), [color]);
+
+	const onClick = useCallback(() => onSelect(color), [onSelect, color]);
+
+	const ariaLabel = sprintf(/* translators: color name */ __('Color: %s'), name);
+
+	return (
+		<button
+			{...props}
+			aria-label={ariaLabel}
+			aria-pressed={isSelected}
+			className={className}
+			style={style}
+			onClick={onClick}
+		/>
+	);
+};
+
+export default Swatch;

--- a/packages/ui-components/src/ColorPicker/Swatch.tsx
+++ b/packages/ui-components/src/ColorPicker/Swatch.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import classNames from 'classnames';
 
 import { sprintf, __ } from '@eventespresso/i18n';
+import { Button } from '../Button';
 
 import { SwatchProps } from './types';
 
@@ -15,13 +16,13 @@ const Swatch: React.FC<SwatchProps> = ({ color, onSelect, isSelected, name, ...p
 	const ariaLabel = sprintf(/* translators: color name */ __('Color: %s'), name);
 
 	return (
-		<button
+		<Button
 			{...props}
 			aria-label={ariaLabel}
 			aria-pressed={isSelected}
 			className={className}
-			style={style}
 			onClick={onClick}
+			style={style}
 		/>
 	);
 };

--- a/packages/ui-components/src/ColorPicker/Swatch.tsx
+++ b/packages/ui-components/src/ColorPicker/Swatch.tsx
@@ -7,7 +7,11 @@ import { Button } from '../Button';
 import { SwatchProps } from './types';
 
 const Swatch: React.FC<SwatchProps> = ({ color, onSelect, isSelected, name, ...props }) => {
-	const className = classNames('ee-color-swatches__swatch', props.className, { 'is-selected': isSelected });
+	const className = classNames(
+		'ee-color-swatches__swatch',
+		isSelected && 'ee-color-swatches__swatch--is-selected',
+		props.className
+	);
 
 	const style = useMemo(() => ({ background: color }), [color]);
 

--- a/packages/ui-components/src/ColorPicker/color-picker.scss
+++ b/packages/ui-components/src/ColorPicker/color-picker.scss
@@ -1,3 +1,6 @@
 .ee-color-picker {
 	width: 200px;
+	.ee-color-swatches {
+		margin-bottom: var(--ee-margin-small);
+	}
 }

--- a/packages/ui-components/src/ColorPicker/color-picker.scss
+++ b/packages/ui-components/src/ColorPicker/color-picker.scss
@@ -1,0 +1,3 @@
+.ee-color-picker {
+	width: 200px;
+}

--- a/packages/ui-components/src/ColorPicker/constants.ts
+++ b/packages/ui-components/src/ColorPicker/constants.ts
@@ -4,6 +4,9 @@ import { PresetColor } from './types';
 
 export const BLACK_COLOR = '#000000';
 
+/**
+ * Copied from @wordpress/block-editor
+ */
 export const PRESET_COLORS: Array<PresetColor> = [
 	{
 		name: __('Black'),

--- a/packages/ui-components/src/ColorPicker/constants.ts
+++ b/packages/ui-components/src/ColorPicker/constants.ts
@@ -1,0 +1,56 @@
+import { __ } from '@eventespresso/i18n';
+
+import { PresetColor } from './types';
+
+export const BLACK_COLOR = '#000000';
+
+export const PRESET_COLORS: Array<PresetColor> = [
+	{
+		name: __('Black'),
+		color: BLACK_COLOR,
+	},
+	{
+		name: __('Cyan bluish gray'),
+		color: '#abb8c3',
+	},
+	{
+		name: __('White'),
+		color: '#ffffff',
+	},
+	{
+		name: __('Pale pink'),
+		color: '#f78da7',
+	},
+	{
+		name: __('Vivid red'),
+		color: '#cf2e2e',
+	},
+	{
+		name: __('Luminous vivid orange'),
+		color: '#ff6900',
+	},
+	{
+		name: __('Luminous vivid amber'),
+		color: '#fcb900',
+	},
+	{
+		name: __('Light green cyan'),
+		color: '#7bdcb5',
+	},
+	{
+		name: __('Vivid green cyan'),
+		color: '#00d084',
+	},
+	{
+		name: __('Pale cyan blue'),
+		color: '#8ed1fc',
+	},
+	{
+		name: __('Vivid cyan blue'),
+		color: '#0693e3',
+	},
+	{
+		name: __('Vivid purple'),
+		color: '#9b51e0',
+	},
+];

--- a/packages/ui-components/src/ColorPicker/index.stories.tsx
+++ b/packages/ui-components/src/ColorPicker/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Story, Meta } from '@storybook/react/types-6-0';
+
+import { ColorPicker } from './ColorPicker';
+import type { ColorPickerProps } from '@eventespresso/adapters';
+
+export default {
+	argTypes: {},
+	component: ColorPicker,
+	title: 'Components/ColorPicker',
+} as Meta;
+
+type ColorPickerStory = Story<ColorPickerProps>;
+
+const Template: ColorPickerStory = (args) => <ColorPicker {...args} />;
+
+export const Basic: ColorPickerStory = Template.bind({});

--- a/packages/ui-components/src/ColorPicker/index.ts
+++ b/packages/ui-components/src/ColorPicker/index.ts
@@ -1,0 +1,1 @@
+export * from './ColorPicker';

--- a/packages/ui-components/src/ColorPicker/swatches.scss
+++ b/packages/ui-components/src/ColorPicker/swatches.scss
@@ -5,7 +5,7 @@
 
 	&__swatch {
 		margin: var(--ee-margin-micro) !important;
-		// padding: 0px !important;
+		padding: 0px !important;
 		height: var(--ee-font-size-bigger) !important;
 		width: var(--ee-font-size-bigger) !important;
 	}

--- a/packages/ui-components/src/ColorPicker/swatches.scss
+++ b/packages/ui-components/src/ColorPicker/swatches.scss
@@ -5,11 +5,9 @@
 	margin-bottom: var(--ee-margin-small);
 
 	&__swatch {
-		margin: var(--ee-margin-micro);
-		border: 0.5px solid var(--ee-border-color);
-		border-radius: var(--ee-border-radius-small);
-		height: var(--ee-font-size-bigger);
-		width: var(--ee-font-size-bigger);
-		cursor: pointer;
+		margin: var(--ee-margin-micro) !important;
+		padding: 0px !important;
+		height: var(--ee-font-size-bigger) !important;
+		width: var(--ee-font-size-bigger) !important;
 	}
 }

--- a/packages/ui-components/src/ColorPicker/swatches.scss
+++ b/packages/ui-components/src/ColorPicker/swatches.scss
@@ -1,0 +1,15 @@
+.ee-color-swatches {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin-bottom: var(--ee-margin-small);
+
+	&__swatch {
+		margin: var(--ee-margin-micro);
+		border: 0.5px solid var(--ee-border-color);
+		border-radius: var(--ee-border-radius-small);
+		height: var(--ee-font-size-bigger);
+		width: var(--ee-font-size-bigger);
+		cursor: pointer;
+	}
+}

--- a/packages/ui-components/src/ColorPicker/swatches.scss
+++ b/packages/ui-components/src/ColorPicker/swatches.scss
@@ -2,11 +2,10 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	margin-bottom: var(--ee-margin-small);
 
 	&__swatch {
 		margin: var(--ee-margin-micro) !important;
-		padding: 0px !important;
+		// padding: 0px !important;
 		height: var(--ee-font-size-bigger) !important;
 		width: var(--ee-font-size-bigger) !important;
 	}

--- a/packages/ui-components/src/ColorPicker/types.ts
+++ b/packages/ui-components/src/ColorPicker/types.ts
@@ -1,0 +1,18 @@
+import type { ButtonHTMLAttributes } from 'react';
+import type { ColorPickerProps as ColorPickerAdapterProps } from '@eventespresso/adapters';
+
+export interface ColorPickerProps extends ColorPickerAdapterProps {
+	defaultColor?: string;
+}
+
+export interface SwatchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onSelect'> {
+	className?: string;
+	color?: string;
+	isSelected?: boolean;
+	onSelect: (color: string) => void;
+}
+
+export type PresetColor = {
+	name: string;
+	color: string;
+};

--- a/packages/ui-components/src/ColorPicker/types.ts
+++ b/packages/ui-components/src/ColorPicker/types.ts
@@ -1,11 +1,11 @@
-import type { ButtonHTMLAttributes } from 'react';
 import type { ColorPickerProps as ColorPickerAdapterProps } from '@eventespresso/adapters';
+import type { ButtonProps } from '../Button';
 
 export interface ColorPickerProps extends ColorPickerAdapterProps {
 	defaultColor?: string;
 }
 
-export interface SwatchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onSelect'> {
+export interface SwatchProps extends Omit<ButtonProps, 'onSelect'> {
 	className?: string;
 	color?: string;
 	isSelected?: boolean;

--- a/packages/ui-components/src/ColorPicker/types.ts
+++ b/packages/ui-components/src/ColorPicker/types.ts
@@ -9,7 +9,7 @@ export interface SwatchProps extends Omit<ButtonProps, 'onSelect'> {
 	className?: string;
 	color?: string;
 	isSelected?: boolean;
-	onSelect: (color: string) => void;
+	onSelect?: (color: string) => void;
 }
 
 export type PresetColor = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17538,6 +17538,11 @@ react-color@^2.17.0:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
+react-colorful@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-4.4.4.tgz#38e7c5b7075bbf63d3cce22d8c61a439a58b7561"
+  integrity sha512-01V2/6rr6sa1vaZntWZJXZxnU7ew02NG2rqq0eoVp4d3gFU5Ug9lDzNMbr+8ns0byXsJbBR8LbwQTlAjz6x7Kg==
+
 react-datepicker@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-3.3.0.tgz#38dec531fd7c8e0de6860a55dfbc3a8ff803d43c"


### PR DESCRIPTION
This PR adds the brand new `ColorPicker` component by creating an adapter for `react-colorful`.

The color picker is needed for RTE, See #561 


DEMO
![demo](https://user-images.githubusercontent.com/18226415/104597326-325ff080-569b-11eb-8207-ed629c8c6994.gif)

