### PR TITLE
Consolidate Apollo imports

### DIFF
--- a/domains/blocks/src/services/apollo/queries/attendees/queries.ts
+++ b/domains/blocks/src/services/apollo/queries/attendees/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const ATTENDEE_ATTRIBUTES: any = gql`
 	fragment blocksAttendeeAttributes on EspressoAttendee {

--- a/domains/blocks/src/services/apollo/queries/datetimes/queries.ts
+++ b/domains/blocks/src/services/apollo/queries/datetimes/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const DATETIME_ATTRIBUTES: any = gql`
 	fragment blocksDatetimeAttributes on EspressoDatetime {

--- a/domains/blocks/src/services/apollo/queries/events/queries.ts
+++ b/domains/blocks/src/services/apollo/queries/events/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const EVENT_ATTRIBUTES: any = gql`
 	fragment blocksEventAttributes on EspressoEvent {

--- a/domains/blocks/src/services/apollo/queries/tickets/queries.ts
+++ b/domains/blocks/src/services/apollo/queries/tickets/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const TICKET_ATTRIBUTES: any = gql`
 	fragment blocksTicketAttributes on EspressoTicket {

--- a/domains/blocks/src/services/utils.ts
+++ b/domains/blocks/src/services/utils.ts
@@ -1,7 +1,5 @@
-import type { ApolloError } from 'apollo-client';
 import { __ } from '@eventespresso/i18n';
-
-import type { Order, EntityQueryOrderBy, AttendeesOrderByFields } from '@eventespresso/data';
+import type { ApolloError, Order, EntityQueryOrderBy, AttendeesOrderByFields } from '@eventespresso/data';
 import type { OptionsType } from '@eventespresso/adapters';
 
 export const buildEntitySelectOptions = (list: Array<any>, loading: boolean, error: ApolloError): OptionsType => {

--- a/domains/rem/src/services/apollo/mutations/recurrences/index.ts
+++ b/domains/rem/src/services/apollo/mutations/recurrences/index.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 import { RECURRENCE_ATTRIBUTES } from '../../queries/recurrences';
 
 export const CREATE_RECURRENCE = gql`

--- a/domains/rem/src/services/apollo/mutations/recurrences/useMutationVariables.ts
+++ b/domains/rem/src/services/apollo/mutations/recurrences/useMutationVariables.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import type { OperationVariables } from 'apollo-client';
 
-import type { MutationType, MutationInput } from '@eventespresso/data';
+import type { OperationVariables, MutationType, MutationInput } from '@eventespresso/data';
 
 type MutationVariablesCb = (mutationType: MutationType, input: MutationInput) => OperationVariables;
 

--- a/domains/rem/src/services/apollo/queries/recurrences/queries.ts
+++ b/domains/rem/src/services/apollo/queries/recurrences/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const RECURRENCE_ATTRIBUTES: any = gql`
 	fragment recurrenceAttributes on EspressoRecurrence {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
 		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
-		"@apollo/react-testing": "^4.0.0",
 		"@babel/core": "7.12.10",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -16,13 +16,8 @@
 	},
 	"sideEffects": false,
 	"dependencies": {
-		"@apollo/react-hooks": "^4.0.0",
-		"apollo-cache-inmemory": "^1.6.6",
-		"apollo-client": "^2.6.10",
-		"apollo-link-batch-http": "^1.2.14",
-		"graphql": "^15.4.0",
-		"graphql-tag": "^2.11.0",
-		"react": "^17.0.1"
+		"@apollo/client": "3.2.7",
+		"graphql": "^15.5.0"
 	},
 	"license": "GPL-3.0",
 	"gitHead": "66fae0230a22c100153cb05f5a624305efc5a8d9"

--- a/packages/data/src/DataProvider.tsx
+++ b/packages/data/src/DataProvider.tsx
@@ -1,4 +1,4 @@
-import { ApolloProvider } from '@apollo/react-hooks';
+import { ApolloProvider } from '@apollo/client';
 
 import { getClient } from './client';
 

--- a/packages/data/src/events.ts
+++ b/packages/data/src/events.ts
@@ -1,4 +1,4 @@
-import type { ApolloError } from '@apollo/react-hooks';
+import type { ApolloError } from '@apollo/client';
 
 import { EventEmitter } from '@eventespresso/events';
 

--- a/packages/data/src/hooks/useReactiveVariable.ts
+++ b/packages/data/src/hooks/useReactiveVariable.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useReactiveVar, ReactiveVar } from '@apollo/react-hooks';
+import { useReactiveVar, ReactiveVar } from '@apollo/client';
 
 export type ReactiveVariable<T> = [T, ReactiveVar<T>];
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -8,7 +8,25 @@ export * from './mutations';
 export * from './queries';
 export * from './types';
 export * from './DataProvider';
+export * from './withDataProvider';
 
-export * from '@apollo/react-hooks';
-export * from '@apollo/client';
-export { default as withDataProvider } from './withDataProvider';
+// export everything explicitely instead of export *
+export {
+	gql,
+	makeVar,
+	useApolloClient,
+	useLazyQuery,
+	useMutation,
+	useQuery,
+	useReactiveVar,
+	useSubscription,
+} from '@apollo/client';
+
+export type {
+	ApolloCache,
+	ApolloError,
+	GraphQLRequest,
+	OperationVariables,
+	QueryHookOptions,
+	ReactiveVar,
+} from '@apollo/client';

--- a/packages/data/src/mutations/useMutationWithFeedback.ts
+++ b/packages/data/src/mutations/useMutationWithFeedback.ts
@@ -1,7 +1,6 @@
 import { useCallback, useRef } from 'react';
-import { MutationTuple, useMutation } from '@apollo/react-hooks';
+import { MutationTuple, OperationVariables, useMutation } from '@apollo/client';
 import { DocumentNode } from 'graphql';
-import { OperationVariables } from 'apollo-client';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { MutationType } from './types';

--- a/packages/data/src/queries/attendees/useAttendeesQuery.ts
+++ b/packages/data/src/queries/attendees/useAttendeesQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { AttendeesList, AttendeesQueryArgs } from './types';

--- a/packages/data/src/queries/currentUser/queries.ts
+++ b/packages/data/src/queries/currentUser/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 export const GET_CURRENT_USER: any = gql`
 	query GET_CURRENT_USER {

--- a/packages/data/src/queries/currentUser/test/useUpdateCurrentUserCache.test.ts
+++ b/packages/data/src/queries/currentUser/test/useUpdateCurrentUserCache.test.ts
@@ -1,4 +1,4 @@
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import { useCacheRehydration } from '@eventespresso/edtr-services';

--- a/packages/data/src/queries/datetimes/useDatetimesQuery.ts
+++ b/packages/data/src/queries/datetimes/useDatetimesQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { DatetimesList, DatetimesQueryArgs } from './types';

--- a/packages/data/src/queries/events/useEventsQuery.ts
+++ b/packages/data/src/queries/events/useEventsQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { EventsList, EventsQueryArgs } from './types';

--- a/packages/data/src/queries/generalSettings/queries.ts
+++ b/packages/data/src/queries/generalSettings/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client';
 
 export const GET_GENERAL_SETTINGS: any = gql`
 	query GET_GENERAL_SETTINGS {

--- a/packages/data/src/queries/generalSettings/test/useUpdateGeneralSettingsCache.test.ts
+++ b/packages/data/src/queries/generalSettings/test/useUpdateGeneralSettingsCache.test.ts
@@ -1,4 +1,4 @@
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import { useCacheRehydration } from '@eventespresso/edtr-services';

--- a/packages/data/src/queries/prices/usePricesQuery.ts
+++ b/packages/data/src/queries/prices/usePricesQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { PricesList, PricesQueryArgs } from './types';

--- a/packages/data/src/queries/recurrences/useRecurrencesQuery.ts
+++ b/packages/data/src/queries/recurrences/useRecurrencesQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { RecurrencesList, RecurrencesQueryArgs } from './types';

--- a/packages/data/src/queries/tickets/useTicketsQuery.ts
+++ b/packages/data/src/queries/tickets/useTicketsQuery.ts
@@ -1,4 +1,4 @@
-import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/react-hooks';
+import type { QueryHookOptions, QueryResult as ApolloQueryResult } from '@apollo/client';
 
 import { useCacheQuery } from '../';
 import type { TicketsList, TicketsQueryArgs } from './types';

--- a/packages/data/src/queries/types.ts
+++ b/packages/data/src/queries/types.ts
@@ -1,8 +1,5 @@
-import type { QueryHookOptions } from '@apollo/react-hooks';
+import type { ApolloError, DataProxy, QueryHookOptions, OperationVariables } from '@apollo/client';
 import type { DocumentNode } from 'graphql';
-import type { OperationVariables } from 'apollo-client';
-import type { DataProxy } from 'apollo-cache';
-import type { ApolloError } from 'apollo-client';
 
 export interface EntityQueryArgs<WhereArgs> {
 	after?: string;

--- a/packages/data/src/queries/useCacheQuery.ts
+++ b/packages/data/src/queries/useCacheQuery.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { useQuery } from '@apollo/react-hooks';
-import type { QueryHookOptions, QueryResult } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/client';
+import type { QueryHookOptions, QueryResult } from '@apollo/client';
 
 const useCacheQuery = <TData = any>(queryOptions: QueryHookOptions<TData>): QueryResult<TData> => {
 	const options = useMemo<QueryHookOptions<TData>>(() => ({ fetchPolicy: 'cache-only', ...queryOptions }), [

--- a/packages/data/src/queries/useLazyCacheQuery.ts
+++ b/packages/data/src/queries/useLazyCacheQuery.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useApolloClient, DataProxy, OperationVariables } from '@apollo/react-hooks';
+import { useApolloClient, DataProxy, OperationVariables } from '@apollo/client';
 
 type Callback<T = any, V = OperationVariables> = (options: DataProxy.Query<V, T>) => T;
 

--- a/packages/data/src/queries/useUpdateCache.ts
+++ b/packages/data/src/queries/useUpdateCache.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useApolloClient } from '@apollo/react-hooks';
+import { useApolloClient } from '@apollo/client';
 
 import type { WriteQueryOptions, CacheUpdaterFn } from './types';
 

--- a/packages/data/src/withDataProvider.tsx
+++ b/packages/data/src/withDataProvider.tsx
@@ -1,7 +1,7 @@
 import { DataProvider } from './DataProvider';
 import type { AnyObject } from '@eventespresso/utils';
 
-const withDataProvider = <P extends AnyObject>(Component: React.ComponentType<P>): React.FC<P> => {
+export const withDataProvider = <P extends AnyObject>(Component: React.ComponentType<P>): React.FC<P> => {
 	const WrappedComponent: React.FC<P> = (props) => {
 		return (
 			<DataProvider>
@@ -12,5 +12,3 @@ const withDataProvider = <P extends AnyObject>(Component: React.ComponentType<P>
 
 	return WrappedComponent;
 };
-
-export default withDataProvider;

--- a/packages/edtr-services/src/apollo/mutations/datetimes/index.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/index.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 import { DATETIME_ATTRIBUTES } from '../../queries/datetimes';
 
 export const CREATE_DATETIME = gql`

--- a/packages/edtr-services/src/apollo/mutations/datetimes/test/data.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/test/data.ts
@@ -1,9 +1,8 @@
-import { GraphQLRequest } from 'apollo-link';
 import { pickBy } from 'ramda';
 import { ExecutionResult } from 'graphql';
 
 import { nodes as datetimes } from '../../../queries/datetimes/test/data';
-import { MutationInput, MutationType } from '@eventespresso/data';
+import { GraphQLRequest, MutationInput, MutationType } from '@eventespresso/data';
 import { ucFirst } from '@eventespresso/utils';
 import { eventId } from '../../../../context/test';
 import type { MockedResponse } from '../../../../context/test/types';

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useMutationVariables.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import type { OperationVariables } from 'apollo-client';
 
-import type { MutationType, MutationInput } from '@eventespresso/data';
+import type { MutationType, MutationInput, OperationVariables } from '@eventespresso/data';
 
 import { useEventId } from '../../queries/events';
 

--- a/packages/edtr-services/src/apollo/mutations/events/index.ts
+++ b/packages/edtr-services/src/apollo/mutations/events/index.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 import { EVENT_ATTRIBUTES } from '../../queries/events';
 

--- a/packages/edtr-services/src/apollo/mutations/events/useMutationHandler.ts
+++ b/packages/edtr-services/src/apollo/mutations/events/useMutationHandler.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
-import { OperationVariables } from 'apollo-client';
+
+import { MutationType, MutationInput, OperationVariables } from '@eventespresso/data';
 
 import useOptimisticResponse from './useOptimisticResponse';
 import type { MutationHandler } from '../types';
-import { MutationType, MutationInput } from '@eventespresso/data';
 import type { Event } from '../../';
 import type { EventBaseInput } from './types';
 

--- a/packages/edtr-services/src/apollo/mutations/prices/index.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/index.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 import { PRICE_ATTRIBUTES } from '../../queries/prices';
 
 export const CREATE_PRICE = gql`

--- a/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/useMutationVariables.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import type { OperationVariables } from 'apollo-client';
 
-import type { MutationType, MutationInput } from '@eventespresso/data';
+import type { MutationType, MutationInput, OperationVariables } from '@eventespresso/data';
 
 type MutationVariablesCb = (mutationType: MutationType, input: MutationInput) => OperationVariables;
 

--- a/packages/edtr-services/src/apollo/mutations/tickets/index.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/index.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 import { TICKET_ATTRIBUTES } from '../../queries/tickets';
 import { PRICE_ATTRIBUTES } from '../../queries/prices';
 

--- a/packages/edtr-services/src/apollo/mutations/tickets/useMutationVariables.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useMutationVariables.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import type { OperationVariables } from 'apollo-client';
 
-import type { MutationType, MutationInput } from '@eventespresso/data';
+import type { MutationType, MutationInput, OperationVariables } from '@eventespresso/data';
 
 type MutationVariablesCb = (mutationType: MutationType, input: MutationInput) => OperationVariables;
 

--- a/packages/edtr-services/src/apollo/mutations/useBulkDeleteEntities.ts
+++ b/packages/edtr-services/src/apollo/mutations/useBulkDeleteEntities.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
-import { useMutationWithFeedback, MutationType } from '@eventespresso/data';
+import { useMutationWithFeedback, gql, MutationType } from '@eventespresso/data';
 import type { ExecutionResult } from 'graphql';
-import gql from 'graphql-tag';
 
 import type { EntityId } from '@eventespresso/data';
 import { TypeName } from './';

--- a/packages/edtr-services/src/apollo/mutations/useReorderEntities.ts
+++ b/packages/edtr-services/src/apollo/mutations/useReorderEntities.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState, useMemo, useEffect } from 'react';
-import { useMutation } from '@eventespresso/data';
-import gql from 'graphql-tag';
 import { clone } from 'ramda';
 import { useDebouncedCallback } from 'use-debounce';
 import type { MutationResult } from '@apollo/client';
 
 import { __ } from '@eventespresso/i18n';
+import { gql, useMutation } from '@eventespresso/data';
 import { useSystemNotifications } from '@eventespresso/toaster';
 import { getGuids } from '@eventespresso/predicates';
 import type { EntityId } from '@eventespresso/data';

--- a/packages/edtr-services/src/apollo/queries/datetimes/queries.ts
+++ b/packages/edtr-services/src/apollo/queries/datetimes/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const DATETIME_ATTRIBUTES: any = gql`
 	fragment datetimeAttributes on EspressoDatetime {

--- a/packages/edtr-services/src/apollo/queries/events/queries.ts
+++ b/packages/edtr-services/src/apollo/queries/events/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const EVENT_ATTRIBUTES: any = gql`
 	fragment eventAttributes on EspressoEvent {

--- a/packages/edtr-services/src/apollo/queries/priceTypes/queries.ts
+++ b/packages/edtr-services/src/apollo/queries/priceTypes/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const PRICE_TYPE_ATTRIBUTES: any = gql`
 	fragment priceTypeAttributes on EspressoPriceType {

--- a/packages/edtr-services/src/apollo/queries/prices/queries.ts
+++ b/packages/edtr-services/src/apollo/queries/prices/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 import { PRICE_TYPE_ATTRIBUTES } from '../priceTypes';
 
 export const PRICE_ATTRIBUTES: any = gql`

--- a/packages/edtr-services/src/apollo/queries/tickets/queries.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/queries.ts
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag';
+import { gql } from '@eventespresso/data';
 
 export const TICKET_ATTRIBUTES: any = gql`
 	fragment ticketAttributes on EspressoTicket {

--- a/packages/edtr-services/src/context/test/TestContextProviders.tsx
+++ b/packages/edtr-services/src/context/test/TestContextProviders.tsx
@@ -1,4 +1,4 @@
-import { MockedProvider } from '@apollo/react-testing';
+import { MockedProvider } from '@apollo/client/testing';
 
 import { cache } from '@eventespresso/data';
 

--- a/packages/edtr-services/src/context/test/types.ts
+++ b/packages/edtr-services/src/context/test/types.ts
@@ -1,4 +1,4 @@
-import type { MockedResponse as ApolloMockedResponse } from '@apollo/react-testing';
+import type { MockedResponse as ApolloMockedResponse } from '@apollo/client/testing';
 import type { ResultFunction } from '@apollo/client/utilities/testing/mocking/mockLink';
 import type { ExecutionResult } from 'graphql';
 

--- a/packages/services/src/context/test/ConfigProvider.test.tsx
+++ b/packages/services/src/context/test/ConfigProvider.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from '@testing-library/react';
-import { MockedProvider } from '@apollo/react-testing';
+import { MockedProvider } from '@apollo/client/testing';
 import '@testing-library/jest-dom/extend-expect';
 
 import { ConfigConsumer, ConfigProvider } from '../ConfigProvider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,32 +43,6 @@
     tslib "^1.10.0"
     zen-observable "^0.8.14"
 
-"@apollo/client@latest":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.6.tgz#f359646308167f38d5bc498dfc2344c888400093"
-  integrity sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.11.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.13.1"
-    prop-types "^15.7.2"
-    symbol-observable "^2.0.0"
-    ts-invariant "^0.6.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
-
-"@apollo/react-testing@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-4.0.0.tgz#9fd1991584510c2ac051d986547ceccbc9c0a30a"
-  integrity sha512-P7Z/flUHpRRZYc3FkIqxZH9XD3FuP2Sgks1IXqGq2Zb7qI0aaTfVeRsLYmZNUcFOh2pTHxs0NXgPnH1VfYOpig==
-  dependencies:
-    "@apollo/client" latest
-
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -4839,11 +4813,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/ungap__global-this@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
-  integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
-
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -5154,11 +5123,6 @@
   dependencies:
     "@typescript-eslint/types" "4.14.0"
     eslint-visitor-keys "^2.0.0"
-
-"@ungap/global-this@^0.4.2":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.3.tgz#44cb668b03e7c4bc88cb6e6f9329d381131878ee"
-  integrity sha512-MuHEpDBurNVeD6mV9xBcAN2wfTwuaFQhHuhWkJuXmyVJ5P5sBCw+nnFpdfb0tAvgWkfefWCsAoAsh7MTUr3LPg==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -5937,13 +5901,6 @@
   integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
   dependencies:
     tslib "^1.9.3"
-
-"@wry/equality@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.1.tgz#81080cdc2e0d8265cd303faa0c64b38a77884e06"
-  integrity sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==
-  dependencies:
-    tslib "^1.14.1"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -15919,7 +15876,7 @@ opn@^5.5.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.13.0, optimism@^0.13.1:
+optimism@^0.13.0:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.2.tgz#002a438b69652bfe8f8754a4493ed35c2e9d9821"
   integrity sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==
@@ -20903,15 +20860,6 @@ ts-invariant@^0.5.0:
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.5.1.tgz#4171fdb85f72a40381c147afd97c12154ada2abc"
   integrity sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==
   dependencies:
-    tslib "^1.9.3"
-
-ts-invariant@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.6.0.tgz#44066ecfeb7a806ff1c3b0b283408a337a885412"
-  integrity sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==
-  dependencies:
-    "@types/ungap__global-this" "^0.3.1"
-    "@ungap/global-this" "^0.4.2"
     tslib "^1.9.3"
 
 ts-jest@^26.5.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,25 @@
   dependencies:
     tunnel "0.0.6"
 
+"@apollo/client@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.7.tgz#1cae8d2f5e15c5d2135a288a9d18962e60c5194c"
+  integrity sha512-4G80jvBLqenCFUhwkHAAHi2ox6Ygq35BkE38yxammqykZm6KE3tVlcEKGOZi0jpiuGJPC6LIQ0d1gtI8ADPtmg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.13.0"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    ts-invariant "^0.5.0"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@apollo/client@latest":
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.6.tgz#f359646308167f38d5bc498dfc2344c888400093"
@@ -42,13 +61,6 @@
     ts-invariant "^0.6.0"
     tslib "^1.10.0"
     zen-observable "^0.8.14"
-
-"@apollo/react-hooks@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-4.0.0.tgz#7bf7b320c90d276f637d9a84b503e17b840dd4e6"
-  integrity sha512-fCu0cbne3gbUl0QbA8X4L33iuuFVQbC5Jo2MIKRK8CyawR6PoxDpFdFA1kc6033ODZuZZ9Eo4RdeJFlFIIYcLA==
-  dependencies:
-    "@apollo/client" latest
 
 "@apollo/react-testing@^4.0.0":
   version "4.0.0"
@@ -4610,7 +4622,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=6":
+"@types/node@*", "@types/node@>= 8":
   version "14.14.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.17.tgz#29fab92f3986c0e379968ad3c2043683d8020dbb"
   integrity sha512-G0lD1/7qD60TJ/mZmhog76k7NcpLWkPVGgzkRy3CTlnFu4LUQh5v2Wa661z6vnXmD8EQrnALUyf0VRtrACYztw==
@@ -5912,14 +5924,6 @@
     "@babel/runtime" "^7.12.5"
     lodash "^4.17.19"
 
-"@wry/context@^0.4.0":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.4.4.tgz#e50f5fa1d6cfaabf2977d1fda5ae91717f8815f8"
-  integrity sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==
-  dependencies:
-    "@types/node" ">=6"
-    tslib "^1.9.3"
-
 "@wry/context@^0.5.2":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.3.tgz#537db8a5b51f98507dc38f869b3a48c672f48942"
@@ -5927,10 +5931,10 @@
   dependencies:
     tslib "^1.14.1"
 
-"@wry/equality@^0.1.2":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
-  integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
   dependencies:
     tslib "^1.9.3"
 
@@ -6256,86 +6260,6 @@ anymatch@^3.0.3, anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-apollo-cache-inmemory@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz#56d1f2a463a6b9db32e9fa990af16d2a008206fd"
-  integrity sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==
-  dependencies:
-    apollo-cache "^1.3.5"
-    apollo-utilities "^1.3.4"
-    optimism "^0.10.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-
-apollo-cache@1.3.5, apollo-cache@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.5.tgz#9dbebfc8dbe8fe7f97ba568a224bca2c5d81f461"
-  integrity sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==
-  dependencies:
-    apollo-utilities "^1.3.4"
-    tslib "^1.10.0"
-
-apollo-client@^2.6.10:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.10.tgz#86637047b51d940c8eaa771a4ce1b02df16bea6a"
-  integrity sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==
-  dependencies:
-    "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.3.5"
-    apollo-link "^1.0.0"
-    apollo-utilities "1.3.4"
-    symbol-observable "^1.0.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.0"
-
-apollo-link-batch-http@^1.2.14:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.14.tgz#4502109d3f32a94d88eabd3a89274ae3a6e2f56f"
-  integrity sha512-LFUmfV3OXR3Er+zSgFxPY/qUe4Wyx0HS1euJZ36RCCaDvPegr24C9OQgKFScHy91VbjRTtFUyjXXVq1xFGPMvQ==
-  dependencies:
-    apollo-link "^1.2.14"
-    apollo-link-batch "^1.1.15"
-    apollo-link-http-common "^0.2.16"
-    tslib "^1.9.3"
-
-apollo-link-batch@^1.1.15:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.15.tgz#3a5b8c7d9cf1b7840ce630238249b95070e75e54"
-  integrity sha512-XbfQI/FNxJW9RSgJTfAl7RDFxxN77425yDtT7YgsImH4/2NQ+U4SWN6thWE3ZU1Wf7ktXd+XFa3KkenBRTybOQ==
-  dependencies:
-    apollo-link "^1.2.14"
-    tslib "^1.9.3"
-
-apollo-link-http-common@^0.2.16:
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
-  integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
-  dependencies:
-    apollo-link "^1.2.14"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
-apollo-link@^1.0.0, apollo-link@^1.2.14:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
-  integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
-  dependencies:
-    apollo-utilities "^1.3.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable-ts "^0.8.21"
-
-apollo-utilities@1.3.4, apollo-utilities@^1.3.0, apollo-utilities@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.4.tgz#6129e438e8be201b6c55b0f13ce49d2c7175c9cf"
-  integrity sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==
-  dependencies:
-    "@wry/equality" "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
 
 app-root-dir@^1.0.2:
   version "1.0.2"
@@ -11825,10 +11749,10 @@ graphql-tag@^2.11.0:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
   integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
-graphql@^15.4.0:
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
-  integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+graphql@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -15995,14 +15919,7 @@ opn@^5.5.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
-  integrity sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==
-  dependencies:
-    "@wry/context" "^0.4.0"
-
-optimism@^0.13.1:
+optimism@^0.13.0, optimism@^0.13.1:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.2.tgz#002a438b69652bfe8f8754a4493ed35c2e9d9821"
   integrity sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==
@@ -20461,7 +20378,7 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -20981,10 +20898,10 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-invariant@^0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
-  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
+ts-invariant@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.5.1.tgz#4171fdb85f72a40381c147afd97c12154ada2abc"
+  integrity sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==
   dependencies:
     tslib "^1.9.3"
 
@@ -22504,15 +22421,7 @@ yup@^0.32.8:
     property-expr "^2.0.4"
     toposort "^2.0.2"
 
-zen-observable-ts@^0.8.21:
-  version "0.8.21"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz#85d0031fbbde1eba3cd07d3ba90da241215f421d"
-  integrity sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==
-  dependencies:
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
-
-zen-observable@^0.8.0, zen-observable@^0.8.14:
+zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Apollo has recently consolidated all packages into one single package - `@apollo/client`. So, this PR:
- Removes all other apollo packages and adds `@apollo/client`
- Removes direct Apollo imports from domains and other packages