### PR TITLE
E2E: Date deletion tests

### DIFF
--- a/packages/e2e-tests/specs/dates/delete.test.ts
+++ b/packages/e2e-tests/specs/dates/delete.test.ts
@@ -1,43 +1,91 @@
-import { saveVideo } from 'playwright-video';
-
-import { addNewDate, createNewEvent, EntityListParser, DateEditor } from '@e2eUtils/admin/event-editor';
+import { addNewDate, createNewEvent, DateEditor, TicketEditor } from '@e2eUtils/admin/event-editor';
 
 const namespace = 'event.dates.delete';
 
 const dateEditor = new DateEditor();
-const ticketsParser = new EntityListParser('ticket');
-
-beforeAll(async () => {
-	await createNewEvent({ title: namespace });
-});
+const ticketEditor = new TicketEditor();
 
 describe(namespace, () => {
-	it('should delete dates by name:', async () => {
-		const capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
-		try {
-			await addNewDate({ name: namespace + '.date' });
-			let dateCount = await dateEditor.getItemCount();
+	it('should trash dates by name', async () => {
+		await createNewEvent({ title: namespace });
+		await addNewDate({ name: namespace + '.date' });
+		let dateCount = await dateEditor.getItemCount();
 
-			expect(dateCount).toBe(2);
+		expect(dateCount).toBe(2);
 
-			await dateEditor.deleteItemBy('name', namespace + '.date');
+		await dateEditor.trashItemBy('name', namespace + '.date');
 
-			dateCount = await dateEditor.getItemCount();
-			let ticketCount = await ticketsParser.getItemCount();
+		dateCount = await dateEditor.getItemCount();
+		let ticketCount = await ticketEditor.getItemCount();
 
-			expect(dateCount).toBe(1);
-			expect(ticketCount).toBe(1);
+		expect(dateCount).toBe(1);
+		expect(ticketCount).toBe(1);
 
-			const date = await dateEditor.getItem();
+		const date = await dateEditor.getItem();
 
-			await dateEditor.deleteItem(date);
+		await dateEditor.trashItem(date);
 
-			dateCount = await dateEditor.getItemCount();
-			ticketCount = await ticketsParser.getItemCount();
-			expect(dateCount).toBe(0);
-			expect(ticketCount).toBe(0);
-		} catch (error) {
-			await capture.stop();
-		}
+		dateCount = await dateEditor.getItemCount();
+		ticketCount = await ticketEditor.getItemCount();
+		expect(dateCount).toBe(0);
+		expect(ticketCount).toBe(0);
+	});
+
+	it('tests the permanent deletion of dates', async () => {
+		await createNewEvent({ title: namespace });
+
+		let itemCount = await dateEditor.getItemCount();
+
+		expect(itemCount).toBe(1);
+
+		let item = await dateEditor.getItem();
+		// Lets trash the only date we have
+		await dateEditor.trashItem(item);
+
+		itemCount = await dateEditor.getItemCount();
+		// Now we should have nothing :(
+		expect(itemCount).toBe(0);
+
+		// Lets unhide the treasure
+		await dateEditor.removeAllFilters();
+
+		itemCount = await dateEditor.getItemCount();
+		// we should now have the trashed one
+		expect(itemCount).toBe(1);
+		item = await dateEditor.getItem();
+		const status = await dateEditor.getItemStatus(item);
+		expect(status).toBe('trashed');
+
+		// Lets open dropdown menu
+		await dateEditor.openDropdownMenu(item);
+		const permanentDeleteBtn = await item.$('[type=button] >> text=delete permanently');
+		// Since we only have single entity in the list, permanent delete button should be disabled
+		expect(await permanentDeleteBtn.isDisabled()).toBe(true);
+
+		await ticketEditor.removeAllFilters();
+		await ticketEditor.editTicket(null, { isTrashed: false });
+
+		// Now lets add another date
+		await addNewDate({ name: namespace + '.date' });
+		// Now we should have 2 dates
+		itemCount = await dateEditor.getItemCount();
+		expect(itemCount).toBe(2);
+
+		// Lets narrow down to only the trashed dates
+		await dateEditor.filterListBy('status', { label: 'trashed dates only' });
+
+		// Now we should have only 1 date (trashed)
+		itemCount = await dateEditor.getItemCount();
+		expect(itemCount).toBe(1);
+		await dateEditor.removeAllFilters();
+		itemCount = await dateEditor.getItemCount();
+		expect(itemCount).toBe(2);
+
+		item = await dateEditor.getItemBy('status', 'trashed');
+		// we should now be able to delete the item pemanently
+		await dateEditor.permanentlyDeleteItem(item);
+
+		itemCount = await dateEditor.getItemCount();
+		expect(itemCount).toBe(1);
 	});
 });

--- a/packages/e2e-tests/specs/dates/delete.test.ts
+++ b/packages/e2e-tests/specs/dates/delete.test.ts
@@ -1,3 +1,5 @@
+import { saveVideo } from 'playwright-video';
+
 import { addNewDate, createNewEvent, DateEditor, TicketEditor } from '@e2eUtils/admin/event-editor';
 
 const namespace = 'event.dates.delete';
@@ -5,87 +7,98 @@ const namespace = 'event.dates.delete';
 const dateEditor = new DateEditor();
 const ticketEditor = new TicketEditor();
 
+beforeEach(async () => {
+	await createNewEvent({ title: namespace });
+});
+
 describe(namespace, () => {
 	it('should trash dates by name', async () => {
-		await createNewEvent({ title: namespace });
-		await addNewDate({ name: namespace + '.date' });
-		let dateCount = await dateEditor.getItemCount();
+		const capture = await saveVideo(page, `artifacts/${namespace}.trash.mp4`);
+		try {
+			await addNewDate({ name: namespace + '.date' });
+			let dateCount = await dateEditor.getItemCount();
 
-		expect(dateCount).toBe(2);
+			expect(dateCount).toBe(2);
 
-		await dateEditor.trashItemBy('name', namespace + '.date');
+			await dateEditor.trashItemBy('name', namespace + '.date');
 
-		dateCount = await dateEditor.getItemCount();
-		let ticketCount = await ticketEditor.getItemCount();
+			dateCount = await dateEditor.getItemCount();
+			let ticketCount = await ticketEditor.getItemCount();
 
-		expect(dateCount).toBe(1);
-		expect(ticketCount).toBe(1);
+			expect(dateCount).toBe(1);
+			expect(ticketCount).toBe(1);
 
-		const date = await dateEditor.getItem();
+			const date = await dateEditor.getItem();
 
-		await dateEditor.trashItem(date);
+			await dateEditor.trashItem(date);
 
-		dateCount = await dateEditor.getItemCount();
-		ticketCount = await ticketEditor.getItemCount();
-		expect(dateCount).toBe(0);
-		expect(ticketCount).toBe(0);
+			dateCount = await dateEditor.getItemCount();
+			ticketCount = await ticketEditor.getItemCount();
+			expect(dateCount).toBe(0);
+			expect(ticketCount).toBe(0);
+		} catch (error) {
+			await capture.stop();
+		}
 	});
 
 	it('tests the permanent deletion of dates', async () => {
-		await createNewEvent({ title: namespace });
+		const capture = await saveVideo(page, `artifacts/${namespace}.delete.mp4`);
+		try {
+			let itemCount = await dateEditor.getItemCount();
 
-		let itemCount = await dateEditor.getItemCount();
+			expect(itemCount).toBe(1);
 
-		expect(itemCount).toBe(1);
+			let item = await dateEditor.getItem();
+			// Lets trash the only date we have
+			await dateEditor.trashItem(item);
 
-		let item = await dateEditor.getItem();
-		// Lets trash the only date we have
-		await dateEditor.trashItem(item);
+			itemCount = await dateEditor.getItemCount();
+			// Now we should have nothing :(
+			expect(itemCount).toBe(0);
 
-		itemCount = await dateEditor.getItemCount();
-		// Now we should have nothing :(
-		expect(itemCount).toBe(0);
+			// Lets unhide the treasure
+			await dateEditor.removeAllFilters();
 
-		// Lets unhide the treasure
-		await dateEditor.removeAllFilters();
+			itemCount = await dateEditor.getItemCount();
+			// we should now have the trashed one
+			expect(itemCount).toBe(1);
+			item = await dateEditor.getItem();
+			const status = await dateEditor.getItemStatus(item);
+			expect(status).toBe('trashed');
 
-		itemCount = await dateEditor.getItemCount();
-		// we should now have the trashed one
-		expect(itemCount).toBe(1);
-		item = await dateEditor.getItem();
-		const status = await dateEditor.getItemStatus(item);
-		expect(status).toBe('trashed');
+			// Lets open dropdown menu
+			await dateEditor.openDropdownMenu(item);
+			const permanentDeleteBtn = await item.$('[type=button] >> text=delete permanently');
+			// Since we only have single entity in the list, permanent delete button should be disabled
+			expect(await permanentDeleteBtn.isDisabled()).toBe(true);
 
-		// Lets open dropdown menu
-		await dateEditor.openDropdownMenu(item);
-		const permanentDeleteBtn = await item.$('[type=button] >> text=delete permanently');
-		// Since we only have single entity in the list, permanent delete button should be disabled
-		expect(await permanentDeleteBtn.isDisabled()).toBe(true);
+			await ticketEditor.removeAllFilters();
+			await ticketEditor.editTicket(null, { isTrashed: false });
 
-		await ticketEditor.removeAllFilters();
-		await ticketEditor.editTicket(null, { isTrashed: false });
+			// Now lets add another date
+			await addNewDate({ name: namespace + '.date' });
+			// Now we should have 2 dates
+			itemCount = await dateEditor.getItemCount();
+			expect(itemCount).toBe(2);
 
-		// Now lets add another date
-		await addNewDate({ name: namespace + '.date' });
-		// Now we should have 2 dates
-		itemCount = await dateEditor.getItemCount();
-		expect(itemCount).toBe(2);
+			// Lets narrow down to only the trashed dates
+			await dateEditor.filterListBy('status', { label: 'trashed dates only' });
 
-		// Lets narrow down to only the trashed dates
-		await dateEditor.filterListBy('status', { label: 'trashed dates only' });
+			// Now we should have only 1 date (trashed)
+			itemCount = await dateEditor.getItemCount();
+			expect(itemCount).toBe(1);
+			await dateEditor.removeAllFilters();
+			itemCount = await dateEditor.getItemCount();
+			expect(itemCount).toBe(2);
 
-		// Now we should have only 1 date (trashed)
-		itemCount = await dateEditor.getItemCount();
-		expect(itemCount).toBe(1);
-		await dateEditor.removeAllFilters();
-		itemCount = await dateEditor.getItemCount();
-		expect(itemCount).toBe(2);
+			item = await dateEditor.getItemBy('status', 'trashed');
+			// we should now be able to delete the item pemanently
+			await dateEditor.permanentlyDeleteItem(item);
 
-		item = await dateEditor.getItemBy('status', 'trashed');
-		// we should now be able to delete the item pemanently
-		await dateEditor.permanentlyDeleteItem(item);
-
-		itemCount = await dateEditor.getItemCount();
-		expect(itemCount).toBe(1);
+			itemCount = await dateEditor.getItemCount();
+			expect(itemCount).toBe(1);
+		} catch (error) {
+			await capture.stop();
+		}
 	});
 });

--- a/packages/e2e-tests/specs/dates/filters/sales.test.ts
+++ b/packages/e2e-tests/specs/dates/filters/sales.test.ts
@@ -1,7 +1,6 @@
 import { saveVideo } from 'playwright-video';
 
-import { addNewTicket, createNewEvent, EntityListParser, removeLastTicket } from '@e2eUtils/admin/event-editor';
-import { clickButton } from '@e2eUtils/common';
+import { addNewTicket, createNewEvent, removeLastTicket, DateEditor } from '@e2eUtils/admin/event-editor';
 
 const namespace = 'eventDates.filters.sales';
 
@@ -11,7 +10,7 @@ beforeAll(async () => {
 	await createNewEvent({ title: namespace });
 });
 
-const datesParser = new EntityListParser('datetime');
+const dateEditor = new DateEditor();
 
 describe(namespace, () => {
 	it('should filter dates corresponding to sales control', async () => {
@@ -21,30 +20,20 @@ describe(namespace, () => {
 
 		// await addNewRegistration();
 
-		await clickButton('show filters');
+		await dateEditor.filterListBy('sales', { value: 'above90Capacity' });
 
-		await page.selectOption('#ee-dates-list-sales-control', {
-			value: 'above90Capacity',
-		});
+		expect(await dateEditor.getItemCount()).toBe(0);
 
-		expect(await datesParser.getItemCount()).toBe(0);
+		await dateEditor.filterListBy('sales', { value: 'above75Capacity' });
 
-		await page.selectOption('#ee-dates-list-sales-control', {
-			value: 'above75Capacity',
-		});
+		expect(await dateEditor.getItemCount()).toBe(0);
 
-		expect(await datesParser.getItemCount()).toBe(0);
+		await dateEditor.filterListBy('sales', { value: 'above50Capacity' });
 
-		await page.selectOption('#ee-dates-list-sales-control', {
-			value: 'above50Capacity',
-		});
+		expect(await dateEditor.getItemCount()).toBe(0);
 
-		expect(await datesParser.getItemCount()).toBe(0);
+		await dateEditor.filterListBy('sales', { value: 'below50Capacity' });
 
-		await page.selectOption('#ee-dates-list-sales-control', {
-			value: 'below50Capacity',
-		});
-
-		expect(await datesParser.getItemCount()).toBe(1);
+		expect(await dateEditor.getItemCount()).toBe(1);
 	});
 });

--- a/packages/e2e-tests/specs/dates/filters/search.test.ts
+++ b/packages/e2e-tests/specs/dates/filters/search.test.ts
@@ -1,7 +1,6 @@
 import { saveVideo } from 'playwright-video';
 
-import { addNewDate, createNewEvent, EntityListParser } from '@e2eUtils/admin/event-editor';
-import { clickButton } from '@e2eUtils/common';
+import { addNewDate, createNewEvent, DateEditor } from '@e2eUtils/admin/event-editor';
 
 const namespace = 'eventDates.filters.search';
 
@@ -11,25 +10,25 @@ beforeAll(async () => {
 	await createNewEvent({ title: namespace });
 });
 
-const datesParser = new EntityListParser('datetime');
+const dateEditor = new DateEditor();
 
 describe(namespace, () => {
 	it('should filter based on search query', async () => {
 		await addNewDate({ name: 'abc' });
 		await addNewDate({ name: 'def' });
 
-		expect(await datesParser.getItemCount()).toBe(3);
+		expect(await dateEditor.getItemCount()).toBe(3);
 
-		await clickButton('show filters');
+		await dateEditor.filterListBy('search', 'abc');
 
-		await page.fill('#ee-ee-search-input-dates-list', 'abc');
-		expect(await datesParser.getItemCount()).toBe(1);
-		let item = await datesParser.getItem();
+		expect(await dateEditor.getItemCount()).toBe(1);
+		let item = await dateEditor.getItem();
 		expect(await item.innerText()).toContain('abc');
 
-		await page.fill('#ee-ee-search-input-dates-list', 'def');
-		expect(await datesParser.getItemCount()).toBe(1);
-		item = await datesParser.getItem();
+		await dateEditor.filterListBy('search', 'def');
+
+		expect(await dateEditor.getItemCount()).toBe(1);
+		item = await dateEditor.getItem();
 		expect(await item.innerText()).toContain('def');
 	});
 });

--- a/packages/e2e-tests/specs/dates/filters/status.test.ts
+++ b/packages/e2e-tests/specs/dates/filters/status.test.ts
@@ -1,7 +1,6 @@
 import { saveVideo } from 'playwright-video';
 
-import { addNewDate, createNewEvent, EntityListParser } from '@e2eUtils/admin/event-editor';
-import { clickButton } from '@e2eUtils/common';
+import { addNewDate, createNewEvent, DateEditor } from '@e2eUtils/admin/event-editor';
 
 const namespace = 'eventDates.filters.status';
 
@@ -11,7 +10,7 @@ beforeAll(async () => {
 	await createNewEvent({ title: namespace });
 });
 
-const datesParser = new EntityListParser('datetime');
+const dateEditor = new DateEditor();
 
 describe(namespace, () => {
 	it('should show trashed date when status filter is set to "all"', async () => {
@@ -19,17 +18,13 @@ describe(namespace, () => {
 
 		await addNewDate({ name: newDateName, isTrashed: true });
 
-		expect(await datesParser.getItemCount()).toBe(1);
+		expect(await dateEditor.getItemCount()).toBe(1);
 
-		await clickButton('show filters');
+		await dateEditor.filterListBy('status', { value: 'all' });
 
-		await page.selectOption('#ee-dates-list-status-control', {
-			value: 'all',
-		});
+		expect(await dateEditor.getItemCount()).toBe(2);
 
-		expect(await datesParser.getItemCount()).toBe(2);
-
-		const datetimesList = await page.$eval(datesParser.getRootSelector(), (elements) => elements.innerHTML);
+		const datetimesList = await page.$eval(dateEditor.getRootSelector(), (elements) => elements.innerHTML);
 
 		expect(datetimesList).toContain('trash');
 	});

--- a/packages/e2e-tests/specs/shared/copy-entity.test.ts
+++ b/packages/e2e-tests/specs/shared/copy-entity.test.ts
@@ -30,7 +30,7 @@ describe(namespace, () => {
 				expect(beforeCopyCount + 1).toBe(afterCopyCount);
 
 				// Lets delete the item by the same name
-				await editor.deleteItemBy('name', itemName);
+				await editor.trashItemBy('name', itemName);
 				// We should still have an item by the same name
 				item = await editor.getItemBy('name', itemName);
 				expect(item).toBeDefined();

--- a/packages/e2e-tests/utils/admin/event-editor/DateEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/DateEditor.ts
@@ -1,5 +1,5 @@
 import { clickButton } from '@e2eUtils/common';
-import { EntityEditor, CommonEntityFields } from './EntityEditor';
+import { EntityEditor, CommonEntityFields, CommonFilters } from './EntityEditor';
 import { ListView, Item, Field } from './EntityListParser';
 import { fillDateTicketForm } from './fillDateTicketForm';
 
@@ -13,7 +13,7 @@ export class DateEditor extends EntityEditor {
 
 		this.dropdownMenuLabel = 'event date main menu';
 		this.editButtonLabel = 'edit datetime';
-		this.deleteButtonLabel = 'trash datetime';
+		this.trashButtonLabel = 'trash datetime';
 		this.copyButtonLabel = 'copy datetime';
 	}
 
@@ -23,6 +23,26 @@ export class DateEditor extends EntityEditor {
 	reset(): void {
 		super.reset();
 		this.setEntityType('datetime');
+	}
+
+	/**
+	 * Filters the list by the given field and value.
+	 */
+	async filterListBy(filter: CommonFilters, values: Parameters<Item['selectOption']>[0]): Promise<void> {
+		const selector =
+			filter === 'status'
+				? '#ee-dates-list-status-control'
+				: filter === 'sales'
+				? '#ee-dates-list-sales-control'
+				: filter === 'search'
+				? '#ee-ee-search-input-dates-list'
+				: '';
+
+		if (!selector) {
+			console.log('Unknown filter supplied: ' + filter);
+			return;
+		}
+		await this.setFilter(selector, values);
 	}
 
 	/**
@@ -57,7 +77,7 @@ export class DateEditor extends EntityEditor {
 	/**
 	 * Opens the edit form for the date identified by the field and its value.
 	 */
-	editDate = async (item: Item, formData: DateFields): Promise<void> => {
+	editDate = async (item?: Item, formData?: DateFields): Promise<void> => {
 		// Open the edit form modal
 		await this.openEditForm(item);
 		// Fill and submit the edit form

--- a/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
@@ -9,13 +9,16 @@ export interface CommonEntityFields {
 	startDate?: Date;
 }
 
+export type CommonFilters = 'status' | 'sales' | 'search';
+
 export class EntityEditor extends EntityListParser {
 	static RTEContentSelector = '.chakra-modal__content-container .public-DraftStyleDefault-block';
 
 	dropdownMenuLabel = '';
 	editButtonLabel = '';
-	deleteButtonLabel = '';
+	trashButtonLabel = '';
 	copyButtonLabel = '';
+	deleteButtonLabel = 'delete permanently';
 
 	/**
 	 * Given an entity item, it updates the name in the inline edit input
@@ -65,9 +68,9 @@ export class EntityEditor extends EntityListParser {
 	/**
 	 * Copies/clones an entity item.
 	 */
-	copyItem = async (item: Item): Promise<void> => {
-		await this.openDropdownMenu(item);
-		await this.copyAndWait(item);
+	copyItem = async (item?: Item): Promise<void> => {
+		const targetItem = await this.openDropdownMenu(item);
+		await this.copyAndWait(targetItem);
 	};
 
 	/**
@@ -88,39 +91,57 @@ export class EntityEditor extends EntityListParser {
 	};
 
 	/**
-	 * Deletes an entity item.
+	 * Trashs an entity item.
 	 */
-	deleteItem = async (item: Item): Promise<void> => {
-		await this.openDropdownMenu(item);
-		await this.confirmAndDelete(item);
+	trashItem = async (item?: Item): Promise<void> => {
+		const targetItem = await this.openDropdownMenu(item);
+		await this.confirmAndDelete(targetItem, this.trashButtonLabel);
 	};
 
 	/**
-	 * Deletes an entity item identified by the field and its value.
+	 * Trashs an entity item identified by the field and its value.
 	 */
-	deleteItemBy = async (field: Field, value: string | number): Promise<void> => {
+	trashItemBy = async (field: Field, value: string | number): Promise<void> => {
 		const item = await this.openDropdownMenuBy(field, value);
-		await this.confirmAndDelete(item);
+		await this.confirmAndDelete(item, this.trashButtonLabel);
+	};
+
+	/**
+	 * Deletes an entity item permanently
+	 */
+	permanentlyDeleteItem = async (item?: Item): Promise<void> => {
+		const targetItem = await this.openDropdownMenu(item);
+		await this.confirmAndDelete(targetItem, this.deleteButtonLabel);
+	};
+
+	/**
+	 * Permanently deletes an entity item identified by the field and its value.
+	 */
+	permanentlyDeleteItemBy = async (field: Field, value: string | number): Promise<void> => {
+		const item = await this.openDropdownMenuBy(field, value);
+		await this.confirmAndDelete(item, this.deleteButtonLabel);
 	};
 
 	/**
 	 * Confirms an entity deletion and waits for the entity list to update.
 	 */
-	confirmAndDelete = async (item: Item): Promise<void> => {
-		await clickButton(this.deleteButtonLabel, item);
+	confirmAndDelete = async (item: Item, label: string): Promise<void> => {
+		console.log({ label, entity: this.entityType, item: await item.innerText() });
+		await clickButton(label, item);
 		const waitForListUpdate = await this.createWaitForListUpdate();
 		await respondToAlert('Yes');
 		await waitForListUpdate();
 	};
 
 	/**
-	 * Opens the dropdown menu for the entity item.
+	 * Opens the dropdown menu for the entity item. Default to first item.
 	 */
-	openDropdownMenu = async (item: Item): Promise<Item> => {
-		const mainMenuButton = await item.$(`[aria-label="${this.dropdownMenuLabel}"]`);
+	openDropdownMenu = async (item?: Item): Promise<Item> => {
+		const targetItem = item || (await this.getItem());
+		const mainMenuButton = await targetItem.$(`[aria-label="${this.dropdownMenuLabel}"]`);
 		await mainMenuButton.click();
-		await item.waitForSelector('.ee-dropdown-menu__toggle--open');
-		return item;
+		await targetItem.waitForSelector('.ee-dropdown-menu__toggle--open');
+		return targetItem;
 	};
 
 	/**
@@ -134,17 +155,17 @@ export class EntityEditor extends EntityListParser {
 	/**
 	 * Opens the edit form for the entity item.
 	 */
-	openEditForm = async (item: Item): Promise<void> => {
-		await this.openDropdownMenu(item);
-		await clickButton(this.editButtonLabel, item);
+	openEditForm = async (item?: Item): Promise<void> => {
+		const targetItem = await this.openDropdownMenu(item);
+		await clickButton(this.editButtonLabel, targetItem);
 	};
 
 	/**
 	 * Opens the edit form for the entity identified by the field and its value.
 	 */
 	openEditFormBy = async (field: Field, value: string | number): Promise<void> => {
-		await this.openDropdownMenuBy(field, value);
-		await clickButton(this.editButtonLabel);
+		const targetItem = await this.openDropdownMenuBy(field, value);
+		await clickButton(this.editButtonLabel, targetItem);
 	};
 
 	/**

--- a/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
@@ -126,7 +126,6 @@ export class EntityEditor extends EntityListParser {
 	 * Confirms an entity deletion and waits for the entity list to update.
 	 */
 	confirmAndDelete = async (item: Item, label: string): Promise<void> => {
-		await page.waitForTimeout(500);
 		await clickButton(label, item);
 		const waitForListUpdate = await this.createWaitForListUpdate();
 		await respondToAlert('Yes');

--- a/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
@@ -126,6 +126,7 @@ export class EntityEditor extends EntityListParser {
 	 * Confirms an entity deletion and waits for the entity list to update.
 	 */
 	confirmAndDelete = async (item: Item, label: string): Promise<void> => {
+		await page.waitForTimeout(500);
 		await clickButton(label, item);
 		const waitForListUpdate = await this.createWaitForListUpdate();
 		await respondToAlert('Yes');

--- a/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/EntityEditor.ts
@@ -126,7 +126,7 @@ export class EntityEditor extends EntityListParser {
 	 * Confirms an entity deletion and waits for the entity list to update.
 	 */
 	confirmAndDelete = async (item: Item, label: string): Promise<void> => {
-		console.log({ label, entity: this.entityType, item: await item.innerText() });
+		await page.waitForTimeout(500);
 		await clickButton(label, item);
 		const waitForListUpdate = await this.createWaitForListUpdate();
 		await respondToAlert('Yes');

--- a/packages/e2e-tests/utils/admin/event-editor/TicketEditor.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/TicketEditor.ts
@@ -1,5 +1,5 @@
 import { clickButton } from '@e2eUtils/common';
-import { EntityEditor, CommonEntityFields } from './EntityEditor';
+import { EntityEditor, CommonEntityFields, CommonFilters } from './EntityEditor';
 import { ListView, Item, Field } from './EntityListParser';
 import { fillDateTicketForm } from './fillDateTicketForm';
 
@@ -13,7 +13,7 @@ export class TicketEditor extends EntityEditor {
 
 		this.dropdownMenuLabel = 'ticket main menu';
 		this.editButtonLabel = 'edit ticket';
-		this.deleteButtonLabel = 'trash ticket';
+		this.trashButtonLabel = 'trash ticket';
 		this.copyButtonLabel = 'copy ticket';
 	}
 
@@ -23,6 +23,26 @@ export class TicketEditor extends EntityEditor {
 	reset(): void {
 		super.reset();
 		this.setEntityType('ticket');
+	}
+
+	/**
+	 * Filters the list by the given field and value.
+	 */
+	async filterListBy(filter: CommonFilters, values: Parameters<Item['selectOption']>[0]): Promise<void> {
+		const selector =
+			filter === 'status'
+				? '#ee-tickets-list-status-control'
+				: filter === 'sales'
+				? '#ee-tickets-list-sales-control'
+				: filter === 'search'
+				? '#ee-ee-search-input-tickets-list-label'
+				: '';
+
+		if (!selector) {
+			console.log('Unknown filter supplied: ' + filter);
+			return;
+		}
+		await this.setFilter(selector, values);
 	}
 
 	/**
@@ -71,7 +91,7 @@ export class TicketEditor extends EntityEditor {
 	/**
 	 * Opens the edit form for the ticket identified by the field and its value.
 	 */
-	editTicket = async (item: Item, formData: TicketFields): Promise<void> => {
+	editTicket = async (item?: Item, formData?: TicketFields): Promise<void> => {
 		// Open the edit form modal
 		await this.openEditForm(item);
 		// Fill and submit the edit form

--- a/packages/e2e-tests/utils/admin/event-editor/fillDateTicketForm.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/fillDateTicketForm.ts
@@ -47,7 +47,7 @@ export const fillDateTicketForm = async ({
 			await page.fill('[name="quantity"]', quantity);
 		}
 
-		isTrashed && (await page.click('label[for="isTrashed"]'));
+		isTrashed !== undefined && (await page.click('label[for="isTrashed"]'));
 	} catch (e) {
 		console.log(e);
 	}


### PR DESCRIPTION
This PR adds e2e tests for permanent date deletion and also improves the utils to manipulate entity list filters.

See #774 