### PR TITLE
Fix start end date validations/adjustments

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -8,6 +8,7 @@ import type { EspressoFormProps } from '@eventespresso/form';
 import { PLUS_ONE_MONTH } from '@eventespresso/constants';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { setDefaultTime } from '@eventespresso/dates';
+import { EndDateFieldWrapper } from '@eventespresso/ee-components';
 import { EntityId } from '@eventespresso/data';
 import { __ } from '@eventespresso/i18n';
 import type { Datetime, DateFormShape, DateFormConfig } from '@eventespresso/edtr-services';
@@ -97,6 +98,7 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 							label: __('End Date'),
 							fieldType: 'datetimepicker',
 							required: true,
+							wrapper: EndDateFieldWrapper,
 						},
 					],
 				},

--- a/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
@@ -15,7 +15,7 @@ const DateCardSidebar: React.FC<DateItemProps> = ({ entity: date }) => {
 	const { updateEntity } = useDatetimeMutator(date.id);
 	const { siteTimeToUtc } = useTimeZoneTime();
 
-	const onEditHandler = useCallback(
+	const onChange = useCallback(
 		([start, end]: DateRange): void => {
 			// convert start & end dates to proper UTC "startDate" and "endDate"
 			const startDate = siteTimeToUtc(start).toISOString();
@@ -36,7 +36,7 @@ const DateCardSidebar: React.FC<DateItemProps> = ({ entity: date }) => {
 			<EditDateRangeButton
 				endDate={date.endDate}
 				header={__('Edit Event Date')}
-				onEditHandler={onEditHandler}
+				onChange={onChange}
 				popoverPlacement='right-end'
 				startDate={date.startDate}
 				tooltip={__('edit start and end dates')}

--- a/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -11,6 +11,7 @@ import { EntityId } from '@eventespresso/data';
 import { __ } from '@eventespresso/i18n';
 import type { EspressoFormProps } from '@eventespresso/form';
 import type { Ticket, TicketFormConfig } from '@eventespresso/edtr-services';
+import { EndDateFieldWrapper } from '@eventespresso/ee-components';
 
 import { validate } from './formValidation';
 
@@ -106,6 +107,7 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 							label: __('End Date'),
 							fieldType: 'datetimepicker',
 							required: true,
+							wrapper: EndDateFieldWrapper,
 						},
 					],
 				},

--- a/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
@@ -14,7 +14,7 @@ const TicketCardSidebar: React.FC<Partial<TicketItemProps>> = ({ entity: ticket 
 	const { updateEntity } = useTicketMutator(ticket.id);
 	const { siteTimeToUtc } = useTimeZoneTime();
 
-	const onEditHandler = useCallback(
+	const onChange = useCallback(
 		([start, end]: DateRange): void => {
 			// convert start & end dates to proper UTC "startDate" and "endDate"
 			const startDate = siteTimeToUtc(start).toISOString();
@@ -35,7 +35,7 @@ const TicketCardSidebar: React.FC<Partial<TicketItemProps>> = ({ entity: ticket 
 			<EditDateRangeButton
 				endDate={ticket.endDate}
 				header={__('Edit Ticket Sale Dates')}
-				onEditHandler={onEditHandler}
+				onChange={onChange}
 				popoverPlacement='left-end'
 				startDate={ticket.startDate}
 				tooltip={__('edit ticket sales start and end dates')}

--- a/domains/rem/src/ui/Tickets/formValidation.ts
+++ b/domains/rem/src/ui/Tickets/formValidation.ts
@@ -1,10 +1,10 @@
-import { __ } from '@eventespresso/i18n';
 import * as yup from 'yup';
 
+import { __ } from '@eventespresso/i18n';
 import { yupToFinalFormErrors } from '@eventespresso/form';
 import { IntervalType } from '@eventespresso/dates';
 import { datesSchema, requiredMessage } from '@eventespresso/edtr-services';
-import { TicketSalesDates } from './types';
+
 import { RemTicket } from '../../data';
 
 export const validate = async (values: RemTicket): Promise<any> => {
@@ -14,11 +14,8 @@ export const validate = async (values: RemTicket): Promise<any> => {
 /**
  * switches required schema based on the value of isShared
  */
-const requiredWhenIsSharedEquals = <T extends any>(
-	isSharedEquals: boolean,
-	objectShape: yup.ObjectSchemaDefinition<yup.ObjectSchema['shape']>
-): yup.WhenOptionsBuilderFunction<T> => {
-	return ((isShared: boolean, schema: yup.ObjectSchema) => {
+const requiredWhenIsSharedEquals = (isSharedEquals: boolean, objectShape: Record<string, yup.BaseSchema>) => {
+	return (isShared: boolean, schema: yup.BaseSchema) => {
 		// if isShared equals the expected value
 		if (isShared === isSharedEquals) {
 			// make the field required and set its shape
@@ -26,10 +23,10 @@ const requiredWhenIsSharedEquals = <T extends any>(
 		}
 		// otherwise return the actual schema
 		return schema;
-	}) as yup.WhenOptionsBuilderFunction<T>;
+	};
 };
 
-const salesDatesSchema = yup.object<TicketSalesDates>().when(
+const salesDatesSchema = yup.object().when(
 	'isShared',
 	// make it required when `isShared` is true
 	requiredWhenIsSharedEquals(true, datesSchema)
@@ -49,7 +46,7 @@ const ticketSalesSchema = yup.object().when(
 	})
 );
 
-const validationSchema = yup.object<Partial<RemTicket>>({
+const validationSchema = yup.object({
 	name: yup
 		.string()
 		.required(() => __('Name is required'))

--- a/packages/dates/src/components/DateRangePicker/index.tsx
+++ b/packages/dates/src/components/DateRangePicker/index.tsx
@@ -7,13 +7,17 @@ import { NOW } from '@eventespresso/constants';
 import { DatePicker, DateTimePicker } from '../';
 import { DateRangePickerLegend } from './DateRangePickerLegend';
 import type { DateRangePickerProps } from '../../types';
+import { isOnOrBeforeDate, setTimeToJustBeforeZeroHour } from '../../utils';
 
 import './styles.scss';
+
+const justBeforeZeroHour = setTimeToJustBeforeZeroHour(new Date());
 
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 	endDateTZ,
 	endLabel,
 	inputValue,
+	limitEndByStart,
 	onChange,
 	showTime,
 	startDateTZ,
@@ -29,6 +33,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [endDate, startDate]);
 
+	// if the state changes from the consumer, we need to update the local state
+	useEffect(() => {
+		setStartDate(value?.[0]);
+		setEndDate(value?.[1]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [value]);
+
 	const onChangeStart = useCallback((date) => setStartDate(date), []);
 
 	const onChangeEnd = useCallback((date) => setEndDate(date), []);
@@ -37,6 +48,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 
 	const Component = showTime ? DateTimePicker : DatePicker;
 
+	// if start and end dates are on the same day of the month
+	const isOnSameDay = isOnOrBeforeDate(endDate, startDate, false);
+
+	// add time restrictions only if the day is same as startDate
+	const minTime = limitEndByStart && isOnSameDay && startDate;
+	const maxTime = limitEndByStart && isOnSameDay && justBeforeZeroHour;
+	const minDate = limitEndByStart && startDate;
 	return (
 		<div className={className}>
 			<div className='date-range-picker__start'>
@@ -68,6 +86,9 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 						selectsEnd
 						startDate={startDate}
 						value={endDate}
+						minDate={minDate}
+						minTime={minTime}
+						maxTime={maxTime}
 						{...props}
 					>
 						<DateRangePickerLegend />

--- a/packages/dates/src/types.ts
+++ b/packages/dates/src/types.ts
@@ -16,6 +16,7 @@ export interface DateRangePickerProps extends ShowTime, Omit<ReactDatePickerProp
 	endDateTZ?: React.ReactNode;
 	endLabel?: string;
 	inputValue?: [string, string];
+	limitEndByStart?: boolean;
 	locale?: string; // "en-US", "en_US", "ar" etc.
 	onChange: (dates: DateRange) => void;
 	startLabel?: string;

--- a/packages/dates/src/utils/misc.ts
+++ b/packages/dates/src/utils/misc.ts
@@ -111,7 +111,7 @@ type AdjustEndDateArgs = {
 };
 
 /**
- * utility function to see if end date needs to adjusted
+ * utility function to see if end date needs to be adjusted
  * based upon the new start date
  */
 export const mayBeAdjustEndDate = ({

--- a/packages/dates/src/utils/misc.ts
+++ b/packages/dates/src/utils/misc.ts
@@ -7,8 +7,10 @@ import type { OptionsType } from '@eventespresso/adapters';
 import { NOW } from '@eventespresso/constants';
 
 import { add, sub } from './addSub';
+import diff from './diff';
 import type { Intervals, ShiftDateArgs } from './types';
 import type { PrepDatesComparisonFunc } from './types';
+import isOnOrBeforeDate from './isOnOrBeforeDate';
 
 export const DATE_INTERVALS: Intervals = {
 	months: __('month(s)'),
@@ -99,4 +101,32 @@ export const prepDatesForComparison: PrepDatesComparisonFunc = (firstDate, secon
 	}
 
 	return [parsedFirstDate, parsedSecondDate];
+};
+
+type AdjustEndDateArgs = {
+	newEndDate: Date;
+	newStartDate: Date;
+	prevEndDate: Date;
+	prevStartDate: Date;
+};
+
+/**
+ * utility function to see if end date needs to adjusted
+ * based upon the new start date
+ */
+export const mayBeAdjustEndDate = ({
+	newEndDate,
+	newStartDate,
+	prevEndDate,
+	prevStartDate,
+}: AdjustEndDateArgs): Date => {
+	const isStartDateAfterEndDate = newStartDate > newEndDate;
+
+	if (isStartDateAfterEndDate) {
+		// calculate the difference between previous start and end date in minutes.
+		const difference = diff('minutes', prevEndDate, prevStartDate);
+		// add the difference to end date
+		return add('minutes', newStartDate, difference);
+	}
+	return newEndDate;
 };

--- a/packages/dates/src/utils/misc.ts
+++ b/packages/dates/src/utils/misc.ts
@@ -54,6 +54,12 @@ export const setDefaultTime = (date: Date, type: 'start' | 'end' = 'start'): Dat
 export const setTimeToZeroHour = (date: Date): Date => pipe(setHours(0), setMinutes(0), setSeconds(0))(date);
 
 /**
+ * Sets the time of the date object to 23:59:59
+ */
+export const setTimeToJustBeforeZeroHour = (date: Date): Date =>
+	pipe(setHours(23), setMinutes(59), setSeconds(59))(date);
+
+/**
  * Sets the time of the date object to noon
  */
 export const setTimeToNoon = (date: Date): Date => pipe(setHours(12), setMinutes(0), setSeconds(0))(date);

--- a/packages/dates/src/utils/misc.ts
+++ b/packages/dates/src/utils/misc.ts
@@ -10,7 +10,6 @@ import { add, sub } from './addSub';
 import diff from './diff';
 import type { Intervals, ShiftDateArgs } from './types';
 import type { PrepDatesComparisonFunc } from './types';
-import isOnOrBeforeDate from './isOnOrBeforeDate';
 
 export const DATE_INTERVALS: Intervals = {
 	months: __('month(s)'),

--- a/packages/edtr-services/src/apollo/mutations/prices/test/deletePrice.test.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/test/deletePrice.test.ts
@@ -100,8 +100,8 @@ describe('deletePrice', () => {
 
 		await actWait();
 
-		act(() => {
-			mutationResult.current.mutator.deleteEntity(testInput);
+		act(async () => {
+			await mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve

--- a/packages/edtr-services/src/apollo/mutations/prices/test/deletePrice.test.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/test/deletePrice.test.ts
@@ -100,12 +100,9 @@ describe('deletePrice', () => {
 
 		await actWait();
 
-		act(async () => {
+		await act(async () => {
 			await mutationResult.current.mutator.deleteEntity(testInput);
 		});
-
-		// wait for mutation promise to resolve
-		await actWait();
 
 		const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
 			entity: 'prices',

--- a/packages/edtr-services/src/utils/dateAndTime.ts
+++ b/packages/edtr-services/src/utils/dateAndTime.ts
@@ -34,7 +34,7 @@ export const startAndEndDateFixer: Decorator<any, any> = (form) => {
 						const newEndDate = add('minutes', startDate, difference);
 						form.change('endDate', newEndDate);
 						form.mutators.setFieldData('endDate', { changedFromStartDate: true });
-						endDateFieldNotice = __('End date has been adusted');
+						endDateFieldNotice = __('End date has been adjusted');
 					}
 
 					form.mutators.setFieldData('endDate', { fieldNotice: endDateFieldNotice });

--- a/packages/edtr-services/src/utils/dateAndTime.ts
+++ b/packages/edtr-services/src/utils/dateAndTime.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import { add, diff, endDateAfterStartDateErrorMessage, mayBeAdjustEndDate } from '@eventespresso/dates';
+import { endDateAfterStartDateErrorMessage, mayBeAdjustEndDate } from '@eventespresso/dates';
 import { __ } from '@eventespresso/i18n';
 import { Decorator } from '@eventespresso/form';
 

--- a/packages/ee-components/src/EndDateFieldWrapper.tsx
+++ b/packages/ee-components/src/EndDateFieldWrapper.tsx
@@ -1,0 +1,32 @@
+import { FormSpy, FieldWrapperProps } from '@eventespresso/form';
+import { setTimeToJustBeforeZeroHour, isOnOrBeforeDate } from '@eventespresso/dates';
+
+// for 'react-datepicker`, if you specify minTime, you have to specify maxTime as well ¯\_(ツ)_/¯
+// So lets make a fool of it.
+const maxTime = setTimeToJustBeforeZeroHour(new Date());
+
+const subscription = { values: true };
+export const EndDateFieldWrapper: React.FC<FieldWrapperProps> = ({ fieldType, component: Component, ...props }) => {
+	return (
+		<FormSpy subscription={subscription}>
+			{({ values }) => {
+				const startDate = values.startDate;
+				const endDate = props.input.value;
+
+				// if start and end dates are on the same day of the month
+				const isOnSameDay = isOnOrBeforeDate(endDate, startDate, false);
+				return (
+					<Component
+						// just to avoid `fieldType` going to DOM
+						data-type={fieldType}
+						{...props}
+						minDate={values.startDate}
+						// add time restrictions only if the day is same as startDate
+						minTime={isOnSameDay && startDate}
+						maxTime={isOnSameDay && maxTime}
+					/>
+				);
+			}}
+		</FormSpy>
+	);
+};

--- a/packages/ee-components/src/index.ts
+++ b/packages/ee-components/src/index.ts
@@ -4,6 +4,7 @@ export * from './CurrencyDisplay';
 export * from './DatePicker';
 export * from './DateTimePicker';
 export * from './EditDateRangeButton';
+export * from './EndDateFieldWrapper';
 export * from './EntityEditForm';
 export * from './EntityList';
 export * from './filterBar';

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -21,10 +21,9 @@
 		"final-form-set-field-data": "1.0.2",
 		"react-final-form": "^6.5.2",
 		"react-final-form-arrays": "^3.1.3",
-		"yup": "^0.31.1"
+		"yup": "^0.32.8"
 	},
 	"devDependencies": {
-		"@types/yup": "^0.29.11",
 		"@types/final-form-set-field-data": "1.0.0"
 	},
 	"license": "GPL-3.0",

--- a/packages/form/src/adapters/MappedField.tsx
+++ b/packages/form/src/adapters/MappedField.tsx
@@ -15,7 +15,9 @@ import NumberField from './Number';
 import type { FieldRendererProps } from '../types';
 import { fieldPropsAreEqual } from '../utils';
 
-export const MappedField: React.FC<FieldRendererProps> = ({ fieldType, ...props }) => {
+const DefaultComponent = () => null;
+
+export const MappedField: React.FC<FieldRendererProps> = ({ fieldType, wrapper: Wrapper, ...props }) => {
 	let Component: React.ComponentType<Omit<FieldRendererProps, 'fieldType'>>;
 
 	switch (fieldType) {
@@ -56,11 +58,11 @@ export const MappedField: React.FC<FieldRendererProps> = ({ fieldType, ...props 
 			Component = Hidden;
 			break;
 		default:
-			Component = () => null;
+			Component = DefaultComponent;
 			break;
 	}
 
-	return Component && <Component {...props} />;
+	return Wrapper ? <Wrapper {...props} fieldType={fieldType} component={Component} /> : <Component {...props} />;
 };
 
 export default memo(MappedField, fieldPropsAreEqual);

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -42,6 +42,10 @@ type FieldType =
 	| 'textarea'
 	| 'timepicker';
 
+export interface FieldWrapperProps extends Omit<FieldRendererProps, 'component'> {
+	component: React.ComponentType<Omit<FieldRendererProps, 'fieldType'>>;
+}
+
 export interface AdditionalFieldProps<FormValues = AnyObject> {
 	label?: string | JSX.Element;
 	fieldType: FieldType;
@@ -55,6 +59,7 @@ export interface AdditionalFieldProps<FormValues = AnyObject> {
 	conditions?: FieldConditions;
 	formControlProps?: FormControlProps;
 	parseAsInfinity?: boolean;
+	wrapper?: React.ComponentType<FieldWrapperProps>;
 	[key: string]: any;
 }
 

--- a/packages/form/src/utils.ts
+++ b/packages/form/src/utils.ts
@@ -120,7 +120,7 @@ export const evalFieldConditions = (conditions: FieldConditions, formData: AnyOb
  * @param validationSchema
  * @param values
  */
-export const yupToFinalFormErrors = async <T>(validationSchema: ObjectSchema, values: T): Promise<AnyObject> => {
+export const yupToFinalFormErrors = async <T>(validationSchema: ObjectSchema<any>, values: T): Promise<AnyObject> => {
 	try {
 		await validationSchema.validate(values, { abortEarly: false });
 	} catch (err) {

--- a/packages/ui-components/src/EditDateRangeButton/EditDateRangeButton.tsx
+++ b/packages/ui-components/src/EditDateRangeButton/EditDateRangeButton.tsx
@@ -36,7 +36,7 @@ export const EditDateRangeButton: React.FC<EditDateRangeButtonProps> = ({
 
 	const content = (
 		<DateTimeRangePicker
-			dateAjustedMessage={__('End date has been adusted')}
+			dateAjustedMessage={__('End date has been adjusted')}
 			dateFormat={dateTimeFormat}
 			enforceDatesInOrder
 			locale={locale}

--- a/packages/ui-components/src/EditDateRangeButton/EditDateRangeButton.tsx
+++ b/packages/ui-components/src/EditDateRangeButton/EditDateRangeButton.tsx
@@ -15,7 +15,7 @@ export const EditDateRangeButton: React.FC<EditDateRangeButtonProps> = ({
 	dateTimeFormat,
 	header,
 	locale,
-	onEditHandler,
+	onChange,
 	startDate,
 	endDate,
 	popoverPlacement,
@@ -25,20 +25,22 @@ export const EditDateRangeButton: React.FC<EditDateRangeButtonProps> = ({
 	const { isOpen, onOpen, onClose } = useDisclosure();
 	const isMobile = !useViewportWidthGreaterThan(RESPONSIVE_CARD_SWITCH_BREAKPOINT);
 
-	const onChange = useCallback(
+	const onChangeHandler = useCallback(
 		(dates: DateRange) => {
-			onEditHandler(dates);
+			onChange(dates);
 			onClose();
 		},
-		[onClose, onEditHandler]
+		[onClose, onChange]
 	);
 	const value = useMemoStringify<DateRange>([startDate, endDate]);
 
 	const content = (
 		<DateTimeRangePicker
+			dateAjustedMessage={__('End date has been adusted')}
 			dateFormat={dateTimeFormat}
+			enforceDatesInOrder
 			locale={locale}
-			onChange={onChange}
+			onChange={onChangeHandler}
 			TimezoneTimeInfo={TimezoneTimeInfo}
 			value={value}
 		/>

--- a/packages/ui-components/src/EditDateRangeButton/types.ts
+++ b/packages/ui-components/src/EditDateRangeButton/types.ts
@@ -4,12 +4,14 @@ import type { LabelPosition } from '../withLabel';
 import type { ButtonProps } from '../Button';
 import { DateTimeRangePickerProps } from '../DateTimeRangePicker';
 
-export interface EditDateRangeButtonProps extends ButtonProps, Pick<DateTimeRangePickerProps, 'TimezoneTimeInfo'> {
+export interface EditDateRangeButtonProps
+	extends Omit<ButtonProps, 'onChange'>,
+		Pick<DateTimeRangePickerProps, 'TimezoneTimeInfo'> {
 	dateTimeFormat?: string;
 	endDate: Date;
 	header?: string;
 	locale?: string;
-	onEditHandler: (dates: DateRange) => void;
+	onChange: (dates: DateRange) => void;
 	popoverPlacement?: PopoverProps['placement'];
 	startDate: Date;
 	tooltip?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4537,6 +4537,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.166.tgz#07e7f2699a149219dbc3c35574f126ec8737688f"
   integrity sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==
 
+"@types/lodash@^4.14.165":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
@@ -4936,11 +4941,6 @@
   integrity sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
   dependencies:
     "@types/yargs-parser" "*"
-
-"@types/yup@^0.29.11":
-  version "0.29.11"
-  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.11.tgz#d654a112973f5e004bf8438122bd7e56a8e5cd7e"
-  integrity sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g==
 
 "@types/zen-observable@^0.8.0":
   version "0.8.2"
@@ -15082,6 +15082,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
+
 nanoid@^3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
@@ -21997,14 +22002,16 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^0.31.1:
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.31.1.tgz#0954cb181161f397b804346037a04f8a4b31599e"
-  integrity sha512-Lf6648jDYOWR75IlWkVfwesPyW6oj+50NpxlKvsQlpPsB8eI+ndI7b4S1VrwbmeV9hIZDu1MzrlIL4W+gK1jPw==
+yup@^0.32.8:
+  version "0.32.8"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.8.tgz#16e4a949a86a69505abf99fd0941305ac9adfc39"
+  integrity sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==
   dependencies:
     "@babel/runtime" "^7.10.5"
+    "@types/lodash" "^4.14.165"
     lodash "^4.17.20"
     lodash-es "^4.17.11"
+    nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
 


### PR DESCRIPTION
This PR fixes the validations and adjustments made to start and end dates. Here is the implemented behavior:

- User can change start date to any value, without any restrictions
- End date is limited to be after the start date, i.e. the user cannot select end date earlier than start date
- If start date is changed to later than end date, then end date is adjusted by computing the difference between the start and end dates and then adding that difference to end date.
- When the end date is adjusted, it shows an info message that the end date has been adjusted.

Closes #698 

![demo](https://user-images.githubusercontent.com/18226415/106754286-ce559a00-6652-11eb-9af9-3549415d5f41.gif)
