### PR TITLE
TableRow data-testid fix.

### DIFF
--- a/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
@@ -140,7 +140,8 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 			return {
 				cells,
 				className: statusClassName,
-				id: `ee-editor-datetime-list-view-row-${datetime.dbId}`,
+				'data-testid': `ee-datetime-list-view-row-${datetime.dbId}`,
+				id: `ee-editor-datetime-list-view-row-${datetime.id}`,
 				key: `row-${datetime.id}`,
 				rowClassName: 'ee-entity-list-item',
 				type: 'row',

--- a/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
@@ -148,7 +148,8 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 			return {
 				cells,
 				className: `ee-editor-ticket-list-view-row ${statusClassName}`,
-				id: `ee-editor-ticket-list-view-row-${ticket.dbId}`,
+				'data-testid': `ee-ticket-list-view-row-${ticket.dbId}`,
+				id: `ee-editor-ticket-list-view-row-${ticket.id}`,
 				key: `row-${ticket.id}`,
 				rowClassName: 'ee-entity-list-item',
 				type: 'row',

--- a/packages/e2e-tests/config/setup-playwright.js
+++ b/packages/e2e-tests/config/setup-playwright.js
@@ -11,5 +11,5 @@ jest.setTimeout(300000);
 beforeAll(async () => {
 	await loginUser();
 
-	await activatePlugin('event-espresso-core/espresso.php');
+	// await activatePlugin('event-espresso-core/espresso.php');
 });

--- a/packages/e2e-tests/config/setup-playwright.js
+++ b/packages/e2e-tests/config/setup-playwright.js
@@ -11,5 +11,5 @@ jest.setTimeout(300000);
 beforeAll(async () => {
 	await loginUser();
 
-	// await activatePlugin('event-espresso-core/espresso.php');
+	await activatePlugin('event-espresso-core/espresso.php');
 });

--- a/packages/e2e-tests/specs/shared/views/table-view-new-entity-test.ts
+++ b/packages/e2e-tests/specs/shared/views/table-view-new-entity-test.ts
@@ -31,7 +31,7 @@ describe(namespace, () => {
 				});
 				const $document = await getDocument(page);
 				const editableName = await page.$(
-					`${entityList} [data-testid="ee-editor-${entity}-list-view-row-${entityId}"] .ee-tabbable-text`
+					`${entityList} [data-testid="ee-${entity}-list-view-row-${entityId}"] .ee-tabbable-text`
 				);
 				const newTicketNameNode = await getByTestId($document, `ee-entity-list-view-row-editable-${entityId}`);
 				await editableName.click();

--- a/packages/e2e-tests/utils/findEntityIdByName.ts
+++ b/packages/e2e-tests/utils/findEntityIdByName.ts
@@ -12,7 +12,7 @@ export const findEntityIdByName = async ({ entity, name, view }: Props) => {
 		const listItemId = await entityList.$eval(`text=${name}`, (e) =>
 			e.closest('.ee-entity-list-item').getAttribute('data-testid')
 		);
-		const [entityId] = listItemId.split(`ee-editor-${entity}-list-view-row-`).reverse();
+		const [entityId] = listItemId.split(`ee-${entity}-list-view-row-`).reverse();
 
 		return entityId;
 	}

--- a/packages/ui-components/src/EspressoTable/TableBody.tsx
+++ b/packages/ui-components/src/EspressoTable/TableBody.tsx
@@ -52,6 +52,7 @@ const TableBody: React.FC<TableBodyProps> = ({
 		return (
 			<TableRow
 				className={props.className}
+				data-testid={row?.['data-testid']}
 				headerRowCount={headerRowCount}
 				id={row.id || `${tableId}-row`}
 				key={`body-row-${row.key}`}

--- a/packages/ui-components/src/EspressoTable/TableRow.tsx
+++ b/packages/ui-components/src/EspressoTable/TableRow.tsx
@@ -25,7 +25,7 @@ const TableRow: React.FC<BodyRow> = ({
 	);
 
 	return (
-		<tr className={css} data-testid={props?.id} id={id}>
+		<tr className={css} data-testid={props?.['data-testid']} id={id}>
 			{children}
 		</tr>
 	);

--- a/packages/ui-components/src/EspressoTable/types.ts
+++ b/packages/ui-components/src/EspressoTable/types.ts
@@ -137,6 +137,7 @@ export interface BodyRow {
 	cells?: CellData[];
 	children?: React.ReactNode;
 	className?: TableClassName | string;
+	'data-testid'?: string;
 	headerRows?: HeaderRow[];
 	headerRowClassName?: string;
 	headerRowCount?: number;


### PR DESCRIPTION
In this PR `TableRow` `data-testid` is passed explicitly instead of deriving it from the `id`.