### PR TITLE
Fix entity sort popover timezones

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/filterBar/controls/SortByControl/DraggableDatetime.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/filterBar/controls/SortByControl/DraggableDatetime.tsx
@@ -1,4 +1,4 @@
-import { RangeFormat } from '@eventespresso/dates';
+import { RangeFormat } from '@eventespresso/ee-components';
 import type { Datetime } from '@eventespresso/edtr-services';
 
 const formatTokens = { month: 'LLL' };

--- a/domains/eventEditor/src/ui/datetimes/datesList/filterBar/controls/SortByControl/DraggableDatetime.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/filterBar/controls/SortByControl/DraggableDatetime.tsx
@@ -1,4 +1,4 @@
-import { RangeFormat } from '@eventespresso/ee-components';
+import { RangeFormat } from '@eventespresso/dates';
 import type { Datetime } from '@eventespresso/edtr-services';
 
 const formatTokens = { month: 'LLL' };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/SortByControl/DraggableTicket.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/SortByControl/DraggableTicket.tsx
@@ -1,4 +1,5 @@
-import { CurrencyDisplay, RangeFormat } from '@eventespresso/ee-components';
+import { CurrencyDisplay } from '@eventespresso/ee-components';
+import { RangeFormat } from '@eventespresso/dates';
 import { Ticket } from '@eventespresso/edtr-services';
 
 const formatTokens = { month: 'LLL' };

--- a/domains/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/SortByControl/DraggableTicket.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/SortByControl/DraggableTicket.tsx
@@ -1,5 +1,4 @@
-import { CurrencyDisplay } from '@eventespresso/ee-components';
-import { RangeFormat } from '@eventespresso/dates';
+import { CurrencyDisplay, RangeFormat } from '@eventespresso/ee-components';
 import { Ticket } from '@eventespresso/edtr-services';
 
 const formatTokens = { month: 'LLL' };

--- a/packages/dates/src/components/RangeFormat/index.tsx
+++ b/packages/dates/src/components/RangeFormat/index.tsx
@@ -1,4 +1,4 @@
-import { format, isSameDay, isSameMonth, isSameYear } from 'date-fns';
+import { format as formatFunc, isSameDay, isSameMonth, isSameYear } from 'date-fns';
 import { useMemo } from 'react';
 
 import type { RangeFormatProps, RangeFormatTokens } from '../../types';
@@ -20,10 +20,11 @@ const DEFAULT_FORMAT_TOKENS: RangeFormatTokens = {
 
 export const RangeFormat: React.FC<RangeFormatProps> = ({
 	endDate,
+	formatFn: format = formatFunc,
 	formatTokens,
 	showTime,
 	startDate,
-}: RangeFormatProps) => {
+}) => {
 	const { ampm, day, daySeparator, hour, min, month, monthSeparator, timeSeparator, year, yearSeparator } = useMemo(
 		() => ({
 			...DEFAULT_FORMAT_TOKENS,

--- a/packages/dates/src/types.ts
+++ b/packages/dates/src/types.ts
@@ -25,6 +25,7 @@ export interface DateRangePickerProps extends ShowTime, Omit<ReactDatePickerProp
 
 export interface RangeFormatProps extends ShowTime {
 	endDate: string;
+	formatFn?: (date: Date, formatStr: string) => string;
 	formatTokens: RangeFormatTokens;
 	startDate: string;
 }

--- a/packages/ee-components/src/RangeFormat/RangeFormat.tsx
+++ b/packages/ee-components/src/RangeFormat/RangeFormat.tsx
@@ -1,0 +1,8 @@
+import { RangeFormat as RangeFormatAdapter } from '@eventespresso/dates';
+import { useTimeZoneTime } from '@eventespresso/services';
+
+export const RangeFormat: typeof RangeFormatAdapter = (props) => {
+	const { formatForSite } = useTimeZoneTime();
+
+	return <RangeFormatAdapter formatFn={formatForSite} {...props} />;
+};

--- a/packages/ee-components/src/RangeFormat/index.ts
+++ b/packages/ee-components/src/RangeFormat/index.ts
@@ -1,0 +1,1 @@
+export * from './RangeFormat';

--- a/packages/ee-components/src/index.ts
+++ b/packages/ee-components/src/index.ts
@@ -8,5 +8,6 @@ export * from './EntityEditForm';
 export * from './EntityList';
 export * from './filterBar';
 export * from './FormWithConfig';
+export * from './RangeFormat';
 export * from './rich-text-editor';
 export * from './SimpleTextEditorModal';


### PR DESCRIPTION
This PR fixes the inconsistent time shown in entity sort popover by formatting the time in site timezone.

Fixes #632 