### PR TITLE
Remove Entity Name Validation for Edit Forms

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/formValidation.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/formValidation.ts
@@ -1,4 +1,3 @@
-import { __ } from '@eventespresso/i18n';
 import * as yup from 'yup';
 
 import { datesSchema, DateFormShape } from '@eventespresso/edtr-services';

--- a/domains/eventEditor/src/ui/datetimes/dateForm/formValidation.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/formValidation.ts
@@ -9,9 +9,6 @@ export const validate = async (values: DateFormShape): Promise<any> => {
 };
 
 const validationSchema = yup.object({
-	name: yup
-		.string()
-		.required(() => __('Name is required'))
-		.min(3, () => __('Name must be at least three characters')),
+	name: yup.string(),
 	...datesSchema,
 });

--- a/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -73,8 +73,6 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 							name: 'name',
 							label: __('Name'),
 							fieldType: 'text',
-							required: true,
-							min: 3,
 						},
 						{
 							name: 'description',

--- a/domains/eventEditor/src/ui/tickets/ticketForm/formValidation.ts
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/formValidation.ts
@@ -9,9 +9,6 @@ export const validate = async (values: TicketFormShape): Promise<any> => {
 };
 
 const validationSchema = yup.object({
-	name: yup
-		.string()
-		.required(() => __('Name is required'))
-		.min(3, () => __('Name must be at least three characters')),
+	name: yup.string(),
 	...datesSchema,
 });

--- a/domains/eventEditor/src/ui/tickets/ticketForm/formValidation.ts
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/formValidation.ts
@@ -1,4 +1,3 @@
-import { __ } from '@eventespresso/i18n';
 import * as yup from 'yup';
 
 import { datesSchema, TicketFormShape } from '@eventespresso/edtr-services';

--- a/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -82,8 +82,6 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 							name: 'name',
 							label: __('Name'),
 							fieldType: 'text',
-							min: 3,
-							required: true,
 						},
 						{
 							name: 'description',


### PR DESCRIPTION
closes #https://github.com/eventespresso/event-espresso-core/issues/3273

this PR:

- simply removes the validation for the entity name fields in the edit forms