### PR TITLE
E2E tests for TAM toggle assignments

### DIFF
--- a/packages/e2e-tests/specs/tam/single-vs-global-tam.test.ts
+++ b/packages/e2e-tests/specs/tam/single-vs-global-tam.test.ts
@@ -7,7 +7,7 @@ const tamrover = new TAMRover();
 const parser = new EntityListParser();
 
 beforeAll(async () => {
-	await saveVideo(page, 'artifacts/tam-for-single-date.mp4');
+	await saveVideo(page, 'artifacts/tam-for-single-vs-global-data.mp4');
 
 	await createNewEvent({ title: 'Test for Single Vs Global TAM data' });
 	await addDatesAndTickets();
@@ -22,7 +22,7 @@ afterAll(async () => {
 
 describe('TAM:SingleVsGlobalTAM', () => {
 	for (const entityType of ['datetime', 'ticket'] as const) {
-		it(`tests the ralations for each ${entityType} to be the same in single and global TAM modal`, async () => {
+		it(`tests the relations for each ${entityType} to be the same in single and global TAM modal`, async () => {
 			const mapFromTo = entityType === 'ticket' ? 'ticket2dates' : 'date2tickets';
 
 			const entities = await parser.setEntityType(entityType).getListItems();

--- a/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
@@ -1,0 +1,87 @@
+import { saveVideo } from 'playwright-video';
+import { path } from 'ramda';
+
+import { createNewEvent, TAMRover } from '../../utils';
+import { addDatesAndTickets } from './utils';
+
+const tamrover = new TAMRover();
+
+beforeAll(async () => {
+	await saveVideo(page, 'artifacts/tam-toggle-assignments.mp4');
+
+	await createNewEvent({ title: 'TAM: Toggle Assignments' });
+	await addDatesAndTickets();
+
+	await page.waitForTimeout(1000);
+});
+
+afterAll(async () => {
+	// Close TAM modal
+	await tamrover.close();
+});
+
+describe('TAM:ToggleAssignments', () => {
+	it('tests the relationship toggle between dates and tickets', async () => {
+		// Open TAM for all dates/tickets
+		await tamrover.setForType('all').launch();
+		const existingMap = await tamrover.getMap();
+
+		const dateIds = await tamrover.getDateIds();
+		const ticketIds = await tamrover.getTicketIds();
+
+		// Lets flip all the relations
+		await tamrover.toggleAllAssignments();
+
+		// Now in the new map, relations should have changed.
+		const newMap = await tamrover.getMap({ forceGenerate: true });
+
+		/******** CHECK RELATIONS BEFORE SUBMIT ********/
+		for (const dateId of dateIds) {
+			for (const ticketId of ticketIds) {
+				const oldRelation = path([dateId, ticketId], existingMap);
+				const newRelation = path([dateId, ticketId], newMap);
+				// "OLD" relation becomes "REMOVED" and no relation becomes "NEW"
+				const expectedRelation = oldRelation === 'OLD' ? 'REMOVED' : 'NEW';
+
+				expect(newRelation).toBe(expectedRelation);
+			}
+		}
+
+		// Now lets submit.
+		await tamrover.submit();
+
+		await page.waitForTimeout(30000);
+
+		// Open TAM again
+		await tamrover.setForType('all').launch();
+
+		const afterSubmitMap = await tamrover.getMap();
+
+		/******** CHECK RELATIONS AFTER SUBMIT ********/
+		for (const dateId of dateIds) {
+			for (const ticketId of ticketIds) {
+				const relationB4Submit = path([dateId, ticketId], newMap);
+				const relationAfterSubmit = path([dateId, ticketId], afterSubmitMap);
+				// "NEW" relation becomes "OLD" and "REMOVED" becomes null
+				const expectedRelation = relationB4Submit === 'NEW' ? 'OLD' : null;
+
+				expect(relationAfterSubmit).toBe(expectedRelation);
+			}
+		}
+
+		// Close TAM modal
+		await tamrover.close();
+
+		// Reload the page.
+		await page.reload();
+
+		await page.waitForSelector('[type=button] >> text=Ticket Assignments');
+		// Open TAM again
+		await tamrover.setForType('all').launch();
+
+		const afterReloadMap = await tamrover.getMap();
+
+		/******** CHECK RELATIONS AFTER RELOAD ********/
+		expect(afterSubmitMap).toEqual(afterReloadMap);
+	});
+});

--- a/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
@@ -1,7 +1,10 @@
 import { useCallback, useMemo } from 'react';
+import { identity } from 'ramda';
 
 import { useMutationWithFeedback, MutationType } from '@eventespresso/data';
 import { useSystemNotifications } from '@eventespresso/toaster';
+import type { TicketPred } from '@eventespresso/predicates';
+
 import type { TicketEdge, Ticket } from '../../types';
 import { useTicketQueryOptions, useTickets } from '../../queries';
 import { useUpdateTicketList } from '../../../hooks';
@@ -15,7 +18,8 @@ interface BulkEditTickets {
 }
 
 const useBulkEditTickets = (): BulkEditTickets => {
-	const allTickets = useTickets();
+	// ensure that bulk edit preserves default tickets
+	const allTickets = useTickets(identity as TicketPred);
 	const queryOptions = useTicketQueryOptions();
 	const toaster = useSystemNotifications();
 	const updateTicketList = useUpdateTicketList();


### PR DESCRIPTION
This PR adds a comprehensive e2e test for TAM relations. Here is what it does:
- Opens TAM for all dates/tickets
- Toggles relation for each date/ticket
- checks the expected relations
- submits the TAM modal
- Opens the TAM modal again to check for updated relations
- Reloads the page
- Opens the TAM modal again to check for the relations

See #774 