### PR TITLE
Fix stale entity data and wrong dates in table view

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 import classNames from 'classnames';
-import { format } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { filter, pipe } from 'ramda';
 
 import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components';
 import { filterCellByStartOrEndDate, useDatetimes } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
+import { useTimeZoneTime } from '@eventespresso/services';
 import { getDatetimeBackgroundColorClassName, datetimeStatus } from '@eventespresso/helpers';
 import { findEntityByGuid } from '@eventespresso/predicates';
 import { shortenGuid } from '@eventespresso/utils';
@@ -27,6 +28,7 @@ const addZebraStripes = addZebraStripesOnMobile(exclude);
 const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 	const datetimes = useDatetimes();
 	const getDatetime = useCallback((id: EntityId) => findEntityByGuid(datetimes)(id), [datetimes]);
+	const { formatForSite: format } = useTimeZoneTime();
 
 	return useCallback<DatesTableBodyRowGen>(
 		({ entityId, filterState }) => {
@@ -76,13 +78,13 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 			const startCell: CellData = {
 				key: 'start',
 				size: 'default',
-				value: format(new Date(datetime.startDate), ENTITY_LIST_DATE_TIME_FORMAT),
+				value: format(parseISO(datetime.startDate), ENTITY_LIST_DATE_TIME_FORMAT),
 			};
 
 			const endCell: CellData = {
 				key: 'end',
 				size: 'default',
-				value: format(new Date(datetime.endDate), ENTITY_LIST_DATE_TIME_FORMAT),
+				value: format(parseISO(datetime.endDate), ENTITY_LIST_DATE_TIME_FORMAT),
 			};
 
 			const capacityCell: CellData = {
@@ -142,7 +144,7 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 				type: 'row',
 			};
 		},
-		[getDatetime]
+		[format, getDatetime]
 	);
 };
 

--- a/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
@@ -4,10 +4,12 @@ import { format } from 'date-fns';
 import { filter, pipe } from 'ramda';
 
 import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components';
-import { filterCellByStartOrEndDate, useLazyDatetime } from '@eventespresso/edtr-services';
+import { filterCellByStartOrEndDate, useDatetimes } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
 import { getDatetimeBackgroundColorClassName, datetimeStatus } from '@eventespresso/helpers';
+import { findEntityByGuid } from '@eventespresso/predicates';
 import { shortenGuid } from '@eventespresso/utils';
+import type { EntityId } from '@eventespresso/data';
 import type { DatetimesFilterStateManager } from '@eventespresso/edtr-services';
 import type { BodyRowGeneratorFn } from '@eventespresso/ee-components';
 
@@ -23,7 +25,8 @@ const exclude = ['row', 'stripe', 'name', 'actions'];
 const addZebraStripes = addZebraStripesOnMobile(exclude);
 
 const useBodyRowGenerator = (): DatesTableBodyRowGen => {
-	const getDatetime = useLazyDatetime();
+	const datetimes = useDatetimes();
+	const getDatetime = useCallback((id: EntityId) => findEntityByGuid(datetimes)(id), [datetimes]);
 
 	return useCallback<DatesTableBodyRowGen>(
 		({ entityId, filterState }) => {

--- a/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
@@ -5,10 +5,12 @@ import { filter, pipe } from 'ramda';
 
 import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components';
 import { CurrencyDisplay } from '@eventespresso/ee-components';
-import { filterCellByStartOrEndDate, useLazyTicket } from '@eventespresso/edtr-services';
+import { filterCellByStartOrEndDate, useTickets } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
 import { getTicketBackgroundColorClassName, ticketStatus } from '@eventespresso/helpers';
+import { findEntityByGuid } from '@eventespresso/predicates';
 import { shortenGuid } from '@eventespresso/utils';
+import type { EntityId } from '@eventespresso/data';
 import type { BodyRowGeneratorFn } from '@eventespresso/ee-components';
 import type { TicketsFilterStateManager } from '@eventespresso/edtr-services';
 
@@ -21,7 +23,8 @@ import Checkbox from './Checkbox';
 type TicketsTableBodyRowGen = BodyRowGeneratorFn<TicketsFilterStateManager>;
 
 const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
-	const getTicket = useLazyTicket();
+	const tickets = useTickets();
+	const getTicket = useCallback((id: EntityId) => findEntityByGuid(tickets)(id), [tickets]);
 
 	return useCallback<TicketsTableBodyRowGen>(
 		({ entityId, filterState }) => {

--- a/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
@@ -1,12 +1,13 @@
 import { useCallback } from 'react';
 import classNames from 'classnames';
-import { format } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { filter, pipe } from 'ramda';
 
 import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components';
 import { CurrencyDisplay } from '@eventespresso/ee-components';
 import { filterCellByStartOrEndDate, useTickets } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
+import { useTimeZoneTime } from '@eventespresso/services';
 import { getTicketBackgroundColorClassName, ticketStatus } from '@eventespresso/helpers';
 import { findEntityByGuid } from '@eventespresso/predicates';
 import { shortenGuid } from '@eventespresso/utils';
@@ -25,6 +26,7 @@ type TicketsTableBodyRowGen = BodyRowGeneratorFn<TicketsFilterStateManager>;
 const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 	const tickets = useTickets();
 	const getTicket = useCallback((id: EntityId) => findEntityByGuid(tickets)(id), [tickets]);
+	const { formatForSite: format } = useTimeZoneTime();
 
 	return useCallback<TicketsTableBodyRowGen>(
 		({ entityId, filterState }) => {
@@ -73,13 +75,13 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 			const startCell: CellData = {
 				key: 'start',
 				size: 'default',
-				value: format(new Date(ticket.startDate), ENTITY_LIST_DATE_TIME_FORMAT),
+				value: format(parseISO(ticket.startDate), ENTITY_LIST_DATE_TIME_FORMAT),
 			};
 
 			const endCell: CellData = {
 				key: 'end',
 				size: 'default',
-				value: format(new Date(ticket.endDate), ENTITY_LIST_DATE_TIME_FORMAT),
+				value: format(parseISO(ticket.endDate), ENTITY_LIST_DATE_TIME_FORMAT),
 			};
 
 			const priceCell: CellData = {
@@ -150,7 +152,7 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 				type: 'row',
 			};
 		},
-		[getTicket]
+		[format, getTicket]
 	);
 };
 


### PR DESCRIPTION
This PR fixes the issue of table rows not updating when making changes to an entity.
It also fixes the wrong timezone for dates in table view

Note: It comes with a performance trade-off re-renders because of how the table is generated dynamically .

Fixes #675, #683 