### PR TITLE
Fixed stale entity list in reorder UI when new entity is added.

### DIFF
--- a/packages/edtr-services/src/apollo/mutations/datetimes/useReorderDatetimes.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useReorderDatetimes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { datetimesDroppableId } from '@eventespresso/constants';
 import type { EntityId } from '@eventespresso/data';
@@ -23,6 +23,10 @@ const useReorderDatetimes = (filteredEntityIds: Array<EntityId>): ReorderDatetim
 
 	const { sortEntities, done } = useReorderEntities<Datetime>({ entityType: 'DATETIME' });
 	const allEntities = useDatetimes();
+
+	useEffect(() => {
+		setAllOrderedEntities(datetimes);
+	}, [datetimes]);
 
 	const sortResponder = useCallback<SortResponder>(
 		({ destination, source }) => {

--- a/packages/edtr-services/src/apollo/mutations/tickets/useReorderTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useReorderTickets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ticketDroppableId } from '@eventespresso/constants';
 import type { EntityId } from '@eventespresso/data';
@@ -23,6 +23,10 @@ const useReorderTickets = (filteredEntityIds: Array<EntityId>): ReorderTickets =
 
 	const { sortEntities, done } = useReorderEntities<Ticket>({ entityType: 'TICKET' });
 	const allEntities = useTickets();
+
+	useEffect(() => {
+		setAllOrderedEntities(tickets);
+	}, [tickets]);
 
 	const sortResponder = useCallback<SortResponder>(
 		({ destination, source }) => {


### PR DESCRIPTION
Before:

![Peek 2021-01-15 14-14-min](https://user-images.githubusercontent.com/1477453/104728407-8a503300-573f-11eb-8d2d-a4465858ed83.gif)


***
After:

![Peek 2021-01-15 14-19-min](https://user-images.githubusercontent.com/1477453/104727618-4ad51700-573e-11eb-95e8-b8b8d56b9172.gif)

