### PR TITLE
Track if TAM Relations are Initially Valid

### DIFF
--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/TicketAssignmentsManagerModal/buttons/useCancelButtonProps.tsx
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/TicketAssignmentsManagerModal/buttons/useCancelButtonProps.tsx
@@ -4,10 +4,9 @@ import { __ } from '@eventespresso/i18n';
 import { useDataState } from '../../../data';
 import type { ButtonProps } from '@eventespresso/ui-components';
 
-const useCancelButtonProps = (onCloseModal: VoidFunction): ButtonProps => {
+const useCancelButtonProps = (onCloseModal: VoidFunction, hasErrors?: boolean): ButtonProps => {
 	const { hasOrphanEntities } = useDataState();
-
-	const hasErrors = hasOrphanEntities();
+	const disabled = hasErrors !== undefined ? hasErrors : hasOrphanEntities();
 
 	const onClick: ButtonProps['onClick'] = useCallback(() => {
 		onCloseModal();
@@ -16,11 +15,11 @@ const useCancelButtonProps = (onCloseModal: VoidFunction): ButtonProps => {
 	return useMemo<ButtonProps>(
 		() => ({
 			buttonText: __('Cancel'),
-			isDisabled: hasErrors,
+			isDisabled: disabled,
 			onClick,
 			type: 'reset',
 		}),
-		[hasErrors, onClick]
+		[disabled, onClick]
 	);
 };
 

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/TicketAssignmentsManagerModal/index.tsx
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/TicketAssignmentsManagerModal/index.tsx
@@ -11,10 +11,9 @@ import type { TAMModalProps } from '../../context/types';
 import '../styles.scss';
 
 const TicketAssignmentsManagerModal: React.FC<Partial<TAMModalProps>> = ({ onCloseModal, onSubmit, title }) => {
-	const { hasOrphanEntities } = useDataState();
-	const cancelButtonProps = useCancelButtonProps(onCloseModal);
+	const { hasOrphanEntities, initialDataIsValid } = useDataState();
+	const cancelButtonProps = useCancelButtonProps(onCloseModal, !initialDataIsValid);
 	const submitButtonProps = useSubmitButtonProps(onSubmit);
-
 	const hasErrors = hasOrphanEntities();
 
 	return (

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useState } from 'react';
 
 import { EntityId } from '@eventespresso/data';
 import { useRelations } from '@eventespresso/services';
@@ -6,6 +6,7 @@ import { useAssignmentManager, useValidation } from './';
 import { AssignmentStatus, BaseProps, DataStateManager } from '../types';
 
 const useDataStateManager = (props: BaseProps): DataStateManager => {
+	const [initialDataIsValid, setInitialDataIsValid] = useState(false);
 	const assignmentManager = useAssignmentManager();
 	// The existing relations to be used to create initial data
 	// and to calculate difference between new and old data
@@ -14,13 +15,6 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 
 	const { initialize, isInitialized } = assignmentManager;
 	const initialized = isInitialized();
-
-	useEffect(() => {
-		if (!initialized) {
-			// initialize with existing data
-			initialize({ data: relations.getData(), ...props });
-		}
-	}, [initialize, initialized, props, relations]);
 
 	const hasNoAssignedDates = useCallback(({ ticketId }) => orphanEntities.tickets.includes(ticketId), [
 		orphanEntities.tickets,
@@ -90,6 +84,17 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 		[assignmentManager, getOldRelation]
 	);
 
+	useEffect(() => {
+		if (!initialized) {
+			const data = relations.getData();
+			// initialize with existing data
+			initialize({ data, ...props });
+			// now check if there are any orphaned entities in the intial data and save the result
+			const hasOrphans = orphanEntities?.datetimes?.length !== 0 || orphanEntities?.tickets?.length !== 0;
+			setInitialDataIsValid(!hasOrphans);
+		}
+	}, [initialize, initialized, orphanEntities, props, relations, setInitialDataIsValid]);
+
 	return useMemo(
 		() => ({
 			...assignmentManager,
@@ -99,6 +104,7 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 			hasOrphanDates,
 			hasOrphanEntities,
 			hasOrphanTickets,
+			initialDataIsValid,
 		}),
 		[
 			assignmentManager,
@@ -108,6 +114,7 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 			hasOrphanDates,
 			hasOrphanEntities,
 			hasOrphanTickets,
+			initialDataIsValid,
 		]
 	);
 };

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/data/useDataStateManager.ts
@@ -89,7 +89,7 @@ const useDataStateManager = (props: BaseProps): DataStateManager => {
 			const data = relations.getData();
 			// initialize with existing data
 			initialize({ data, ...props });
-			// now check if there are any orphaned entities in the intial data and save the result
+			// now check if there are any orphaned entities in the initial data and save the result
 			const hasOrphans = orphanEntities?.datetimes?.length !== 0 || orphanEntities?.tickets?.length !== 0;
 			setInitialDataIsValid(!hasOrphans);
 		}

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/types.ts
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/types.ts
@@ -53,6 +53,7 @@ export interface DataStateManager extends AssignmentManager {
 	hasOrphanDates: () => boolean;
 	hasOrphanEntities: () => boolean;
 	hasOrphanTickets: () => boolean;
+	initialDataIsValid: boolean;
 }
 
 export interface DatesAndTickets {

--- a/packages/services/src/relations/types.ts
+++ b/packages/services/src/relations/types.ts
@@ -33,14 +33,14 @@ export interface RelationAction extends CommonProps<null> {
 }
 
 export interface RelationsManager {
-	initialize: (data: RelationalData) => void;
-	isInitialized: () => boolean;
+	addRelation: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	dropRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
 	getData: () => RelationalData;
 	getRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => EntityId[];
-	addRelation: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
-	updateRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	initialize: (data: RelationalData) => void;
+	isInitialized: () => boolean;
 	removeRelation: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
-	dropRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	updateRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
 }
 
 export type RelationsReducer = (state: RelationalData, action: RelationAction) => RelationalData;

--- a/packages/services/src/relations/useRelationsManager.ts
+++ b/packages/services/src/relations/useRelationsManager.ts
@@ -130,14 +130,14 @@ const useRelationsManager = (data: RelationalData = INITIAL_STATE): RM => {
 
 	return useMemo(
 		() => ({
-			initialize,
-			isInitialized,
+			addRelation,
+			dropRelations,
 			getData,
 			getRelations,
-			addRelation,
+			initialize,
+			isInitialized,
 			removeRelation,
 			updateRelations,
-			dropRelations,
 		}),
 		[addRelation, dropRelations, getData, getRelations, initialize, isInitialized, removeRelation, updateRelations]
 	);


### PR DESCRIPTION
plz see: https://github.com/eventespresso/event-espresso-core/issues/3267

this PR:

- adds state management to `useDataStateManager` for tracking whether any orphaned relations existed upon initialization and passes a boolean value to consumers with other its other output

- adds a prop to `useCancelButtonProps` for externally controlling whether the button is disabled. This is passed the boolean value from above for the TAM modal

- performs some 🔠 reordering so that Vadim can sleep at night

