### PR TITLE
E2E: More ticket price tests

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/editable/EditablePrice.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/editable/EditablePrice.tsx
@@ -23,7 +23,7 @@ const EditablePrice: React.FC<Partial<EditablePriceProps>> = ({ entity: ticket, 
 	const recalculateBasePrice = useRecalculateBasePrice(ticket.id);
 	const onChangePrice = useCallback(
 		({ amount }: any): void => {
-			const price = parseFloat(amount);
+			const price = Math.abs(amount);
 			if (price !== ticket.price) {
 				recalculateBasePrice(price);
 			}

--- a/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
+++ b/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
@@ -49,9 +49,7 @@ beforeAll(async () => {
 	await tamrover.toggleAllAssignments();
 
 	// Submit TAM
-	const waitForListUpdate = await ticketsParser.createWaitForListUpdate();
 	await tamrover.submit();
-	await waitForListUpdate();
 
 	// Now we have this kind of relationship,
 	/**
@@ -148,9 +146,7 @@ describe(namespace, () => {
 		await tamrover.toggleAllAssignments();
 
 		// Submit TAM
-		const waitForListUpdate = await ticketsParser.createWaitForListUpdate();
 		await tamrover.submit();
-		await waitForListUpdate();
 
 		// Now the old ticket quantity should have changed from 90 to 60
 		const oldTicketQuantity = await getTicketQuantityByName(oldTicketName);

--- a/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/related-count-vs-assignments.test.ts
@@ -72,11 +72,8 @@ describe('TAM:RelatedCountVsAssignments', () => {
 				// Lets flip all the relations
 				await tamrover.toggleAllAssignments();
 
-				const waitForListUpdate = await parser.setEntityType('ticket').createWaitForListUpdate();
 				// Now lets submit.
 				await tamrover.submit();
-
-				await waitForListUpdate();
 
 				/******** CHECK AFTER SUBMIT ********/
 				await assertListAndTAMRelatedCount(entityType, viewType);

--- a/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
+++ b/packages/e2e-tests/specs/tam/toggle-assignments.test.ts
@@ -1,11 +1,10 @@
 import { saveVideo } from 'playwright-video';
 import { path } from 'ramda';
 
-import { createNewEvent, TAMRover, EntityListParser } from '@e2eUtils/admin/event-editor';
+import { createNewEvent, TAMRover } from '@e2eUtils/admin/event-editor';
 import { addDatesAndTickets } from './utils';
 
 const tamrover = new TAMRover();
-const parser = new EntityListParser('ticket');
 
 beforeAll(async () => {
 	await saveVideo(page, 'artifacts/tam-toggle-assignments.mp4');
@@ -47,12 +46,8 @@ describe('TAM:ToggleAssignments', () => {
 			}
 		}
 
-		const waitForListUpdate = await parser.createWaitForListUpdate();
-
 		// Now lets submit.
 		await tamrover.submit();
-
-		await waitForListUpdate();
 
 		// Open TAM again
 		await tamrover.setForType('all').launch();

--- a/packages/e2e-tests/specs/tickets/price.test.ts
+++ b/packages/e2e-tests/specs/tickets/price.test.ts
@@ -71,15 +71,6 @@ describe(namespace, () => {
 		let price = await getTicketPrice(item);
 		expect(Number(price)).toBe(47);
 
-		// for the only ticket we have
-		await tpcSafari.launch();
-
-		const ticketTotal = await tpcSafari.getTicketTotal();
-		// Ticket total should reflect in TPC
-		expect(Number(ticketTotal)).toBe(47);
-
-		await tpcSafari.close();
-
 		// Lets change the list view
 		await editor.switchView('table');
 

--- a/packages/e2e-tests/specs/tickets/price.test.ts
+++ b/packages/e2e-tests/specs/tickets/price.test.ts
@@ -43,10 +43,8 @@ describe(namespace, () => {
 		// Since there are no modifiers, totol is equal to base price
 		expect(Number(ticketTotal)).toBe(13);
 
-		const waitForListUpdate = await editor.createWaitForListUpdate();
 		// Now lets submit.
 		await tpcSafari.submit();
-		await waitForListUpdate();
 
 		// first/only item
 		let item = await editor.getItem();

--- a/packages/e2e-tests/specs/tpc/index.test.ts
+++ b/packages/e2e-tests/specs/tpc/index.test.ts
@@ -40,7 +40,7 @@ const submitAndAssertTotal = async (total: string | number) => {
 
 	const item = await editor.getItem();
 	const price = await getTicketPrice(item);
-	expect(tpcSafari.getFormattedAmount(price)).toBe(tpcSafari.getFormattedAmount(total));
+	expect(tpcSafari.getFormattedAmount(price)).toBe(tpcSafari.getFormattedAmount(total || 0));
 };
 
 describe('TPC:calculateTicketTotal', () => {

--- a/packages/e2e-tests/specs/tpc/index.test.ts
+++ b/packages/e2e-tests/specs/tpc/index.test.ts
@@ -1,4 +1,4 @@
-import { saveVideo } from 'playwright-video';
+// import { saveVideo } from 'playwright-video';
 import { isNil } from 'ramda';
 
 import { ticketTotalTestCases } from '@eventespresso/tpc/src/utils/test/ticketTotalData';
@@ -11,12 +11,15 @@ import {
 	removeAllTickets,
 	removeAllPriceModifiers,
 	TPCSafari,
+	TicketEditor,
+	getTicketPrice,
 } from '@e2eUtils/admin/event-editor';
 
+const editor = new TicketEditor();
 const tpcSafari = new TPCSafari();
 
 beforeAll(async () => {
-	await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
+	// await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
 	const newTicketName = 'one way ticket';
 	const newTicketAmount = 10;
 
@@ -25,13 +28,20 @@ beforeAll(async () => {
 	await removeAllTickets();
 
 	await addNewTicket({ amount: newTicketAmount, name: newTicketName });
-
-	await tpcSafari.launch();
 });
 
 beforeEach(async () => {
+	await tpcSafari.launch();
 	await removeAllPriceModifiers();
 });
+
+const submitAndAssertTotal = async (total: string | number) => {
+	await tpcSafari.submit();
+
+	const item = await editor.getItem();
+	const price = await getTicketPrice(item);
+	expect(tpcSafari.getFormattedAmount(price)).toBe(tpcSafari.getFormattedAmount(total));
+};
 
 describe('TPC:calculateTicketTotal', () => {
 	// lets reverse calculate ticket total from the base price test data
@@ -51,6 +61,8 @@ describe('TPC:calculateTicketTotal', () => {
 			const calculatedTotal = await tpcSafari.getTicketTotal();
 
 			expect(calculatedTotal).toEqual(tpcSafari.getFormattedAmount(total));
+
+			await submitAndAssertTotal(calculatedTotal);
 		});
 	}
 
@@ -64,13 +76,15 @@ describe('TPC:calculateTicketTotal', () => {
 			const calculatedTotal = await tpcSafari.getTicketTotal();
 
 			expect(calculatedTotal).toEqual(tpcSafari.getFormattedAmount(total));
+
+			await submitAndAssertTotal(calculatedTotal);
 		});
 	}
 });
 
 describe('TPC:calculateBasePrice', () => {
-	beforeAll(async () => {
-		await tpcSafari.toggleReverseCalculate();
+	beforeEach(async () => {
+		await tpcSafari.setReverseCalculate(true);
 	});
 
 	// lets reverse calculate base price from the ticket total test data
@@ -91,6 +105,8 @@ describe('TPC:calculateBasePrice', () => {
 			const calculatedPrice = await tpcSafari.getBasePrice();
 
 			expect(calculatedPrice).toBe(tpcSafari.getFormattedAmount(basePrice));
+
+			await submitAndAssertTotal(total);
 		});
 	}
 
@@ -107,6 +123,8 @@ describe('TPC:calculateBasePrice', () => {
 			const calculatedPrice = await tpcSafari.getBasePrice();
 
 			expect(calculatedPrice).toBe(tpcSafari.getFormattedAmount(basePrice));
+
+			await submitAndAssertTotal(total);
 		});
 	}
 });

--- a/packages/e2e-tests/specs/tpc/index.test.ts
+++ b/packages/e2e-tests/specs/tpc/index.test.ts
@@ -1,4 +1,4 @@
-// import { saveVideo } from 'playwright-video';
+import { saveVideo } from 'playwright-video';
 import { isNil } from 'ramda';
 
 import { ticketTotalTestCases } from '@eventespresso/tpc/src/utils/test/ticketTotalData';
@@ -19,7 +19,7 @@ const editor = new TicketEditor();
 const tpcSafari = new TPCSafari();
 
 beforeAll(async () => {
-	// await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
+	await saveVideo(page, 'artifacts/calculateTicketTotal.mp4');
 	const newTicketName = 'one way ticket';
 	const newTicketAmount = 10;
 

--- a/packages/e2e-tests/specs/tpc/price-inline-vs-tpc.test.ts
+++ b/packages/e2e-tests/specs/tpc/price-inline-vs-tpc.test.ts
@@ -1,0 +1,64 @@
+import { createNewEvent, getTicketPrice, TicketEditor, TPCSafari } from '@e2eUtils/admin/event-editor';
+
+const namespace = 'event-tickets-price-change-inline-vs-tpc';
+
+const editor = new TicketEditor();
+const tpcSafari = new TPCSafari();
+
+beforeAll(async () => {
+	await createNewEvent({ title: namespace });
+	// Ensure that we are in card view
+	await editor.switchView('card');
+});
+
+describe(namespace, () => {
+	it('tests the price change in inline edit input reflects in TPC', async () => {
+		// first/only item
+		const item = await editor.getItem();
+
+		await editor.updatePriceInline(item, 63);
+		const price = await getTicketPrice(item);
+		expect(Number(price)).toBe(63);
+
+		// for the only ticket we have
+		await tpcSafari.launch();
+
+		const basePrice = await tpcSafari.getBasePrice();
+		const ticketTotal = await tpcSafari.getTicketTotal();
+		// Ticket total and base price should reflect in TPC
+		expect(Number(basePrice)).toBe(63);
+		expect(Number(ticketTotal)).toBe(63);
+
+		// Since we edited the price inline, reverse calculate should be ON
+		const isReverseCalculateOn = await tpcSafari.isReverseCalculateOn();
+		expect(isReverseCalculateOn).toBe(true);
+
+		await tpcSafari.close();
+	});
+
+	it('tests the price change in TPC reflects in inline edit input', async () => {
+		// for the only ticket we have
+		await tpcSafari.launch();
+
+		await tpcSafari.setReverseCalculate(true);
+
+		// Set ticket total
+		await tpcSafari.setTicketTotal(357.87);
+
+		// Now lets submit.
+		await tpcSafari.submit();
+
+		// first/only item
+		let item = await editor.getItem();
+
+		let price = await getTicketPrice(item);
+		expect(Number(price)).toBe(357.87);
+
+		// Lets change the list view to table
+		await editor.toggleView();
+		// The change should be reflected
+		item = await editor.getItem();
+		price = await getTicketPrice(item);
+		expect(Number(price)).toBe(357.87);
+	});
+});

--- a/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
@@ -130,7 +130,7 @@ export class TAMRover {
 		if (closeButton) {
 			await closeButton.click();
 		} else {
-			EE_DEBUG || console.error('Could not find the close button for TAM.');
+			EE_DEBUG && console.error('Could not find the close button for TAM.');
 		}
 
 		// If TAM is dirty, there may be an alert.

--- a/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
@@ -64,7 +64,7 @@ export class TAMRover {
 
 		// set parser if TAM is for a single date or ticket
 		if (this.forType && this.forType !== 'all') {
-			this.parser = new EntityListParser(this.forType);
+			this.setParser(this.forType);
 		}
 
 		return this;
@@ -75,6 +75,15 @@ export class TAMRover {
 	 */
 	setDbId = (dbId?: number): TAMRover => {
 		this.dbId = dbId;
+
+		return this;
+	};
+
+	/**
+	 * Change the "for entity type".
+	 */
+	setParser = (forType: Exclude<ForType, 'all'>): TAMRover => {
+		this.parser = new EntityListParser(forType);
 
 		return this;
 	};
@@ -143,7 +152,12 @@ export class TAMRover {
 		const submitButton = await page.$(`${this.getRootSelector()} button[type=submit]`);
 
 		if (submitButton) {
+			// Ensure that parser is set
+			this.setParser('ticket');
+
+			const waitForListUpdate = await this.parser.createWaitForListUpdate();
 			await submitButton.click();
+			await waitForListUpdate();
 		}
 
 		this.reset();

--- a/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
@@ -2,6 +2,7 @@ import type { Page, ElementHandle } from 'playwright';
 import { assocPath } from 'ramda';
 
 import { clickButton, respondToAlert } from '@e2eUtils/common';
+import { EE_DEBUG } from '@e2eUtils/misc';
 import { EntityListParser, Field, Item } from './EntityListParser';
 import { EntityType } from '../../../types';
 
@@ -128,6 +129,8 @@ export class TAMRover {
 
 		if (closeButton) {
 			await closeButton.click();
+		} else {
+			EE_DEBUG || console.error('Could not find the close button for TAM.');
 		}
 
 		// If TAM is dirty, there may be an alert.

--- a/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
@@ -155,7 +155,7 @@ export class TAMRover {
 		const submitButton = await page.$(`${this.getRootSelector()} button[type=submit]`);
 
 		if (submitButton) {
-			const oldEntityType = this.parser.entityType;
+			const oldEntityType = this.parser?.entityType;
 			// Ensure that parser is set
 			this.setParser('ticket');
 

--- a/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TAMRover.ts
@@ -155,12 +155,16 @@ export class TAMRover {
 		const submitButton = await page.$(`${this.getRootSelector()} button[type=submit]`);
 
 		if (submitButton) {
+			const oldEntityType = this.parser.entityType;
 			// Ensure that parser is set
 			this.setParser('ticket');
 
 			const waitForListUpdate = await this.parser.createWaitForListUpdate();
 			await submitButton.click();
 			await waitForListUpdate();
+
+			// restore the entity type
+			this.setParser(oldEntityType);
 		}
 
 		this.reset();

--- a/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
@@ -6,6 +6,7 @@ import { getPriceModifiers } from '@eventespresso/predicates';
 import { convertToModifier, createPrices, PriceCreator } from '@eventespresso/tpc/src/utils/test/utils';
 
 import { respondToAlert } from '@e2eUtils/common';
+import { EE_DEBUG } from '@e2eUtils/misc';
 import { EntityListParser } from './EntityListParser';
 import { setPrice } from './setPrice';
 import { setPrices } from './setPrices';
@@ -76,13 +77,13 @@ export class TPCSafari {
 	 * Close TPC modal.
 	 */
 	close = async (): Promise<void> => {
-		const root = await this.getRoot();
-		const closeButton = await root.$('[aria-label="close modal"]');
+		const closeButton = await page.$(`${this.getRootSelector()} [aria-label="close modal"]`);
 
 		if (closeButton) {
 			await closeButton.click();
+		} else {
+			EE_DEBUG || console.error('Could not find the close button for TPC.');
 		}
-
 		// If TPC is dirty, there may be an alert.
 		await respondToAlert('Yes');
 
@@ -112,21 +113,37 @@ export class TPCSafari {
 		await root.$eval(
 			'header.ee-modal__header',
 			(header, text) => {
-				// eslint-disable-next-line no-param-reassign
-				header.innerHTML = text;
+				// First child node is the text node, containing the title
+				header.firstChild.replaceWith(text);
 			},
 			title
 		);
 	};
 
 	/**
-	 * Updates the TPC Modal header title
+	 * Returns true if reverse calculate is ON
 	 */
-	toggleReverseCalculate = async (): Promise<void> => {
+	isReverseCalculateOn = async (): Promise<boolean> => {
 		const root = await this.getRoot();
-		const revCalcButton = await root.$('[aria-label="Enable reverse calculate"]');
+		const revCalcButton = await root.$('[aria-label="Disable reverse calculate"]');
+		// If the element is found, it will be truthy
+		return Boolean(revCalcButton);
+	};
 
-		await revCalcButton?.click().catch(console.log);
+	/**
+	 * Sets reverse calculate to true or false
+	 */
+	setReverseCalculate = async (value = false): Promise<void> => {
+		const isReverseCalculateOn = await this.isReverseCalculateOn();
+
+		if (isReverseCalculateOn !== value) {
+			const selector = `[aria-label="${isReverseCalculateOn ? 'Disable' : 'Enable'} reverse calculate"]`;
+
+			const root = await this.getRoot();
+			const revCalcButton = await root.$(selector);
+
+			await revCalcButton?.click();
+		}
 	};
 
 	/**
@@ -180,6 +197,10 @@ export class TPCSafari {
 
 		// set modifiers
 		await setPrices(modifiersOnly ? getPriceModifiers(testPrices) : testPrices);
+
+		// Focus on root to make sure the amount is updated when empty
+		const root = await this.getRoot();
+		await root.focus();
 	};
 
 	/**

--- a/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
@@ -82,7 +82,7 @@ export class TPCSafari {
 		if (closeButton) {
 			await closeButton.click();
 		} else {
-			EE_DEBUG || console.error('Could not find the close button for TPC.');
+			EE_DEBUG && console.error('Could not find the close button for TPC.');
 		}
 		// If TPC is dirty, there may be an alert.
 		await respondToAlert('Yes');

--- a/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TPCSafari.ts
@@ -96,7 +96,9 @@ export class TPCSafari {
 		const submitButton = await page.$(`${this.getRootSelector()} button[type=submit]`);
 
 		if (submitButton) {
+			const waitForListUpdate = await this.parser.createWaitForListUpdate();
 			await submitButton.click();
+			await waitForListUpdate();
 		}
 
 		this.reset();

--- a/packages/e2e-tests/utils/admin/event-editor/setPrice.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/setPrice.ts
@@ -12,7 +12,6 @@ export const setPrice = async (price: TpcPriceModifier) => {
 	if (!isBasePrice(price)) {
 		await page.click(`${parentSelector} [aria-label="add new price modifier after this row"]`);
 		// Set price order
-		await page.focus(`${parentSelector} [aria-label="price order"]`);
 		await page.fill(`${parentSelector} [aria-label="price order"]`, (price.order || 2).toString());
 
 		// Set price type
@@ -21,14 +20,11 @@ export const setPrice = async (price: TpcPriceModifier) => {
 	}
 
 	// Set price name
-	await page.focus(`${parentSelector} [aria-label="price name"]`);
 	await page.fill(`${parentSelector} [aria-label="price name"]`, price.name || '');
 
 	// Set price description
-	await page.focus(`${parentSelector} [aria-label="price description"]`);
 	await page.fill(`${parentSelector} [aria-label="price description"]`, price.description || '');
 
 	// Set price amount
-	await page.focus(`${parentSelector} [aria-label="amount"]`);
 	await page.fill(`${parentSelector} [aria-label="amount"]`, (price.amount || '').toString());
 };

--- a/packages/e2e-tests/utils/common/respondToAlert.ts
+++ b/packages/e2e-tests/utils/common/respondToAlert.ts
@@ -1,3 +1,5 @@
+import { EE_DEBUG } from '../misc';
+
 const selector = '.ee-alert-dialog';
 
 export const respondToAlert = async (optionToChoose = 'Yes') => {
@@ -8,7 +10,7 @@ export const respondToAlert = async (optionToChoose = 'Yes') => {
 		if (button) {
 			button.click();
 		} else {
-			console.error(`Could not find the option "${optionToChoose}" in the alert.`);
+			EE_DEBUG && console.error(`Could not find the option "${optionToChoose}" in the alert.`);
 		}
 	}
 };

--- a/packages/tpc/src/fields/TicketPriceField.tsx
+++ b/packages/tpc/src/fields/TicketPriceField.tsx
@@ -19,7 +19,7 @@ const TicketPriceField: React.FC<TicketPriceFieldProps> = (props) => {
 
 	const parse: BFP['parse'] = useCallback((price) => parsedAmount(price), []);
 
-	const setValue: BFP['setValue'] = useCallback((value) => updateTicketPrice(parsedAmount(value)), [
+	const setValue: BFP['setValue'] = useCallback((value) => updateTicketPrice(Math.abs(parsedAmount(value)) || 0), [
 		updateTicketPrice,
 	]);
 
@@ -33,6 +33,7 @@ const TicketPriceField: React.FC<TicketPriceFieldProps> = (props) => {
 				parse={parse}
 				setValue={setValue}
 				type='number'
+				min={0}
 			/>
 		</MoneyInputWithConfig>
 	);

--- a/packages/tpc/src/fields/usePriceAmount.tsx
+++ b/packages/tpc/src/fields/usePriceAmount.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import { parsedAmount } from '@eventespresso/utils';
+
 import { useDataState } from '../data';
 import type { BaseFieldProps, UsePrice, UsePriceAmount } from './types';
 
@@ -12,7 +14,7 @@ const usePriceAmount = ({ field, price }: UsePriceAmount): UsePrice => {
 
 	const setValue = useCallback<BFP['setValue']>(
 		(value) => {
-			const absValue = Math.abs(value as number) || 0;
+			const absValue = Math.abs(parsedAmount(value as number)) || 0;
 			updatePrice({ id: price.id, fieldValues: { [field]: absValue } });
 		},
 		[updatePrice, price.id, field]


### PR DESCRIPTION
This PR adds more e2e tests for changes to ticket price in TPC and the inline inputs.

It also fixes the negative ticket total price in TPC and inline input.

See #774