### PR TITLE
Standardize Tooltip & Menu Placement

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/DateRegistrationsLink.tsx
+++ b/domains/eventEditor/src/ui/datetimes/DateRegistrationsLink.tsx
@@ -7,14 +7,12 @@ interface Props {
 	datetime: Datetime;
 }
 
-const tooltipProps = { placement: 'top' as const };
-
 const DateRegistrationsLink: React.FC<Props> = ({ datetime }) => {
 	const regListUrl = useRegistrationsLink({ datetime_id: datetime.dbId });
 
 	const tooltip = __('view ALL registrations for this date.');
 
-	return <RegistrationsLink href={regListUrl} tooltip={tooltip} tooltipProps={tooltipProps} />;
+	return <RegistrationsLink href={regListUrl} tooltip={tooltip} />;
 };
 
 export default DateRegistrationsLink;

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { BaseProps } from '@edtrUI/ticketAssignmentsManager';
 import { EdtrGlobalModals, useRelatedTickets } from '@eventespresso/edtr-services';
 import { IconButton, ItemCount } from '@eventespresso/ui-components';
 import { Ticket } from '@eventespresso/icons';
 import { TypeName, withIsLoaded } from '@eventespresso/services';
 import { useGlobalModal } from '@eventespresso/registry';
+import type { BaseProps } from '@edtrUI/ticketAssignmentsManager';
 
 import type { Datetime } from '@eventespresso/edtr-services';
 import type { EntityListItemProps } from '@eventespresso/ui-components';

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -1,18 +1,15 @@
 import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-
-import { useRelatedTickets, EdtrGlobalModals } from '@eventespresso/edtr-services';
-import type { EntityListItemProps } from '@eventespresso/ui-components';
+import { BaseProps } from '@edtrUI/ticketAssignmentsManager';
+import { EdtrGlobalModals, useRelatedTickets } from '@eventespresso/edtr-services';
 import { IconButton, ItemCount } from '@eventespresso/ui-components';
-import { TypeName, withIsLoaded } from '@eventespresso/services';
 import { Ticket } from '@eventespresso/icons';
-import type { Datetime } from '@eventespresso/edtr-services';
-import { useMemoStringify } from '@eventespresso/hooks';
-import type { TooltipProps } from '@eventespresso/adapters';
+import { TypeName, withIsLoaded } from '@eventespresso/services';
 import { useGlobalModal } from '@eventespresso/registry';
 
-import { BaseProps } from '@edtrUI/ticketAssignmentsManager';
+import type { Datetime } from '@eventespresso/edtr-services';
+import type { EntityListItemProps } from '@eventespresso/ui-components';
 
 const AssignTicketsButton: React.FC<EntityListItemProps<Datetime>> = ({ entity }) => {
 	const { openWithData } = useGlobalModal<BaseProps>(EdtrGlobalModals.TAM);
@@ -28,21 +25,13 @@ const AssignTicketsButton: React.FC<EntityListItemProps<Datetime>> = ({ entity }
 		? __('Number of related tickets')
 		: __('There are no tickets assigned to this datetime. Please click the ticket icon to update the assignments.');
 
-	const tooltipProps = useMemoStringify<TooltipProps>({ placement: 'right' });
-
 	const onOpen = useCallback(() => {
 		openWithData({ entity, assignmentType: 'forDate' });
 	}, [entity, openWithData]);
 
 	return (
 		<ItemCount count={count} title={title} zeroCountChar='!'>
-			<IconButton
-				borderless
-				icon={Ticket}
-				onClick={onOpen}
-				tooltip={__('assign tickets')}
-				tooltipProps={tooltipProps}
-			/>
+			<IconButton borderless icon={Ticket} onClick={onOpen} tooltip={__('assign tickets')} />
 		</ItemCount>
 	);
 };

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-
 import {
 	DropdownMenu,
 	DropdownToggleProps,
@@ -12,11 +11,12 @@ import {
 } from '@eventespresso/ui-components';
 import { EdtrGlobalModals, useDatesListFilterState } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
-import { useMemoStringify } from '@eventespresso/hooks';
 import type { EntityEditModalData } from '@edtrUI/types';
 
 import useActions from './useActions';
 import type { DateMainMenuProps } from './types';
+
+const toggleProps: DropdownToggleProps = { tooltip: __('event date main menu') };
 
 const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 	const { copyDate, trashDate, isTrashed } = useActions(datetime.id);
@@ -37,8 +37,6 @@ const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 		title,
 		onConfirm: trashDate,
 	});
-
-	const toggleProps: DropdownToggleProps = useMemoStringify({ tooltip: __('event date main menu') });
 
 	const trashDateTitle = isTrashed ? __('delete permanently') : __('trash datetime');
 

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
@@ -38,10 +38,7 @@ const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 		onConfirm: trashDate,
 	});
 
-	const toggleProps: DropdownToggleProps = useMemoStringify({
-		tooltip: __('event date main menu'),
-		tooltipProps: { placement: 'right' },
-	});
+	const toggleProps: DropdownToggleProps = useMemoStringify({ tooltip: __('event date main menu') });
 
 	const trashDateTitle = isTrashed ? __('delete permanently') : __('trash datetime');
 

--- a/domains/eventEditor/src/ui/styles.scss
+++ b/domains/eventEditor/src/ui/styles.scss
@@ -5,10 +5,6 @@ html.wp-toolbar {
 }
 
 .post-type-espresso_events {
-	#adminmenuwrap {
-		z-index: 2;
-	}
-
 	#ed_toolbar {
 		box-sizing: content-box;
 	}
@@ -24,7 +20,6 @@ html.wp-toolbar {
 	}
 
 	#wpcontent {
-		// margin: 0;
 		padding: 0 var(--ee-padding-tiny);
 
 		#wpbody-content > .wrap {

--- a/domains/eventEditor/src/ui/ticketAssignmentsManager/components/table/styles.scss
+++ b/domains/eventEditor/src/ui/ticketAssignmentsManager/components/table/styles.scss
@@ -66,7 +66,7 @@
 					width: 300px;
 
 					> div {
-						align-items: start;
+						align-items: flex-start;
 						display: flex;
 						flex-direction: column;
 						font-weight: normal;
@@ -263,6 +263,7 @@
 						span,
 						svg {
 							height: var(--ee-icon-button-size);
+							margin: 0;
 							padding: 0;
 							width: var(--ee-icon-button-size);
 						}

--- a/domains/eventEditor/src/ui/tickets/TicketRegistrationsLink.tsx
+++ b/domains/eventEditor/src/ui/tickets/TicketRegistrationsLink.tsx
@@ -1,14 +1,11 @@
 import { __ } from '@eventespresso/i18n';
-
 import { RegistrationsLink, ItemCount } from '@eventespresso/ui-components';
-import type { Ticket } from '@eventespresso/edtr-services';
 import { useRegistrationsLink } from '@eventespresso/edtr-services';
+import type { Ticket } from '@eventespresso/edtr-services';
 
 interface Props {
 	ticket: Ticket;
 }
-
-const tooltipProps = { placement: 'top' as const };
 
 const TicketRegistrationsLink: React.FC<Props> = ({ ticket }) => {
 	const regListUrl = useRegistrationsLink({ ticket_id: ticket.dbId });
@@ -18,7 +15,7 @@ const TicketRegistrationsLink: React.FC<Props> = ({ ticket }) => {
 
 	return (
 		<ItemCount count={ticket.registrationCount} emphasizeZero={false} title={countTitle}>
-			<RegistrationsLink href={regListUrl} tooltip={tooltip} tooltipProps={tooltipProps} />
+			<RegistrationsLink href={regListUrl} tooltip={tooltip} />
 		</ItemCount>
 	);
 };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
@@ -7,9 +7,7 @@ import { IconButton, EntityListItemProps, ItemCount } from '@eventespresso/ui-co
 import { useRelatedDatetimes, EdtrGlobalModals } from '@eventespresso/edtr-services';
 import { TypeName } from '@eventespresso/services';
 import { withIsLoaded } from '@eventespresso/services';
-import { useMemoStringify } from '@eventespresso/hooks';
 import type { Ticket } from '@eventespresso/edtr-services';
-import type { TooltipProps } from '@eventespresso/adapters';
 import { useGlobalModal } from '@eventespresso/registry';
 
 import { BaseProps } from '@edtrUI/ticketAssignmentsManager';
@@ -30,21 +28,13 @@ const AssignDatesButton: React.FC<EntityListItemProps<Ticket>> = ({ entity }) =>
 				'There are no event dates assigned to this ticket. Please click the calendar icon to update the assignments.'
 		  );
 
-	const tooltipProps = useMemoStringify<TooltipProps>({ placement: 'left' });
-
 	const onOpen = useCallback(() => {
 		openWithData({ entity, assignmentType: 'forTicket' });
 	}, [entity, openWithData]);
 
 	return (
 		<ItemCount count={count} emphasizeZero title={title} zeroCountChar='!'>
-			<IconButton
-				borderless
-				icon={Calendar}
-				onClick={onOpen}
-				tooltip={__('assign dates')}
-				tooltipProps={tooltipProps}
-			/>
+			<IconButton borderless icon={Calendar} onClick={onOpen} tooltip={__('assign dates')} />
 		</ItemCount>
 	);
 };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-
 import {
 	Copy,
 	Edit,
@@ -12,11 +11,12 @@ import {
 } from '@eventespresso/ui-components';
 import { EdtrGlobalModals, useTicketsListFilterState } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
-import { useMemoStringify } from '@eventespresso/hooks';
 
 import type { TicketMainMenuProps } from './types';
 import useActions from './useActions';
 import { EntityEditModalData } from '@edtrUI/types';
+
+const toggleProps: DropdownToggleProps = { tooltip: __('ticket main menu') };
 
 const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 	const { copyTicket, trashTicket, isTrashed } = useActions(ticket.id);
@@ -36,8 +36,6 @@ const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 		title,
 		onConfirm: trashTicket,
 	});
-
-	const toggleProps: DropdownToggleProps = useMemoStringify({ tooltip: __('ticket main menu') });
 
 	const trashTicketTitle = isTrashed ? __('delete permanently') : __('trash ticket');
 

--- a/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
@@ -37,10 +37,7 @@ const TicketMainMenu: React.FC<TicketMainMenuProps> = ({ ticket }) => {
 		onConfirm: trashTicket,
 	});
 
-	const toggleProps: DropdownToggleProps = useMemoStringify({
-		tooltip: __('ticket main menu'),
-		tooltipProps: { placement: 'left' },
-	});
+	const toggleProps: DropdownToggleProps = useMemoStringify({ tooltip: __('ticket main menu') });
 
 	const trashTicketTitle = isTrashed ? __('delete permanently') : __('trash ticket');
 

--- a/packages/adapters/src/Tooltip/Tooltip.tsx
+++ b/packages/adapters/src/Tooltip/Tooltip.tsx
@@ -6,7 +6,15 @@ export const Tooltip: React.FC<TooltipProps> = ({ children, tooltip, ...props })
 	const ariaLabel = tooltip || props['aria-label'];
 
 	return (
-		<ChakraTooltip {...props} aria-label={ariaLabel} closeOnClick label={tooltip} hideDelay={250} showDelay={500}>
+		<ChakraTooltip
+			placement='auto-start'
+			{...props}
+			aria-label={ariaLabel}
+			closeOnClick
+			label={tooltip}
+			hideDelay={250}
+			showDelay={500}
+		>
 			{children}
 		</ChakraTooltip>
 	);

--- a/packages/tpc/src/buttons/TicketPriceCalculatorButton.tsx
+++ b/packages/tpc/src/buttons/TicketPriceCalculatorButton.tsx
@@ -7,8 +7,6 @@ import { IconButton, IconButtonProps } from '@eventespresso/ui-components';
 import { EdtrGlobalModals, useTicketItem } from '@eventespresso/edtr-services';
 import { TypeName, withIsLoaded } from '@eventespresso/services';
 import { useGlobalModal } from '@eventespresso/registry';
-import { useMemoStringify } from '@eventespresso/hooks';
-import type { TooltipProps } from '@eventespresso/adapters';
 
 import type { BaseProps } from '../types';
 import { SOLD_TICKET_ERROR_MESSAGE } from '../utils';
@@ -17,8 +15,6 @@ interface TPCButtonProps extends BaseProps, IconButtonProps {}
 
 const TicketPriceCalculatorButton: React.FC<TPCButtonProps> = ({ ticketId, ...buttonProps }) => {
 	const { openWithData } = useGlobalModal<BaseProps>(EdtrGlobalModals.TPC);
-
-	const tooltipProps = useMemoStringify<TooltipProps>({ placement: 'left' });
 
 	const onOpen = useCallback(() => {
 		openWithData({ ticketId });
@@ -35,7 +31,6 @@ const TicketPriceCalculatorButton: React.FC<TPCButtonProps> = ({ ticketId, ...bu
 			icon={Calculator}
 			onClick={isDisabled ? null : onOpen}
 			tooltip={tooltip}
-			tooltipProps={tooltipProps}
 			{...buttonProps}
 		/>
 	);

--- a/packages/ui-components/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui-components/src/DropdownMenu/DropdownMenu.tsx
@@ -1,13 +1,17 @@
 import { Menu } from '@eventespresso/adapters';
+import { isRTL as getRTL } from '@eventespresso/i18n';
 import { DropdownMenuList, DropdownToggle } from './';
 import type { DropdownMenuProps } from './types';
 
 import './styles.scss';
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, className, menuListProps, toggleProps }) => {
+	const isRTL = getRTL();
+	const placement = isRTL ? 'left-start' : 'right-start';
+
 	return (
 		<div className='ee-dropdown-menu__wrapper'>
-			<Menu placement='right-start'>
+			<Menu placement={placement}>
 				{({ isOpen, onClose }) => (
 					<div className='ee-dropdown-menu'>
 						<DropdownToggle isOpen={isOpen} onClose={onClose} {...toggleProps} />

--- a/packages/ui-components/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui-components/src/DropdownMenu/DropdownMenu.tsx
@@ -7,7 +7,7 @@ import './styles.scss';
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, className, menuListProps, toggleProps }) => {
 	return (
 		<div className='ee-dropdown-menu__wrapper'>
-			<Menu placement='left-start'>
+			<Menu placement='right-start'>
 				{({ isOpen, onClose }) => (
 					<div className='ee-dropdown-menu'>
 						<DropdownToggle isOpen={isOpen} onClose={onClose} {...toggleProps} />

--- a/packages/ui-components/src/TimezoneTimeInfo/Trigger.tsx
+++ b/packages/ui-components/src/TimezoneTimeInfo/Trigger.tsx
@@ -1,8 +1,6 @@
 import { forwardRef } from 'react';
 
 import { GlobalOutlined } from '@eventespresso/icons';
-import type { TooltipProps } from '@eventespresso/adapters';
-
 import { IconButton } from '../../';
 
 interface TriggerProps {
@@ -12,8 +10,6 @@ interface TriggerProps {
 
 const Icon: React.FC = () => <GlobalOutlined size='smaller' />;
 
-const tooltipProps: TooltipProps = { placement: 'top' as const };
-
 const Trigger = forwardRef<typeof IconButton, TriggerProps>(({ tooltip, ...props }, ref) => {
 	return (
 		<IconButton
@@ -22,7 +18,6 @@ const Trigger = forwardRef<typeof IconButton, TriggerProps>(({ tooltip, ...props
 			className='ee-timezone-info__button'
 			icon={Icon}
 			tooltip={tooltip}
-			tooltipProps={tooltipProps}
 			ref={ref}
 		/>
 	);


### PR DESCRIPTION
plz see: https://github.com/eventespresso/event-espresso-core/issues/3266

this PR:

- fixes the 🐔 <-> 🥚 situation where the WP admin menu displays beneath the EDTR entity card dropdown menu, unless the WP admin menu has a higher z-index which results in the EDTR entity card dropdown menu displaying beneath the WP admin menu unless the EDTR entity card dropdown menu has a higher z-index, etc, etc

- standardizes tooltip placement and simplifies a bunch of code simply by setting that option once in our adapter AND by using an "auto" value from Chakra that senses if the tooltip will be blocked and changes the placement to somewhere clear

- some more 🔠 for Vadim
