### PR TITLE
Change ticket quantity when a new date is added.

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/useOnSubmit.ts
+++ b/domains/eventEditor/src/ui/datetimes/dateForm/multiStep/useOnSubmit.ts
@@ -7,7 +7,7 @@ import {
 	useDatetimeItem,
 } from '@eventespresso/edtr-services';
 import type { EntityId } from '@eventespresso/data';
-import { wait } from '@eventespresso/utils';
+import { isInfinite, wait } from '@eventespresso/utils';
 
 import { OnSubmit } from './types';
 
@@ -15,7 +15,7 @@ const useOnSubmit = (entityId: EntityId, onClose: VoidFunction): OnSubmit => {
 	const { createEntity, updateEntity } = useDatetimeMutator();
 	const datetime = useDatetimeItem({ id: entityId });
 
-	const updateRelatedTickets = useUpdateRelatedTickets(entityId);
+	const updateRelatedTickets = useUpdateRelatedTickets();
 	const ticketQuantityForCapacity = useTicketQuantityForCapacity();
 
 	const onSubmit = useCallback(
@@ -23,22 +23,31 @@ const useOnSubmit = (entityId: EntityId, onClose: VoidFunction): OnSubmit => {
 			// wait the next event cycle to fire up isLoading for submit button
 			await wait();
 
+			// whether date capacity has been changed
+			let capacityChanged = false;
+			let id = entityId;
+
 			onClose();
 			// If it's an existing entity
 			if (entityId) {
 				// Update it
 				await updateEntity(fields);
 
-				// whether date capacity has been changed
-				const capacityChanged = fields?.capacity !== datetime?.capacity;
-				// if true, we need to update the quantity of all the related tickets
-				if (capacityChanged) {
-					const inputGenerator = ticketQuantityForCapacity(fields?.capacity);
-					updateRelatedTickets(inputGenerator, fields?.tickets);
-				}
+				capacityChanged = fields?.capacity !== datetime?.capacity;
 			} else {
 				// otherwise create it
-				await createEntity(fields);
+				const result = await createEntity(fields);
+
+				// Get the ID.
+				id = result?.data?.createEspressoDatetime?.espressoDatetime?.id;
+
+				// For new dates, capacity matters only if it's finite.
+				capacityChanged = !isInfinite(fields?.capacity);
+			}
+			// if true, we need to update the quantity of all the related tickets
+			if (capacityChanged && id) {
+				const inputGenerator = ticketQuantityForCapacity(fields?.capacity);
+				updateRelatedTickets(id, inputGenerator, fields?.tickets);
 			}
 		},
 		[

--- a/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -14,12 +14,12 @@ import type { EntityListItemProps } from '@eventespresso/ui-components';
 const AssignTicketsButton: React.FC<EntityListItemProps<Datetime>> = ({ entity }) => {
 	const { openWithData } = useGlobalModal<BaseProps>(EdtrGlobalModals.TAM);
 
-	const relatedTickets = useRelatedTickets({
+	const getRelatedTickets = useRelatedTickets();
+
+	const count = getRelatedTickets({
 		entity: 'datetimes',
 		entityId: entity.id,
-	});
-
-	const count = relatedTickets.length;
+	}).length;
 
 	const title = count
 		? __('Number of related tickets')

--- a/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCapacity.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/cardView/DateCapacity.tsx
@@ -14,7 +14,7 @@ import type { DateItemProps } from '../types';
 const DateCapacity: React.FC<DateItemProps> = ({ entity: datetime }) => {
 	const { updateEntity } = useDatetimeMutator(datetime.id);
 
-	const updateRelatedTickets = useUpdateRelatedTickets(datetime.id);
+	const updateRelatedTickets = useUpdateRelatedTickets();
 	const ticketQuantityForCapacity = useTicketQuantityForCapacity();
 
 	const onChange: InlineEditProps['onChange'] = useCallback(
@@ -24,10 +24,10 @@ const DateCapacity: React.FC<DateItemProps> = ({ entity: datetime }) => {
 				updateEntity({ capacity });
 
 				const inputGenerator = ticketQuantityForCapacity(capacity);
-				updateRelatedTickets(inputGenerator);
+				updateRelatedTickets(datetime.id, inputGenerator);
 			}
 		},
-		[datetime.capacity, updateEntity, ticketQuantityForCapacity, updateRelatedTickets]
+		[datetime.capacity, datetime.id, updateEntity, ticketQuantityForCapacity, updateRelatedTickets]
 	);
 
 	return (

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useUpdateRelatedTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useUpdateRelatedTickets.ts
@@ -7,15 +7,20 @@ import { useTicketMutator, UpdateTicketInput } from '../tickets';
 import { entitiesWithGuIdInArray } from '@eventespresso/predicates';
 
 type InputGenerator = (ticket: Ticket) => UpdateTicketInput;
-type UpdateCallback = (inputGenerator: InputGenerator, relatedTicketIds?: Array<EntityId>) => void;
+type UpdateCallback = (
+	datetimeId: EntityId,
+	inputGenerator: InputGenerator,
+	relatedTicketIds?: Array<EntityId>
+) => void;
 
-const useUpdateRelatedTickets = (datetimeId: EntityId): UpdateCallback => {
+const useUpdateRelatedTickets = (): UpdateCallback => {
 	const tickets = useTickets();
-	const prevRelatedTickets = useRelatedTickets({ entity: 'datetimes', entityId: datetimeId });
+	const getRelatedTickets = useRelatedTickets();
 	const { updateEntity } = useTicketMutator();
 
 	return useCallback<UpdateCallback>(
-		(generateInput, relatedTicketIds = []) => {
+		(datetimeId, generateInput, relatedTicketIds = []) => {
+			const prevRelatedTickets = getRelatedTickets({ entity: 'datetimes', entityId: datetimeId });
 			/**
 			 * As of now, TAM can't be submitted without a date being related to a ticket
 			 * So, if this function is called after submission of multi-step and
@@ -34,7 +39,7 @@ const useUpdateRelatedTickets = (datetimeId: EntityId): UpdateCallback => {
 				updateEntity({ id: ticket.id, ...input });
 			});
 		},
-		[prevRelatedTickets, tickets, updateEntity]
+		[getRelatedTickets, tickets, updateEntity]
 	);
 };
 

--- a/packages/edtr-services/src/apollo/queries/tickets/test/useRelatedTickets.test.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/test/useRelatedTickets.test.ts
@@ -11,22 +11,22 @@ import { actWait } from '@eventespresso/utils/src/test';
 describe('useRelatedTickets', () => {
 	const wrapper = ApolloMockedProvider();
 	it('returns empty array for unrelated entity types', async () => {
-		const { result } = renderHook(() => useRelatedTickets({ entity: 'priceTypes', entityId: '' }), { wrapper });
+		const { result } = renderHook(() => useRelatedTickets(), { wrapper });
 
 		await actWait();
 
-		expect(result.current).toEqual([]);
+		expect(result.current({ entity: 'priceTypes', entityId: '' })).toEqual([]);
 	});
 
 	it('returns empty array for null or undefined entity types', async () => {
 		for (const value of [null, undefined]) {
-			const { result } = renderHook(() => useRelatedTickets({ entity: value, entityId: value }), {
+			const { result } = renderHook(() => useRelatedTickets(), {
 				wrapper,
 			});
 
 			await actWait();
 
-			expect(result.current).toEqual([]);
+			expect(result.current({ entity: value, entityId: value })).toEqual([]);
 		}
 	});
 
@@ -34,47 +34,47 @@ describe('useRelatedTickets', () => {
 		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
-				return useRelatedTickets({ entity: 'datetimes', entityId: datetimes[0].id });
+				return useRelatedTickets();
 			},
 			{ wrapper }
 		);
 		await actWait();
 
-		expect(result.current).toEqual([tickets[0], tickets[1]]);
+		expect(result.current({ entity: 'datetimes', entityId: datetimes[0].id })).toEqual([tickets[0], tickets[1]]);
 
 		const { result: anotherResult } = renderHook(
 			() => {
 				useInitTicketTestCache();
-				return useRelatedTickets({ entity: 'datetimes', entityId: datetimes[1].id });
+				return useRelatedTickets();
 			},
 			{ wrapper }
 		);
 		await actWait();
 
-		expect(anotherResult.current).toEqual([tickets[1]]);
+		expect(anotherResult.current({ entity: 'datetimes', entityId: datetimes[1].id })).toEqual([tickets[1]]);
 	});
 
 	it('returns related tickets for a given price', async () => {
 		const { result } = renderHook(
 			() => {
 				useInitTicketTestCache();
-				return useRelatedTickets({ entity: 'prices', entityId: prices[0].id });
+				return useRelatedTickets();
 			},
 			{ wrapper }
 		);
 		await actWait();
 
-		expect(result.current).toEqual([tickets[0]]);
+		expect(result.current({ entity: 'prices', entityId: prices[0].id })).toEqual([tickets[0]]);
 
 		const { result: anotherResult } = renderHook(
 			() => {
 				useInitTicketTestCache();
-				return useRelatedTickets({ entity: 'prices', entityId: prices[1].id });
+				return useRelatedTickets();
 			},
 			{ wrapper }
 		);
 		await actWait();
 
-		expect(anotherResult.current).toEqual([tickets[1]]);
+		expect(anotherResult.current({ entity: 'prices', entityId: prices[1].id })).toEqual([tickets[1]]);
 	});
 });

--- a/packages/edtr-services/src/apollo/queries/tickets/useRelatedTickets.ts
+++ b/packages/edtr-services/src/apollo/queries/tickets/useRelatedTickets.ts
@@ -1,26 +1,27 @@
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { entitiesWithGuIdInArray } from '@eventespresso/predicates';
-import { entityListCacheIdString } from '@eventespresso/utils';
 import { useRelations } from '@eventespresso/services';
 import useTickets from './useTickets';
 import type { Ticket } from '../../types';
 import type { RelatedEntitiesHook } from '../types';
 
-const useRelatedTickets: RelatedEntitiesHook<Ticket, 'tickets'> = ({ entity, entityId }) => {
+const useRelatedTickets = (): RelatedEntitiesHook<Ticket, 'tickets'> => {
 	const tickets = useTickets();
 	const { getRelations } = useRelations();
-	const relatedTicketIds = getRelations({
-		entity,
-		entityId,
-		relation: 'tickets',
-	});
 
-	const cacheIds = entityListCacheIdString(tickets);
-	const relatedTicketIdsStr = JSON.stringify(relatedTicketIds);
+	return useCallback(
+		({ entity, entityId }) => {
+			const relatedTicketIds = getRelations({
+				entity,
+				entityId,
+				relation: 'tickets',
+			});
 
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	return useMemo(() => entitiesWithGuIdInArray(tickets, relatedTicketIds), [relatedTicketIdsStr, cacheIds]);
+			return entitiesWithGuIdInArray(tickets, relatedTicketIds);
+		},
+		[getRelations, tickets]
+	);
 };
 
 export default useRelatedTickets;


### PR DESCRIPTION
This PR fixes the issue that adding a new date with finite capacity does not update/limit the quantity of the related tickets.

See https://github.com/eventespresso/barista/issues/766#issuecomment-800253154