### PR TITLE
E2E Timeout improvements

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -73,12 +73,12 @@ jobs:
     e2e:
         env:
             # If you want to run e2e in parallel to build, just set this to false and comment out needs: and if:
-            run_after_build: 'true'
+            run_after_build: 'false'
         name: E2E Tests
-        needs: [build, what-is-hit]
+        # needs: [build, what-is-hit]
         runs-on: ubuntu-latest
         # Run the job only if JS is affected
-        if: ${{ needs.what-is-hit.outputs.js == 'true' }}
+        # if: ${{ needs.what-is-hit.outputs.js == 'true' }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -73,12 +73,12 @@ jobs:
     e2e:
         env:
             # If you want to run e2e in parallel to build, just set this to false and comment out needs: and if:
-            run_after_build: 'false'
+            run_after_build: 'true'
         name: E2E Tests
-        # needs: [build, what-is-hit]
+        needs: [build, what-is-hit]
         runs-on: ubuntu-latest
         # Run the job only if JS is affected
-        # if: ${{ needs.what-is-hit.outputs.js == 'true' }}
+        if: ${{ needs.what-is-hit.outputs.js == 'true' }}
         steps:
             - uses: actions/checkout@v2
 

--- a/domains/eventEditor/src/ui/datetimes/datesList/DatesList.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/DatesList.tsx
@@ -11,7 +11,7 @@ import {
 } from '@eventespresso/edtr-services';
 import { EntityList } from '@eventespresso/ee-components';
 
-import DatesListButtons from './DatesListButtons';
+import DatesListFooter from './DatesListFooter';
 import { legendConfig } from './config';
 import { RenderCardView } from './cardView';
 import { RenderTableView } from './tableView';
@@ -30,7 +30,7 @@ const DatesList: React.FC = () => {
 			domain={domain}
 			entityType={TypeName.datetimes}
 			filterState={filterState}
-			footer={<DatesListButtons />}
+			footer={<DatesListFooter />}
 			headerText={__('Event Dates')}
 			legendConfig={legendConfig}
 			listId={datesList}

--- a/domains/eventEditor/src/ui/datetimes/datesList/DatesListFooter.tsx
+++ b/domains/eventEditor/src/ui/datetimes/datesList/DatesListFooter.tsx
@@ -1,0 +1,17 @@
+import { useDatetimes } from '@eventespresso/edtr-services';
+import { EntityCacheIds } from '@eventespresso/ee-components';
+
+import DatesListButtons from './DatesListButtons';
+
+const DatesListFooter: React.FC = () => {
+	const entities = useDatetimes();
+
+	return (
+		<>
+			<EntityCacheIds entities={entities} />
+			<DatesListButtons />
+		</>
+	);
+};
+
+export default DatesListFooter;

--- a/domains/eventEditor/src/ui/tickets/ticketsList/TicketsListFooter.tsx
+++ b/domains/eventEditor/src/ui/tickets/ticketsList/TicketsListFooter.tsx
@@ -1,9 +1,15 @@
+import { useTickets } from '@eventespresso/edtr-services';
+import { EntityCacheIds } from '@eventespresso/ee-components';
+
 import { NewTicketButton } from './newTicketOptions';
 import { Actions } from './actions';
 
-const TicketsListFooter = () => {
+const TicketsListFooter: React.FC = () => {
+	const entities = useTickets();
+
 	return (
 		<>
+			<EntityCacheIds entities={entities} />
 			<NewTicketButton />
 			<Actions />
 		</>

--- a/packages/e2e-tests/specs/dates/card.test.ts
+++ b/packages/e2e-tests/specs/dates/card.test.ts
@@ -18,23 +18,28 @@ describe(namespace, () => {
 		const newDateName = 'new date name';
 		const newDateDesc = 'new date description';
 		const newDateCap = '100';
-		const capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
 
-		try {
-			await page.click(`${parser.getRootSelector()} .entity-card-details__name`);
-			await page.type(`${parser.getRootSelector()} .entity-card-details__name`, newDateName);
-			await page.click(`${parser.getRootSelector()} .entity-card-details__text`);
-			await page.click(modalRTESel);
-			await page.type(modalRTESel, newDateDesc);
-			await page.click('.chakra-modal__footer button[type=submit]');
-			await page.click(`${parser.getRootSelector()} .ee-entity-details__value .ee-tabbable-text`);
-			await page.type(`${parser.getRootSelector()} .ee-entity-details__value .ee-inline-edit__input`, newDateCap);
-			const waitForListUpdate = await parser.createWaitForListUpdate();
-			await page.click(parser.getRootSelector()); // click outside of the inline input
-			await waitForListUpdate();
-		} catch (e) {
-			await capture.stop();
-		}
+		await page.click(`${parser.getRootSelector()} .entity-card-details__name`);
+		await page.type(`${parser.getRootSelector()} .entity-card-details__name`, newDateName);
+
+		let waitForListUpdate = await parser.createWaitForListUpdate();
+		await page.click(parser.getRootSelector()); // click outside of the inline input
+		await waitForListUpdate();
+
+		await page.click(`${parser.getRootSelector()} .entity-card-details__text`);
+		await page.click(modalRTESel);
+		await page.type(modalRTESel, newDateDesc);
+
+		waitForListUpdate = await parser.createWaitForListUpdate();
+		await page.click('.chakra-modal__footer button[type=submit]');
+		await waitForListUpdate();
+
+		await page.click(`${parser.getRootSelector()} .ee-entity-details__value .ee-tabbable-text`);
+		await page.type(`${parser.getRootSelector()} .ee-entity-details__value .ee-inline-edit__input`, newDateCap);
+
+		waitForListUpdate = await parser.createWaitForListUpdate();
+		await page.click(parser.getRootSelector()); // click outside of the inline input
+		await waitForListUpdate();
 
 		// first/only item
 		const item = await parser.getItem();

--- a/packages/e2e-tests/specs/dates/card.test.ts
+++ b/packages/e2e-tests/specs/dates/card.test.ts
@@ -29,7 +29,9 @@ describe(namespace, () => {
 			await page.click('.chakra-modal__footer button[type=submit]');
 			await page.click(`${parser.getRootSelector()} .ee-entity-details__value .ee-tabbable-text`);
 			await page.type(`${parser.getRootSelector()} .ee-entity-details__value .ee-inline-edit__input`, newDateCap);
+			const waitForListUpdate = await parser.createWaitForListUpdate();
 			await page.click(parser.getRootSelector()); // click outside of the inline input
+			await waitForListUpdate();
 		} catch (e) {
 			await capture.stop();
 		}

--- a/packages/e2e-tests/specs/dates/edit.test.ts
+++ b/packages/e2e-tests/specs/dates/edit.test.ts
@@ -1,12 +1,14 @@
 import { saveVideo } from 'playwright-video';
 
-import { createNewEvent, setListDisplayControl } from '@e2eUtils/admin/event-editor';
+import { createNewEvent, setListDisplayControl, EntityListParser } from '@e2eUtils/admin/event-editor';
 import { clickButton, clickLastDateFromPicker } from '@e2eUtils/common';
 
 import { expectCardToContain } from '../../assertions';
 import { modalRTESel } from '../../constants';
 
 const namespace = 'event.dates.edit';
+
+const parser = new EntityListParser('datetime');
 
 beforeAll(async () => {
 	await createNewEvent({ title: namespace });
@@ -38,7 +40,13 @@ describe(namespace, () => {
 			await page.click('[name="capacity"]');
 			await page.type('[name="capacity"]', newDateCap);
 			await clickButton('Save and assign tickets');
+
+			const waitForListUpdate = await parser.createWaitForListUpdate();
+
 			await page.click('button[type=submit]');
+
+			await waitForListUpdate();
+
 			await setListDisplayControl('datetime', 'both');
 
 			await expectCardToContain({

--- a/packages/e2e-tests/specs/rem/index.test.ts
+++ b/packages/e2e-tests/specs/rem/index.test.ts
@@ -64,9 +64,10 @@ describe('REM', () => {
 
 		await clickButton('Next');
 
-		await page.waitForTimeout(2000);
+		const perPageSelector = '.rrule-generator-wrapper .ee-pagination__per-page';
 
-		await page.selectOption('.rrule-generator-wrapper .ee-pagination__per-page', {
+		await page.waitForSelector(perPageSelector);
+		await page.selectOption(perPageSelector, {
 			value: '48',
 		});
 

--- a/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
@@ -13,9 +13,8 @@ beforeAll(async () => {
 	await saveVideo(page, 'artifacts/tam-related-count-vs-assignments.mp4');
 
 	await createNewEvent({ title: 'TAM: Related Count in card and table view vs TAM Assignments' });
-	await addDatesAndTickets();
 
-	await page.waitForTimeout(1000);
+	await addDatesAndTickets();
 });
 
 const toggleAllFilters = async () => {
@@ -73,9 +72,11 @@ describe('TAM:RelatedCountVsAssignments', () => {
 				// Lets flip all the relations
 				await tamrover.toggleAllAssignments();
 
+				const waitForListUpdate = await parser.createWaitForListUpdate();
 				// Now lets submit.
 				await tamrover.submit();
-				await page.waitForTimeout(15000);
+
+				await waitForListUpdate();
 
 				/******** CHECK AFTER SUBMIT ********/
 				await assertListAndTAMRelatedCount(entityType, viewType);

--- a/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
@@ -72,7 +72,7 @@ describe('TAM:RelatedCountVsAssignments', () => {
 				// Lets flip all the relations
 				await tamrover.toggleAllAssignments();
 
-				const waitForListUpdate = await parser.createWaitForListUpdate();
+				const waitForListUpdate = await parser.setEntityType('ticket').createWaitForListUpdate();
 				// Now lets submit.
 				await tamrover.submit();
 

--- a/packages/e2e-tests/specs/tam/single-vs-global-tam.test.ts
+++ b/packages/e2e-tests/specs/tam/single-vs-global-tam.test.ts
@@ -10,9 +10,8 @@ beforeAll(async () => {
 	await saveVideo(page, 'artifacts/tam-for-single-vs-global-data.mp4');
 
 	await createNewEvent({ title: 'Test for Single Vs Global TAM data' });
-	await addDatesAndTickets();
 
-	await page.waitForTimeout(1000);
+	await addDatesAndTickets();
 });
 
 afterAll(async () => {

--- a/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
@@ -1,18 +1,18 @@
 import { saveVideo } from 'playwright-video';
 import { path } from 'ramda';
 
-import { createNewEvent, TAMRover } from '@e2eUtils/admin/event-editor';
+import { createNewEvent, TAMRover, EntityListParser } from '@e2eUtils/admin/event-editor';
 import { addDatesAndTickets } from './utils';
 
 const tamrover = new TAMRover();
+const parser = new EntityListParser('ticket');
 
 beforeAll(async () => {
 	await saveVideo(page, 'artifacts/tam-toggle-assignments.mp4');
 
 	await createNewEvent({ title: 'TAM: Toggle Assignments' });
-	await addDatesAndTickets();
 
-	await page.waitForTimeout(1000);
+	await addDatesAndTickets();
 });
 
 afterAll(async () => {
@@ -47,10 +47,12 @@ describe('TAM:ToggleAssignments', () => {
 			}
 		}
 
+		const waitForListUpdate = await parser.createWaitForListUpdate();
+
 		// Now lets submit.
 		await tamrover.submit();
 
-		await page.waitForTimeout(30000);
+		await waitForListUpdate();
 
 		// Open TAM again
 		await tamrover.setForType('all').launch();

--- a/packages/e2e-tests/specs/tam/utils.ts
+++ b/packages/e2e-tests/specs/tam/utils.ts
@@ -16,6 +16,4 @@ export const addDatesAndTickets = async () => {
 	for (const item of data) {
 		await addNewTicket({ ...item, name: 'Ticket ' + item.name, amount: 10 });
 	}
-
-	await page.waitForTimeout(1000);
 };

--- a/packages/e2e-tests/specs/tickets/card.test.ts
+++ b/packages/e2e-tests/specs/tickets/card.test.ts
@@ -30,10 +30,10 @@ describe(namespace, () => {
 		const waitForListUpdate = await parser.createWaitForListUpdate();
 		await page.click(parser.getRootSelector()); // click outside of the inline input
 
+		await waitForListUpdate();
+
 		// first/only item
 		const item = await parser.getItem();
-
-		await waitForListUpdate();
 
 		expect(await parser.getItemName(item)).toContain(newTicketName);
 

--- a/packages/e2e-tests/specs/tickets/card.test.ts
+++ b/packages/e2e-tests/specs/tickets/card.test.ts
@@ -17,19 +17,28 @@ describe(namespace, () => {
 	it('should check the ticket card inline inputs', async () => {
 		const newTicketName = 'new ticket name';
 		const newTicketDesc = 'new ticket description';
-		const newTicketQty = '100';
+		const newTicketQty = '123';
 
 		await page.click(`${parser.getRootSelector()} .entity-card-details__name`);
 		await page.type(`${parser.getRootSelector()} .entity-card-details__name`, newTicketName);
+
+		let waitForListUpdate = await parser.createWaitForListUpdate();
+		await page.click(parser.getRootSelector()); // click outside of the inline input
+		await waitForListUpdate();
+
 		await page.click(`${parser.getRootSelector()} .entity-card-details__text`);
 		await page.click(modalRTESel);
 		await page.type(modalRTESel, newTicketDesc);
+
+		waitForListUpdate = await parser.createWaitForListUpdate();
 		await page.click('.chakra-modal__footer button[type=submit]');
+		await waitForListUpdate();
+
 		await page.click(`${parser.getRootSelector()} .ee-entity-details__value .ee-tabbable-text`);
 		await page.type(`${parser.getRootSelector()} .ee-entity-details__value .ee-inline-edit__input`, newTicketQty);
-		const waitForListUpdate = await parser.createWaitForListUpdate();
-		await page.click(parser.getRootSelector()); // click outside of the inline input
 
+		waitForListUpdate = await parser.createWaitForListUpdate();
+		await page.click(parser.getRootSelector()); // click outside of the inline input
 		await waitForListUpdate();
 
 		// first/only item

--- a/packages/e2e-tests/specs/tickets/card.test.ts
+++ b/packages/e2e-tests/specs/tickets/card.test.ts
@@ -27,12 +27,13 @@ describe(namespace, () => {
 		await page.click('.chakra-modal__footer button[type=submit]');
 		await page.click(`${parser.getRootSelector()} .ee-entity-details__value .ee-tabbable-text`);
 		await page.type(`${parser.getRootSelector()} .ee-entity-details__value .ee-inline-edit__input`, newTicketQty);
+		const waitForListUpdate = await parser.createWaitForListUpdate();
 		await page.click(parser.getRootSelector()); // click outside of the inline input
 
 		// first/only item
 		const item = await parser.getItem();
 
-		await page.waitForTimeout(2000);
+		await waitForListUpdate();
 
 		expect(await parser.getItemName(item)).toContain(newTicketName);
 

--- a/packages/e2e-tests/specs/tickets/edit.test.ts
+++ b/packages/e2e-tests/specs/tickets/edit.test.ts
@@ -1,12 +1,13 @@
 import { saveVideo } from 'playwright-video';
 
-import { createNewEvent, setListDisplayControl } from '@e2eUtils/admin/event-editor';
+import { createNewEvent, setListDisplayControl, EntityListParser } from '@e2eUtils/admin/event-editor';
 import { clickButton, clickLastDateFromPicker } from '@e2eUtils/common';
 
 import { expectCardToContain } from '../../assertions';
 import { modalRTESel } from '../../constants';
 
 const namespace = 'event.tickets.edit';
+const parser = new EntityListParser('ticket');
 
 beforeAll(async () => {
 	await saveVideo(page, `artifacts/${namespace}.mp4`);
@@ -38,7 +39,13 @@ describe(namespace, () => {
 			await page.click('[name="quantity"]');
 			await page.type('[name="quantity"]', newTicketQuantity);
 			await clickButton('Skip prices - assign dates');
+
+			const waitForListUpdate = await parser.createWaitForListUpdate();
+
 			await page.click('button[type=submit]');
+
+			await waitForListUpdate();
+
 			await setListDisplayControl('ticket', 'both');
 
 			await expectCardToContain({

--- a/packages/e2e-tests/specs/tickets/index.test.ts
+++ b/packages/e2e-tests/specs/tickets/index.test.ts
@@ -8,8 +8,6 @@ describe('availableTickets', () => {
 	it('should add new ticket', async () => {
 		const capture = await saveVideo(page, 'artifacts/new-ticket.mp4');
 
-		await page.waitForTimeout(500);
-
 		await createNewEvent({ title: 'to be deleted' });
 
 		const newTicketName = 'one way ticket';

--- a/packages/e2e-tests/specs/tpc/index.test.ts
+++ b/packages/e2e-tests/specs/tpc/index.test.ts
@@ -14,10 +14,7 @@ import {
 	removeAllPriceModifiers,
 	setPrice,
 	setPrices,
-	EntityListParser,
 } from '@e2eUtils/admin/event-editor';
-
-const parser = new EntityListParser('ticket');
 
 beforeAll(async () => {
 	await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
@@ -26,11 +23,7 @@ beforeAll(async () => {
 
 	await createNewEvent({ title: 'calculateTicketTotal: to be deleted' });
 
-	const waitForListUpdate = await parser.createWaitForListUpdate();
-
 	await removeAllTickets();
-
-	await waitForListUpdate();
 
 	await addNewTicket({ amount: newTicketAmount, name: newTicketName });
 

--- a/packages/e2e-tests/specs/tpc/index.test.ts
+++ b/packages/e2e-tests/specs/tpc/index.test.ts
@@ -14,9 +14,10 @@ import {
 	removeAllPriceModifiers,
 	setPrice,
 	setPrices,
+	EntityListParser,
 } from '@e2eUtils/admin/event-editor';
 
-const ticketsListSelector = '#ee-entity-list-tickets .ee-entity-list__card-view';
+const parser = new EntityListParser('ticket');
 
 beforeAll(async () => {
 	await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
@@ -25,21 +26,13 @@ beforeAll(async () => {
 
 	await createNewEvent({ title: 'calculateTicketTotal: to be deleted' });
 
-	// Wait for page load after the event is published
-	await page.waitForNavigation();
-
-	// Wait for tickets list lazy load
-	await page.waitForFunction((selector) => document.querySelector(selector), ticketsListSelector);
+	const waitForListUpdate = await parser.createWaitForListUpdate();
 
 	await removeAllTickets();
 
-	// Wait for tickets list to refresh
-	await page.waitForFunction((selector) => !document.querySelector(selector), ticketsListSelector);
+	await waitForListUpdate();
 
 	await addNewTicket({ amount: newTicketAmount, name: newTicketName });
-
-	// Wait for tickets list to update
-	await page.waitForFunction((selector) => document.querySelector(selector), ticketsListSelector);
 
 	await page.click('[aria-label="ticket price calculator"]');
 });

--- a/packages/e2e-tests/utils/admin/event-editor/addNewDate.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/addNewDate.ts
@@ -1,5 +1,8 @@
 import { clickButton } from '@e2eUtils/common';
+import { EntityListParser } from '@e2eUtils/admin/event-editor';
 import { DateTicketFormArgs, fillDateTicketForm } from './fillDateTicketForm';
+
+const parser = new EntityListParser('datetime');
 
 export const addNewDate = async (fields: DateTicketFormArgs) => {
 	try {
@@ -14,7 +17,11 @@ export const addNewDate = async (fields: DateTicketFormArgs) => {
 
 		await page.click('[aria-label="assign ticket"]');
 
+		const waitForListUpdate = await parser.createWaitForListUpdate();
+
 		await page.click('button[type=submit]');
+
+		await waitForListUpdate();
 	} catch (e) {
 		console.log(e);
 	}

--- a/packages/e2e-tests/utils/admin/event-editor/addNewTicket.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/addNewTicket.ts
@@ -29,9 +29,5 @@ export const addNewTicket = async ({ amount, ...fields }: DateTicketFormArgs & {
 
 	await page.click('button[type=submit]');
 
-	page.on('console', async (msg) => {
-		for (let i = 0; i < msg.args().length; ++i) console.log(await msg.args()[i].jsonValue());
-	});
-
 	await waitForListUpdate();
 };

--- a/packages/e2e-tests/utils/admin/event-editor/addNewTicket.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/addNewTicket.ts
@@ -1,6 +1,9 @@
+import { EntityListParser } from '@e2eUtils/admin/event-editor';
 import { clickButton } from '@e2eUtils/common';
 import { fillDateTicketForm, DateTicketFormArgs } from './';
 import { setPrice } from './setPrice';
+
+const parser = new EntityListParser('ticket');
 
 export const addNewTicket = async ({ amount, ...fields }: DateTicketFormArgs & { amount?: number }) => {
 	await page.click('text=Add New Ticket');
@@ -9,7 +12,7 @@ export const addNewTicket = async ({ amount, ...fields }: DateTicketFormArgs & {
 
 	await clickButton('Set ticket prices');
 
-	await page.waitForTimeout(1000);
+	await page.waitForSelector('text=Add default prices');
 
 	await page.click('text=Add default prices');
 
@@ -22,7 +25,13 @@ export const addNewTicket = async ({ amount, ...fields }: DateTicketFormArgs & {
 
 	await page.click('[aria-label="assign ticket"]');
 
+	const waitForListUpdate = await parser.createWaitForListUpdate();
+
 	await page.click('button[type=submit]');
 
-	await page.waitForTimeout(2000); // the ticket list is not updated instantly
+	page.on('console', async (msg) => {
+		for (let i = 0; i < msg.args().length; ++i) console.log(await msg.args()[i].jsonValue());
+	});
+
+	await waitForListUpdate();
 };

--- a/packages/e2e-tests/utils/admin/event-editor/createNewEvent.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/createNewEvent.ts
@@ -1,13 +1,15 @@
+const menuLinkSelector = '.toplevel_page_espresso_events > a';
+
 export async function createNewEvent({ title }: any = {}) {
-	await page.waitForTimeout(1000);
+	await page.waitForSelector(menuLinkSelector);
 
-	await page.click(`.toplevel_page_espresso_events > a`).catch(console.log);
+	await page.click(menuLinkSelector);
 
-	await page.click(`#add-new-event`).catch(console.log);
+	await page.click(`#add-new-event`);
 
-	await page.focus('#titlewrap #title').catch(console.log);
+	await page.focus('#titlewrap #title');
 
-	await page.type('#titlewrap #title', title).catch(console.log);
+	await page.type('#titlewrap #title', title);
 
-	await page.click(`#publishing-action #publish`).catch(console.log);
+	await page.click(`#publishing-action #publish`);
 }

--- a/packages/e2e-tests/utils/admin/event-editor/createNewEvent.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/createNewEvent.ts
@@ -1,5 +1,7 @@
 const menuLinkSelector = '.toplevel_page_espresso_events > a';
 
+const ticketsListSelector = '#ee-entity-list-tickets .ee-entity-list__card-view';
+
 export async function createNewEvent({ title }: any = {}) {
 	await page.waitForSelector(menuLinkSelector);
 
@@ -12,4 +14,10 @@ export async function createNewEvent({ title }: any = {}) {
 	await page.type('#titlewrap #title', title);
 
 	await page.click(`#publishing-action #publish`);
+
+	// Wait for page load after the event is published
+	await page.waitForNavigation();
+
+	// Wait for tickets list lazy load
+	await page.waitForFunction((selector) => document.querySelector(selector), ticketsListSelector);
 }

--- a/packages/e2e-tests/utils/admin/event-editor/deleteDateByName.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/deleteDateByName.ts
@@ -25,7 +25,10 @@ export const deleteDateByName = async (name: string) => {
 
 	const trashBtn = await getByTestId($document, `ee-trash-date-${dateId}`);
 
+	const waitForListUpdate = await parser.createWaitForListUpdate();
 	await trashBtn.click();
 
 	await clickButton('Yes');
+
+	await waitForListUpdate();
 };

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
@@ -41,16 +41,17 @@ const useOptimisticResponse = (): OptimisticResCb => {
 			};
 
 			const datetime = getDatetime(input.id);
+			const cacheId = `temp:${uuidv4()}`;
 
 			switch (mutationType) {
 				case MutationType.Create:
 					espressoDatetime = {
 						...espressoDatetime,
 						...DATETIME_DEFAULTS,
+						cacheId,
 						// make sure the id is generated on each call to make sure
 						// it is unique for each entity created in bulk
-						id: `temp:${uuidv4()}`,
-						cacheId: uuidv4(),
+						id: cacheId,
 						...input,
 					};
 					break;
@@ -61,7 +62,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 						...datetime,
 						...input,
 						isTrashed: true,
-						cacheId: uuidv4(),
+						cacheId,
 					};
 					break;
 				case MutationType.Update:
@@ -69,7 +70,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 						...espressoDatetime,
 						...datetime,
 						...input,
-						cacheId: uuidv4(),
+						cacheId,
 					};
 					break;
 			}

--- a/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
@@ -50,15 +50,17 @@ const useOptimisticResponse = (): OptimisticResCb => {
 				__typename: 'EspressoTicket',
 			};
 			const ticket = getTicket(input.id);
+			const cacheId = `temp:${uuidv4()}`;
 
 			switch (mutationType) {
 				case MutationType.Create:
 					espressoTicket = {
 						...espressoTicket,
 						...TICKET_DEFAULTS,
+						cacheId,
 						// make sure the id is generated on each call to make sure
 						// it is unique for each entity created in bulk
-						id: `temp:${uuidv4()}`,
+						id: cacheId,
 						...input,
 						prices: null,
 					};
@@ -70,7 +72,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 						...ticket,
 						...input,
 						isTrashed: true,
-						cacheId: uuidv4(),
+						cacheId,
 					};
 					break;
 				case MutationType.Update:
@@ -78,7 +80,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 						...espressoTicket,
 						...ticket,
 						...input,
-						cacheId: uuidv4(),
+						cacheId,
 						prices: null,
 					};
 					break;

--- a/packages/edtr-services/src/apollo/mutations/utils.ts
+++ b/packages/edtr-services/src/apollo/mutations/utils.ts
@@ -67,7 +67,7 @@ export const cacheNodesFromBulkInput = <T extends UpdateDatetimeInput | UpdateTi
 			...node,
 			...input.sharedInput,
 			...uniqueInputs[node.id],
-			cacheId: `temp:${uuidv4()}`,
+			cacheId: uuidv4(),
 		};
 	});
 
@@ -92,7 +92,7 @@ export const cacheNodesFromBulkDelete = <E extends Datetime | Ticket | Price>(
 		return {
 			...node,
 			isTrashed: true,
-			cacheId: `temp:${uuidv4()}`,
+			cacheId: uuidv4(),
 		};
 	});
 

--- a/packages/edtr-services/src/apollo/mutations/utils.ts
+++ b/packages/edtr-services/src/apollo/mutations/utils.ts
@@ -67,7 +67,7 @@ export const cacheNodesFromBulkInput = <T extends UpdateDatetimeInput | UpdateTi
 			...node,
 			...input.sharedInput,
 			...uniqueInputs[node.id],
-			cacheId: uuidv4(),
+			cacheId: `temp:${uuidv4()}`,
 		};
 	});
 
@@ -92,7 +92,7 @@ export const cacheNodesFromBulkDelete = <E extends Datetime | Ticket | Price>(
 		return {
 			...node,
 			isTrashed: true,
-			cacheId: uuidv4(),
+			cacheId: `temp:${uuidv4()}`,
 		};
 	});
 

--- a/packages/ee-components/src/EntityList/EntityCacheIds.tsx
+++ b/packages/ee-components/src/EntityList/EntityCacheIds.tsx
@@ -1,0 +1,10 @@
+import { Cacheable } from '@eventespresso/data';
+import { getCacheIds } from '@eventespresso/predicates';
+
+export type EntityCacheIdsProps<E extends Cacheable> = {
+	entities: Array<E>;
+};
+
+export const EntityCacheIds = <E extends Cacheable>({ entities }: EntityCacheIdsProps<E>): JSX.Element => {
+	return <div className='ee-entity-cache-ids' data-cache-ids={getCacheIds(entities).join(',')}></div>;
+};

--- a/packages/ee-components/src/EntityList/index.ts
+++ b/packages/ee-components/src/EntityList/index.ts
@@ -3,5 +3,6 @@ export { default as EntityList } from './EntityList';
 export { default as EntityTable } from './EntityTable';
 
 export * from './EntityListFilterBar';
+export * from './EntityCacheIds';
 
 export * from './types';


### PR DESCRIPTION
This PR attempts to improve waiting for timeouts.
**How it does that?**
To ensure that a list has actually updated/refreshed after making a change, we need to take into account all of the mutations. Then, to actually ensure that a list has updated when it doesn't reflect on the current page of the entity list, we need something which can actually tell us whether the list has updated.

**Welcome `EntityCacheIds`**
This hidden component adds the cache IDs of all the entities in Apollo cache to the markup as `data-cache-ids` attribute. It gets updated after mutations.

**But How?**
Welcome `EntityListParser.createWaitForListUpdate()`! This method lets you create an await-ed promise which is aware of the list before and after the update.

See #774 