### PR TITLE
Reinstate Prev RTE

### DIFF
--- a/packages/rich-text-editor/src/components/index.stories.tsx
+++ b/packages/rich-text-editor/src/components/index.stories.tsx
@@ -1,17 +1,16 @@
 import type { Story, Meta } from '@storybook/react/types-6-0';
 
-import { noop } from '../../../utils';
 import { AdvancedTextEditor, RichTextEditor, SimpleTextEditor } from './';
 import type { RichTextEditorProps } from './RichTextEditor';
 
 export default {
 	argTypes: {},
 	component: RichTextEditor,
-	title: 'Components/RichTextEditor',
+	title: 'Components/RichTextEditor_Exp',
 } as Meta;
 
 type RTEStory = Story<RichTextEditorProps>;
 
-export const Simple: RTEStory = () => <SimpleTextEditor onChange={noop} />;
+export const Simple: RTEStory = () => <SimpleTextEditor onChange={console.log} />;
 
-export const Advanced: RTEStory = () => <AdvancedTextEditor onChange={noop} toolbar={null} />;
+export const Advanced: RTEStory = () => <AdvancedTextEditor onChange={console.log} toolbar={null} />;

--- a/packages/rich-text-editor/src/index.ts
+++ b/packages/rich-text-editor/src/index.ts
@@ -1,3 +1,4 @@
-export * from './components';
-export * from './hooks';
-export * from './utils';
+// export * from './components';
+// export * from './hooks';
+// export * from './utils';
+export * from './rte-old';

--- a/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/AdvancedTextEditor.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/AdvancedTextEditor.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames';
+
+import { RTEWithEditMode } from '../RTEWithEditMode';
+import { AdvancedTextEditorProps } from './types';
+import { toolbar } from './toolbar';
+import toolbarButtons from '../toolbarButtons';
+
+export const AdvancedTextEditor: React.FC<AdvancedTextEditorProps> = (props) => {
+	const wrapperClassName = classNames('ee-advanced-text-editor', props.wrapperClassName);
+
+	return (
+		<RTEWithEditMode
+			{...props}
+			wrapperClassName={wrapperClassName}
+			toolbarCustomButtons={toolbarButtons}
+			toolbar={toolbar}
+		/>
+	);
+};

--- a/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/index.ts
+++ b/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/index.ts
@@ -1,0 +1,2 @@
+export * from './AdvancedTextEditor';
+export * from './types';

--- a/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/toolbar.ts
+++ b/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/toolbar.ts
@@ -1,0 +1,17 @@
+export const toolbar = {
+	options: [
+		'inline',
+		'blockType',
+		'fontSize',
+		'fontFamily',
+		'list',
+		'textAlign',
+		'colorPicker',
+		'link',
+		'embedded',
+		'emoji',
+		// 'image', disable image in favor of WP Media
+		'remove',
+		'history',
+	],
+};

--- a/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/types.ts
+++ b/packages/rich-text-editor/src/rte-old/components/AdvancedTextEditor/types.ts
@@ -1,0 +1,3 @@
+import { RTEWithEditModeProps } from '../RTEWithEditMode';
+
+export interface AdvancedTextEditorProps extends RTEWithEditModeProps {}

--- a/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/RTEWithEditMode.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/RTEWithEditMode.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+
+import { __ } from '@eventespresso/i18n';
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from '@eventespresso/adapters';
+import { Textarea } from '@eventespresso/ui-components';
+
+import { RTEWithEditModeProps } from './types';
+import { RichTextEditor } from '../RichTextEditor';
+
+import './style.scss';
+
+export const RTEWithEditMode: React.FC<RTEWithEditModeProps> = ({ enableEditMode = true, ...props }) => {
+	const editor = <RichTextEditor {...props} />;
+
+	const { defaultValue, onChange, onChangeValue, placeholder, value } = props;
+
+	const onChangeHandler = useCallback(
+		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+			const html = e.target.value;
+			onChange?.(html);
+			onChangeValue?.(html);
+		},
+		[onChange, onChangeValue]
+	);
+
+	if (!enableEditMode) {
+		return editor;
+	}
+
+	return (
+		<Tabs align='end' variant='enclosed' wrapperClassName='ee-rte-with-edit-mode'>
+			<TabList>
+				<Tab>{__('Visual editor')}</Tab>
+				<Tab>{__('HTML editor')}</Tab>
+			</TabList>
+			<TabPanels>
+				<TabPanel>{editor}</TabPanel>
+				<TabPanel>
+					<Textarea
+						className='ee-html-editor'
+						defaultValue={defaultValue}
+						placeholder={placeholder}
+						value={value}
+						onChange={onChangeHandler}
+					/>
+				</TabPanel>
+			</TabPanels>
+		</Tabs>
+	);
+};

--- a/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/index.ts
+++ b/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/index.ts
@@ -1,0 +1,2 @@
+export * from './RTEWithEditMode';
+export * from './types';

--- a/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/style.scss
+++ b/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/style.scss
@@ -1,0 +1,75 @@
+@import '~@eventespresso/styles/src';
+
+.ee-rte-with-edit-mode {
+	margin-top: var(--ee-margin-small);
+
+	@include min1280px {
+		margin-top: calc(var(--ee-margin-big) * -1);
+	}
+
+	.ee-tabs {
+		border-radius: var(--ee-border-radius-default);
+
+		&__tab-list {
+			border: none;
+			margin-bottom: 0;
+			padding: 0 var(--ee-padding-small);
+
+			button,
+			button:active,
+			button:focus,
+			button:hover,
+			button:visited,
+			button[data-focus] {
+				background: var(--ee-button-transparent-background);
+				border: 3px solid var(--ee-button-transparent-background);
+				border-bottom: none !important;
+				border-bottom-color: transparent !important;
+				box-shadow: none !important;
+				margin: 0 0 0 var(--ee-margin-tiny);
+
+				&[data-selected],
+				&[aria-selected='true'] {
+					background: var(--ee-background-color);
+					border-color: var(--ee-background-color);
+					color: var(--ee-default-text-color);
+				}
+
+				&:focus,
+				&[data-focus] {
+					border-color: var(--ee-color-primary);
+				}
+
+				&:hover {
+					border-color: var(--ee-color-primary-low-contrast);
+				}
+			}
+		}
+
+		&__tab-panels {
+			background: var(--ee-background-color);
+			border-radius: var(--ee-border-radius-default);
+			box-shadow: var(--ee-box-shadow-tiny-diffuse);
+
+			> div {
+				padding: var(--ee-padding-tiny);
+				@include min667px {
+					padding: var(--ee-padding-small);
+				}
+			}
+		}
+	}
+
+	.ee-textarea.ee-html-editor {
+		border: none;
+		font-size: var(--ee-font-size-big);
+		min-height: 15rem;
+		padding: var(--ee-padding-smaller);
+		resize: none;
+
+		&:hover {
+			border: none;
+			color: var(--ee-default-text-color);
+		}
+	}
+}

--- a/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/types.ts
+++ b/packages/rich-text-editor/src/rte-old/components/RTEWithEditMode/types.ts
@@ -1,0 +1,5 @@
+import { RichTextEditorProps } from '../RichTextEditor';
+
+export interface RTEWithEditModeProps extends RichTextEditorProps {
+	enableEditMode?: boolean;
+}

--- a/packages/rich-text-editor/src/rte-old/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/RichTextEditor/RichTextEditor.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useMemo } from 'react';
+
+import classNames from 'classnames';
+import { Editor, EditorProps } from 'react-draft-wysiwyg';
+
+import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
+import './style.scss';
+
+import { RichTextEditorProps } from './types';
+import { editorStateToHtml, htmlToEditorState } from '../../utils';
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({
+	className,
+	defaultValue,
+	onChange,
+	onChangeValue,
+	placeholder,
+	value,
+	...props
+}) => {
+	const editorClassName = classNames('ee-rich-text-editor', className);
+
+	const wrapperClassName = classNames('ee-rich-text-editor__root', props.wrapperClassName);
+
+	const editorState = useMemo(() => htmlToEditorState(value || placeholder), [placeholder, value]);
+
+	const defaultEditorState = useMemo(() => htmlToEditorState(defaultValue), [defaultValue]);
+
+	const onEditorStateChange = useCallback<EditorProps['onEditorStateChange']>(
+		(newEditorState) => {
+			const html = editorStateToHtml(newEditorState);
+			onChange?.(html);
+			onChangeValue?.(html);
+		},
+		[onChange, onChangeValue]
+	);
+
+	/**
+	 * `react-draft-wysiwyg` uses Object.hasProperty() check to decide controlled/uncontrolled state,
+	 * it considers the state to be controlled even if it's undefined ¯\_(ツ)_/¯
+	 * So, we will only pass the state props if they are defined
+	 */
+	const editorProps = useMemo(() => {
+		const stateProps: Partial<EditorProps> = {};
+		if (typeof editorState !== 'undefined') {
+			stateProps.editorState = editorState;
+		}
+		if (typeof defaultEditorState !== 'undefined') {
+			stateProps.defaultEditorState = defaultEditorState;
+		}
+		return stateProps;
+	}, [defaultEditorState, editorState]);
+
+	return (
+		<Editor
+			{...props}
+			{...editorProps}
+			editorClassName={editorClassName}
+			onEditorStateChange={onEditorStateChange}
+			toolbarClassName='ee-rich-text-editor__toolbar'
+			wrapperClassName={wrapperClassName}
+		/>
+	);
+};

--- a/packages/rich-text-editor/src/rte-old/components/RichTextEditor/index.ts
+++ b/packages/rich-text-editor/src/rte-old/components/RichTextEditor/index.ts
@@ -1,0 +1,2 @@
+export * from './RichTextEditor';
+export * from './types';

--- a/packages/rich-text-editor/src/rte-old/components/RichTextEditor/style.scss
+++ b/packages/rich-text-editor/src/rte-old/components/RichTextEditor/style.scss
@@ -1,0 +1,154 @@
+@import '~@eventespresso/styles/src';
+
+@mixin ee-rte-option {
+	background: var(--ee-button-background-rte);
+	border: var(--ee-border-width) solid var(--ee-border-color);
+	border-color: transparent;
+	border-radius: var(--ee-border-radius-small);
+	box-shadow: var(--ee-button-box-shadow);
+	height: var(--ee-icon-button-size);
+	margin: var(--ee-margin-nano);
+	padding: var(--ee-padding-micro);
+	width: var(--ee-icon-button-size);
+
+	&:focus {
+		border-color: var(--ee-color-primary);
+	}
+	&:hover {
+		border-color: var(--ee-color-primary-low-contrast);
+	}
+}
+
+@mixin ee-rte-block-dropdown {
+	background: var(--ee-background-color);
+	border-radius: var(--ee-border-radius-small);
+	border: var(--ee-border-width) solid var(--ee-border-color);
+	box-shadow: none;
+	color: var(--ee-default-text-color);
+	font-size: var(--ee-font-size-default);
+	max-width: none;
+	min-height: var(--ee-icon-button-size);
+	outline: none;
+	padding: var(--ee-padding-micro) var(--ee-padding-tiny);
+
+	@include transition(all 50ms ease);
+
+	&:focus {
+		border-color: var(--ee-color-primary);
+	}
+	&:hover {
+		border-color: var(--ee-color-primary-low-contrast);
+	}
+}
+
+.ee-rich-text-editor {
+	border-top: none;
+	cursor: text;
+	font-size: var(--ee-font-size-big);
+	margin: 0;
+
+	&__root {
+		border: none;
+		box-shadow: none;
+
+		.ee-rich-text-editor {
+			line-height: var(--ee-font-size-huge);
+			padding: 0 var(--ee-padding-smaller);
+		}
+
+		.rdw-option-wrapper {
+			@include ee-rte-option;
+
+			&.rdw-option-disabled {
+				cursor: not-allowed;
+			}
+		}
+
+		.rdw-block-dropdown,
+		.rdw-fontsize-dropdown,
+		.rdw-fontfamily-dropdown {
+			@include ee-rte-block-dropdown;
+		}
+
+		.rdw-block-dropdown {
+			min-width: calc(var(--ee-icon-button-size) * 3.41);
+		}
+		.rdw-fontsize-dropdown {
+			min-width: calc(var(--ee-icon-button-size) * 2.3);
+		}
+		.rdw-fontfamily-dropdown {
+			min-width: calc(var(--ee-icon-button-size) * 3.36);
+		}
+
+		.rdw-block-dropdown,
+		.rdw-fontsize-dropdown,
+		.rdw-fontfamily-dropdown {
+			a {
+				justify-content: space-between;
+			}
+		}
+
+		.rdw-dropdown-carettoclose,
+		.rdw-dropdown-carettoopen {
+			border-top-color: var(--ee-default-text-color);
+			position: unset;
+			top: unset;
+			right: unset;
+		}
+
+		&.ee-simple-text-editor {
+			border-color: var(--ee-border-color);
+			border-radius: var(--ee-border-radius-small);
+			border-style: solid;
+			border-width: var(--ee-border-width);
+		}
+	}
+
+	&__toolbar {
+		border: none;
+		border-bottom: 3px solid rgba(192, 192, 192, .5);
+		border-radius: 0;
+		margin: 0 var(--ee-margin-micro);
+		padding: var(--ee-padding-tiny) 0;
+
+		@include min667px {
+			margin: 0 var(--ee-margin-smaller);
+			padding: var(--ee-padding-small) 0;
+		}
+
+		.rdw-inline-wrapper,
+		.rdw-fontfamily-wrapper,
+		.rdw-list-wrapper,
+		.rdw-text-align-wrapper {
+			.ee-advanced-text-editor & {
+				@include min667px {
+					margin-right: calc(var(--ee-icon-button-size) * 1.1);
+				}
+			}
+		}
+
+		img {
+			// override WP image styles
+			border: 0 !important;
+			opacity: 0.65;
+		}
+	}
+
+	&__controls {
+		&-bold,
+		&-italic,
+		&-underline,
+		&-ordered,
+		&-unordered {
+			@include ee-rte-option;
+		}
+
+		&-block-type {
+			@include ee-rte-block-dropdown;
+		}
+	}
+
+	a {
+		text-decoration: underline !important;
+	}
+}

--- a/packages/rich-text-editor/src/rte-old/components/RichTextEditor/types.ts
+++ b/packages/rich-text-editor/src/rte-old/components/RichTextEditor/types.ts
@@ -1,0 +1,10 @@
+import { EditorProps } from 'react-draft-wysiwyg';
+
+export interface RichTextEditorProps extends Omit<EditorProps, 'onChange'> {
+	className?: string;
+	defaultValue?: string;
+	onChange?: (string: string) => void;
+	onChangeValue?: (string: string) => void;
+	placeholder?: string;
+	value?: string;
+}

--- a/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/SimpleTextEditor.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/SimpleTextEditor.tsx
@@ -1,0 +1,11 @@
+import classNames from 'classnames';
+
+import { RTEWithEditMode } from '../RTEWithEditMode';
+import { SimpleTextEditorProps } from './types';
+import { toolbar } from './toolbar';
+
+export const SimpleTextEditor: React.FC<SimpleTextEditorProps> = (props) => {
+	const wrapperClassName = classNames('ee-simple-text-editor', props.wrapperClassName);
+
+	return <RTEWithEditMode enableEditMode={false} {...props} toolbar={toolbar} wrapperClassName={wrapperClassName} />;
+};

--- a/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/index.ts
+++ b/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/index.ts
@@ -1,0 +1,2 @@
+export * from './SimpleTextEditor';
+export * from './types';

--- a/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/toolbar.ts
+++ b/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/toolbar.ts
@@ -1,0 +1,17 @@
+export const toolbar = {
+	options: ['inline', 'blockType', 'list'],
+	blockType: {
+		className: 'ee-rich-text-editor__controls-block-type',
+	},
+	inline: {
+		options: ['bold', 'italic', 'underline'],
+		bold: { className: 'ee-rich-text-editor__controls-bold' },
+		italic: { className: 'ee-rich-text-editor__controls-italic' },
+		underline: { className: 'ee-rich-text-editor__controls-underline' },
+	},
+	list: {
+		options: ['unordered', 'ordered'],
+		ordered: { className: 'ee-rich-text-editor__controls-ordered' },
+		unordered: { className: 'ee-rich-text-editor__controls-unordered' },
+	},
+};

--- a/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/types.ts
+++ b/packages/rich-text-editor/src/rte-old/components/SimpleTextEditor/types.ts
@@ -1,0 +1,3 @@
+import { RTEWithEditModeProps } from '../RTEWithEditMode';
+
+export interface SimpleTextEditorProps extends RTEWithEditModeProps {}

--- a/packages/rich-text-editor/src/rte-old/components/constants.ts
+++ b/packages/rich-text-editor/src/rte-old/components/constants.ts
@@ -1,0 +1,77 @@
+import { DraftBlockType } from 'draft-js';
+import { __ } from '@eventespresso/i18n';
+
+interface Block {
+	'aria-label'?: string;
+	label: string;
+	style?: DraftBlockType;
+	value?: DraftBlockType;
+}
+
+export const BLOCK_TYPES: Block[] = [
+	{
+		'aria-label': __('blockquote'),
+		label: 'Blockquote',
+		style: 'blockquote',
+	},
+	{
+		'aria-label': __('unordered list'),
+		label: 'UL',
+		style: 'unordered-list-item',
+	},
+	{
+		'aria-label': __('ordered list'),
+		label: 'OL',
+		style: 'ordered-list-item',
+	},
+];
+
+export const HEADING_BLOCK_TYPES: Block[] = [
+	{
+		label: 'H1',
+		value: 'header-one',
+	},
+	{
+		label: 'H2',
+		value: 'header-two',
+	},
+	{
+		label: 'H3',
+		value: 'header-three',
+	},
+	{
+		label: 'H4',
+		value: 'header-four',
+	},
+	{
+		label: 'H5',
+		value: 'header-five',
+	},
+	{
+		label: 'H6',
+		value: 'header-six',
+	},
+];
+
+export const INLINE_STYLES: Block[] = [
+	{
+		'aria-label': __('bold'),
+		label: 'B',
+		style: 'BOLD',
+	},
+	{
+		'aria-label': __('italic'),
+		label: 'I',
+		style: 'ITALIC',
+	},
+	{
+		'aria-label': __('underline'),
+		label: 'U',
+		style: 'UNDERLINE',
+	},
+	{
+		'aria-label': __('strikethrough'),
+		label: 'S',
+		style: 'STRIKETHROUGH',
+	},
+];

--- a/packages/rich-text-editor/src/rte-old/components/index.stories.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Story, Meta } from '@storybook/react/types-6-0';
+
+import { AdvancedTextEditor, RichTextEditor, SimpleTextEditor } from './';
+import type { RichTextEditorProps } from './RichTextEditor';
+
+export default {
+	argTypes: {},
+	component: RichTextEditor,
+	title: 'Components/RichTextEditor',
+} as Meta;
+
+type RTEStory = Story<RichTextEditorProps>;
+
+export const Simple: RTEStory = () => <SimpleTextEditor onChange={console.log} />;
+
+export const Advanced: RTEStory = () => <AdvancedTextEditor onChange={console.log} />;

--- a/packages/rich-text-editor/src/rte-old/components/index.ts
+++ b/packages/rich-text-editor/src/rte-old/components/index.ts
@@ -1,0 +1,4 @@
+export * from './AdvancedTextEditor';
+export * from './RichTextEditor';
+export * from './RTEWithEditMode';
+export * from './SimpleTextEditor';

--- a/packages/rich-text-editor/src/rte-old/components/toolbarButtons/WPMedia.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/toolbarButtons/WPMedia.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect } from 'react';
+import { AtomicBlockUtils } from 'draft-js';
+
+import { __ } from '@eventespresso/i18n';
+import { Image } from '@eventespresso/icons';
+
+import { ToolbarButtonProps } from './types';
+
+const wpMedia = window?.wp?.media({
+	title: __('Select media'),
+	button: {
+		text: __('Select'),
+	},
+	multiple: false,
+	library: {
+		type: ['image'],
+	},
+});
+
+const openMediaModal = () => wpMedia?.open();
+
+type AddMediaArgs = {
+	src: string;
+	height: number;
+	width: number;
+	alt: string;
+	type: string; // 'image', 'video' etc.
+};
+
+const WPMedia: React.FC<ToolbarButtonProps> = ({ onChange, editorState }) => {
+	const addMedia = useCallback(
+		({ src, height, width, alt, type }: AddMediaArgs) => {
+			const entityData = { src, height, width, alt };
+
+			const entityType = type?.toUpperCase();
+
+			const entityKey = editorState
+				.getCurrentContent()
+				.createEntity(entityType, 'MUTABLE', entityData)
+				.getLastCreatedEntityKey();
+
+			const newEditorState = AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
+			onChange(newEditorState);
+		},
+		[editorState, onChange]
+	);
+
+	const mediaHandler = useCallback(() => {
+		const attachment = wpMedia?.state()?.get('selection')?.first()?.toJSON();
+
+		const { alt, height, url, type, width } = attachment;
+
+		addMedia({ alt, height, src: url, type, width });
+	}, [addMedia]);
+
+	useEffect(() => {
+		// de-register the previous listener.
+		wpMedia?.off('select', mediaHandler);
+
+		wpMedia?.on('select', mediaHandler);
+
+		return () => wpMedia?.off('select', mediaHandler);
+	}, [mediaHandler]);
+
+	return (
+		<div className='rdw-image-wrapper'>
+			<div
+				aria-label={__('Add Media')}
+				className='rdw-option-wrapper'
+				onClick={openMediaModal}
+				onKeyPress={console.log}
+				role='button'
+				tabIndex={0}
+			>
+				<Image size='small' />
+			</div>
+		</div>
+	);
+};
+
+export default WPMedia;

--- a/packages/rich-text-editor/src/rte-old/components/toolbarButtons/index.tsx
+++ b/packages/rich-text-editor/src/rte-old/components/toolbarButtons/index.tsx
@@ -1,0 +1,7 @@
+import { EditorProps } from 'react-draft-wysiwyg';
+
+import WPMedia from './WPMedia';
+
+const toolbarButtons: EditorProps['toolbarCustomButtons'] = [<WPMedia key='wpmedia' />];
+
+export default toolbarButtons;

--- a/packages/rich-text-editor/src/rte-old/components/toolbarButtons/types.ts
+++ b/packages/rich-text-editor/src/rte-old/components/toolbarButtons/types.ts
@@ -1,0 +1,6 @@
+import { EditorProps } from 'react-draft-wysiwyg';
+
+export interface ToolbarButtonProps {
+	onChange?: EditorProps['onEditorStateChange'];
+	editorState?: EditorProps['editorState'];
+}

--- a/packages/rich-text-editor/src/rte-old/index.ts
+++ b/packages/rich-text-editor/src/rte-old/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/packages/rich-text-editor/src/rte-old/utils/index.ts
+++ b/packages/rich-text-editor/src/rte-old/utils/index.ts
@@ -1,0 +1,17 @@
+import { EditorState, convertToRaw, ContentState } from 'draft-js';
+import draftToHtml from 'draftjs-to-html';
+import htmlToDraft from 'html-to-draftjs';
+
+export const htmlToEditorState = (html: string): EditorState => {
+	let state: EditorState;
+	if (html) {
+		const contentBlock = htmlToDraft(html);
+		const contentState = ContentState.createFromBlockArray(contentBlock.contentBlocks);
+		state = EditorState.createWithContent(contentState);
+	}
+	return state;
+};
+
+export const editorStateToHtml = (editorState: EditorState): string => {
+	return draftToHtml(convertToRaw(editorState.getCurrentContent()));
+};


### PR DESCRIPTION
This PR reinstates previous RTE and hides the new experimental RTE from the consumer packages and domains. Please see [this comment](https://github.com/eventespresso/barista/issues/616#issuecomment-760777083).

Closes #616 