### PR TITLE
Fix RTE Toolbar Items

### DIFF
--- a/packages/rich-text-editor/src/components/AdvancedTextEditor/toolbarButtons/WPMedia.tsx
+++ b/packages/rich-text-editor/src/components/AdvancedTextEditor/toolbarButtons/WPMedia.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
+import { IconButton } from '@eventespresso/ui-components';
 import { __ } from '@eventespresso/i18n';
 
 import { ToolbarItemProps, ToolbarItem } from '../../RichTextEditor';
@@ -35,7 +36,7 @@ export const WPMedia: React.FC<ToolbarItemProps<'image'>> = ({ onChange, config,
 		return () => wpMedia?.off('select', mediaHandler);
 	}, [mediaHandler]);
 
-	return <ToolbarItem {...toolbar} onClick={openMediaModal} icon={config?.icon} />;
+	return <ToolbarItem {...toolbar} as={IconButton} borderless icon={config?.icon} onClick={openMediaModal} />;
 };
 
 export default WPMedia;

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/ToolbarItem.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/ToolbarItem.tsx
@@ -2,25 +2,23 @@ import { forwardRef } from 'react';
 import { ToolbarItem as ReakitToolbarItem } from 'reakit/Toolbar';
 import classNames from 'classnames';
 
-import { Button, IconButton } from '@eventespresso/ui-components';
 import type { IconComponent } from '@eventespresso/icons';
 
 interface ToolbarItemProps extends React.ComponentProps<typeof ReakitToolbarItem> {
-	isActive?: boolean;
+	as: any;
 	borderless?: boolean;
 	icon?: IconComponent;
+	isActive?: boolean;
 }
 
-export const ToolbarItem = forwardRef<typeof ReakitToolbarItem, ToolbarItemProps>(({ isActive, ...props }, ref) => {
+export const ToolbarItem = forwardRef<typeof ReakitToolbarItem, ToolbarItemProps>(({ as, isActive, ...props }, ref) => {
 	const className = classNames(
 		'ee-rich-text-editor__toolbar-item',
 		isActive && 'ee-rich-text-editor__toolbar-item--active',
 		props.className
 	);
 
-	const As = props?.icon ? IconButton : Button;
-
-	return <ReakitToolbarItem as={As} {...props} ref={ref} className={className} />;
+	return <ReakitToolbarItem as={as} {...props} ref={ref} className={className} />;
 });
 
 export default ToolbarItem;

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/colorPicker/Component.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/colorPicker/Component.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { ColorPicker } from '@eventespresso/ui-components';
+import { ColorPicker, IconButton } from '@eventespresso/ui-components';
 import { useDisclosure } from '@eventespresso/hooks';
 
 import { ToolbarItem } from '../../ToolbarItem';
@@ -34,6 +34,8 @@ const Component: React.FC<ToolbarItemProps<'colorPicker'>> = ({ currentValue, to
 				<ToolbarItem
 					{...toolbar}
 					aria-label={__('Set color')}
+					as={IconButton}
+					borderless
 					onClick={toggleColorPickerPopover}
 					icon={config?.icon}
 				/>

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/image/Component.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/image/Component.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { Button, TextInput } from '@eventespresso/ui-components';
+import { Button, IconButton, TextInput } from '@eventespresso/ui-components';
 import { useDisclosure } from '@eventespresso/hooks';
 
 import { ToolbarItem } from '../../ToolbarItem';
@@ -33,6 +33,8 @@ const Component: React.FC<ToolbarItemProps<'image'>> = ({ toolbar, onChange, con
 				<ToolbarItem
 					{...toolbar}
 					aria-label={__('Add image')}
+					as={IconButton}
+					borderless
 					onClick={toggleImagePopover}
 					icon={config?.icon}
 				/>

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/inline/Component.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/inline/Component.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { IconButton } from '@eventespresso/ui-components';
+
 import { ToolbarItem } from '../../ToolbarItem';
 import { ToolbarItemProps } from '../../types';
 
@@ -18,7 +20,15 @@ const Component: React.FC<ToolbarItemProps<'inline'>> = ({ toolbar, currentValue
 				const isActive = currentValue?.[item] === true || (item === 'monospace' && currentValue?.CODE);
 
 				return (
-					<ToolbarItem {...toolbar} isActive={isActive} key={item} onClick={getOnClick(item)} icon={itemIcon}>
+					<ToolbarItem
+						{...toolbar}
+						as={IconButton}
+						borderless
+						icon={itemIcon}
+						isActive={isActive}
+						key={item}
+						onClick={getOnClick(item)}
+					>
 						{item}
 					</ToolbarItem>
 				);

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/link/Component.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/link/Component.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { Switch, Button, TextInput } from '@eventespresso/ui-components';
+import { Button, IconButton, Switch, TextInput } from '@eventespresso/ui-components';
 import { useDisclosure } from '@eventespresso/hooks';
 
 import { ToolbarItem } from '../../ToolbarItem';
@@ -45,10 +45,18 @@ const Component: React.FC<ToolbarItemProps<'link'>> = ({ currentValue, toolbar, 
 				initialFocusRef={inputRef}
 				isOpen={isUrlPopoverOpen}
 				trigger={
-					<ToolbarItem {...toolbar} aria-label={__('Edit link')} onClick={onClickTrigger} icon={link?.icon} />
+					<ToolbarItem
+						{...toolbar}
+						aria-label={__('Edit link')}
+						as={IconButton}
+						borderless
+						icon={link?.icon}
+						onClick={onClickTrigger}
+					/>
 				}
 				onClose={toggleUrlPopover}
 			>
+				<br />
 				<TextInput value={title} placeholder={__('URL title')} onChangeValue={setTitle as typeof onChange} />
 				<br />
 				<br />
@@ -59,7 +67,9 @@ const Component: React.FC<ToolbarItemProps<'link'>> = ({ currentValue, toolbar, 
 					onChangeValue={setUrl as typeof onChange}
 				/>
 				<br />
+				<br />
 				<Switch isChecked={openInNewTab} onChangeValue={setOpenInNewTab} id='open-in-new-tab' />
+				&emsp;
 				<label htmlFor='open-in-new-tab'>Open in new tab</label>
 				<br />
 				<Button onClick={addLink} isDisabled={!url || !title}>
@@ -69,7 +79,7 @@ const Component: React.FC<ToolbarItemProps<'link'>> = ({ currentValue, toolbar, 
 				<Button onClick={onCloseUrlPopover}>{'Cancel'}</Button>
 			</ToolbarPopover>
 
-			<ToolbarItem {...toolbar} onClick={removeLink} icon={unlink?.icon} />
+			<ToolbarItem {...toolbar} as={IconButton} borderless icon={unlink?.icon} onClick={removeLink} />
 		</>
 	);
 };

--- a/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/remove/Component.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/Toolbar/controls/remove/Component.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { IconButton } from '@eventespresso/ui-components';
+
 import { ToolbarItem } from '../../ToolbarItem';
 import { ToolbarItemProps } from '../../types';
 
@@ -8,7 +10,7 @@ const Component: React.FC<ToolbarItemProps<'remove'>> = ({ toolbar, onChange, co
 		onChange('');
 	}, [onChange]);
 
-	return <ToolbarItem {...toolbar} onClick={onClick} icon={config?.icon} />;
+	return <ToolbarItem {...toolbar} as={IconButton} borderless icon={config?.icon} onClick={onClick} />;
 };
 
 export default Component;

--- a/packages/rich-text-editor/src/components/RichTextEditor/render/Image/Toolbar.tsx
+++ b/packages/rich-text-editor/src/components/RichTextEditor/render/Image/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { DOMAttributes, useCallback } from 'react';
 import { Toolbar as ReakitToolbar } from 'reakit/Toolbar';
 
+import { IconButton } from '@eventespresso/ui-components';
 import { AlignCenter, AlignLeft, AlignRight } from '@eventespresso/icons';
 import { __ } from '@eventespresso/i18n';
 
@@ -31,12 +32,14 @@ const Toolbar: React.FC<ToolbarProps> = ({ align, setAlignment, toolbar }) => {
 			{Object.entries(alignmentWithIcons).map(([alignment, Icon]) => {
 				return (
 					<ToolbarItem
-						key={alignment}
 						{...toolbar}
-						onKeyPress={onKeyPress}
-						isActive={align === alignment}
-						onClick={getOnClick(alignment)}
+						as={IconButton}
+						borderless
 						icon={Icon}
+						isActive={align === alignment}
+						key={alignment}
+						onClick={getOnClick(alignment)}
+						onKeyPress={onKeyPress}
 					/>
 				);
 			})}


### PR DESCRIPTION
This PR:

- adds a required "as" prop to the ToolBarItem component
- ensures "as" prop is set accordingly for all components
- passes any additional props as needed (like "bordeless" for IconButton)