### PR TITLE
E2E: Add crazy test cases for ticket price inputs

### DIFF
--- a/packages/e2e-tests/specs/tpc/data.ts
+++ b/packages/e2e-tests/specs/tpc/data.ts
@@ -1,0 +1,47 @@
+export const crazyTestCases = [
+	{
+		name: 'sets the price to 0 for non-numeric input',
+		inputTotal: 'I am not crazy!',
+		expectedTotal: 0,
+	},
+	{
+		name: 'tests the craziness quotient by setting the price to 0 for the craziest input',
+		inputTotal: '()*&@_+hkj&68(7)=!)(*0989^%$3(*^&(*%&^$^%#$%476hbgFYU^$%6VR87',
+		expectedTotal: 0,
+	},
+	{
+		name: 'tests the tolerance level of the editor',
+		inputTotal: '999999999999999999999999999999999999999999',
+		expectedTotal: 1e42,
+	},
+	{
+		name: 'tests the niceness of the craziness',
+		inputTotal: '00000000000000000000000000000000000000000000',
+		expectedTotal: 0,
+	},
+	{
+		name: 'tests the arrogance of the craziness',
+		inputTotal: '999999999999999999999999999999999999999999.9999999999999999999999999999999999999',
+		expectedTotal: 1e42,
+	},
+	{
+		name: 'tests the smartness of the craziness',
+		inputTotal: '000000000000000000000000000000000000000000.00000000000000000000000000000000000000000',
+		expectedTotal: 0,
+	},
+	{
+		name: 'sets the price to its absolute value if it is negative',
+		inputTotal: '-876876.89',
+		expectedTotal: 876876.89,
+	},
+	{
+		name: 'sets the price to correct round figure - ceiling',
+		inputTotal: '123456789.987654321',
+		expectedTotal: 123456789.99,
+	},
+	{
+		name: 'sets the price to correct round figure - floor',
+		inputTotal: '123456789.123456789',
+		expectedTotal: 123456789.12,
+	},
+];

--- a/packages/e2e-tests/specs/tpc/price-precision.test.ts
+++ b/packages/e2e-tests/specs/tpc/price-precision.test.ts
@@ -1,0 +1,28 @@
+import { createNewEvent, getTicketPrice, TicketEditor, TPCSafari } from '@e2eUtils/admin/event-editor';
+
+import { crazyTestCases } from './data';
+
+const namespace = 'event-tickets-price-craziness';
+
+const editor = new TicketEditor();
+const tpcSafari = new TPCSafari();
+
+beforeAll(async () => {
+	await createNewEvent({ title: namespace });
+	// Ensure that we are in card view
+	await editor.switchView('card');
+});
+
+describe(namespace, () => {
+	for (const { name, inputTotal, expectedTotal } of crazyTestCases) {
+		it(name, async () => {
+			// first/only item
+			const item = await editor.getItem();
+
+			await editor.updatePriceInline(item, inputTotal);
+			const price = await getTicketPrice(item);
+			expect(Number(price)).toBe(expectedTotal);
+			expect(tpcSafari.getFormattedAmount(price)).toBe(tpcSafari.getFormattedAmount(expectedTotal));
+		});
+	}
+});

--- a/packages/e2e-tests/utils/admin/event-editor/TicketEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TicketEditor.ts
@@ -33,7 +33,7 @@ export class TicketEditor extends EntityEditor {
 	/**
 	 * Given an entity item, it updates the price in the inline edit input
 	 */
-	updatePriceInline = async (item: Item, price: number) => {
+	updatePriceInline = async (item: Item, price: number | string) => {
 		const inlineEditPreview = await item.$('.entity-card__details .ee-currency-input .ee-tabbable-text');
 		await inlineEditPreview.click();
 		const inlineEditInput = await item.$('.entity-card__details .ee-currency-input input');


### PR DESCRIPTION
This PR adds e2e test edge cases for ticket price inputs.

See #774 