### PR TITLE
Table cell width fix.

### DIFF
--- a/packages/ui-components/src/EspressoTable/style/cell.scss
+++ b/packages/ui-components/src/EspressoTable/style/cell.scss
@@ -68,7 +68,7 @@
 			&:not(.ee-entity-list-status-stripe):not(.ee-rspnsv-table-hide-on-mobile) {
 				@include max1280px {
 					padding: var(--ee-padding-micro) var(--ee-padding-smaller);
-					width: 100%;
+					width: fit-content;
 				}
 
 				@include max782px {

--- a/packages/ui-components/src/EspressoTable/style/laptop-style.scss
+++ b/packages/ui-components/src/EspressoTable/style/laptop-style.scss
@@ -178,7 +178,7 @@
 		.ee-rspnsv-table-body-td.ee-rspnsv-table-column-auto:not(.ee-entity-list-status-stripe):not(.ee-rspnsv-table-hide-on-mobile),
 		.ee-rspnsv-table-footer-th.ee-rspnsv-table-column-auto:not(.ee-entity-list-status-stripe):not(.ee-rspnsv-table-hide-on-mobile) {
 			padding: var(--ee-padding-micro) var(--ee-padding-smaller);
-			width: fit-content;
+			width: 100%;
 		}
 
 		.ee-rspnsv-table-body-td.ee-col-1 {


### PR DESCRIPTION
In https://github.com/eventespresso/barista/pull/777 the fix was been applied while the E2E browser instance was open, but we have 2 similar selectors and I've picked the wrong one.
