### PR TITLE
Simplify Form Builder UI

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -84,17 +84,23 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 					title: __('Dates'),
 					fields: [
 						{
-							name: 'startDate',
-							label: __('Start Date'),
-							fieldType: 'datetimepicker',
-							required: true,
-						},
-						{
-							name: 'endDate',
-							label: __('End Date'),
-							fieldType: 'datetimepicker',
-							required: true,
-							wrapper: EndDateFieldWrapper,
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'startDate',
+									label: __('Start Date'),
+									fieldType: 'datetimepicker',
+									required: true,
+								},
+								{
+									name: 'endDate',
+									label: __('End Date'),
+									fieldType: 'datetimepicker',
+									required: true,
+									wrapper: EndDateFieldWrapper,
+								},
+							],
 						},
 					],
 				},
@@ -104,23 +110,29 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 					title: __('Details'),
 					fields: [
 						{
-							name: 'capacity',
-							label: __('Capacity'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							min: -1,
-							info:
-								__(
-									'The maximum number of registrants that can attend the event at this particular date.'
-								) +
-								'\n' +
-								__('Set to 0 to close registration or leave blank for no limit.'),
-							width: 'small',
-						},
-						{
-							name: 'isTrashed',
-							label: __('Trash'),
-							fieldType: 'switch',
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'capacity',
+									label: __('Capacity'),
+									fieldType: 'number',
+									parseAsInfinity: true,
+									min: -1,
+									info:
+										__(
+											'The maximum number of registrants that can attend the event at this particular date.'
+										) +
+										'\n' +
+										__('Set to 0 to close registration or leave blank for no limit.'),
+									width: 'small',
+								},
+								{
+									name: 'isTrashed',
+									label: __('Trash'),
+									fieldType: 'switch',
+								},
+							],
 						},
 					],
 				},

--- a/domains/core/admin/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -19,6 +19,10 @@ const FIELD_NAMES: Array<keyof Datetime> = ['id', 'name', 'description', 'capaci
 
 const decorators = [startAndEndDateFixer];
 
+const adjacentFormItemProps = {
+	className: 'ee-form-item-pair',
+};
+
 const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormConfig => {
 	const datetime = useDatetimeItem({ id });
 
@@ -84,23 +88,19 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 					title: __('Dates'),
 					fields: [
 						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'startDate',
-									label: __('Start Date'),
-									fieldType: 'datetimepicker',
-									required: true,
-								},
-								{
-									name: 'endDate',
-									label: __('End Date'),
-									fieldType: 'datetimepicker',
-									required: true,
-									wrapper: EndDateFieldWrapper,
-								},
-							],
+							name: 'startDate',
+							label: __('Start Date'),
+							fieldType: 'datetimepicker',
+							required: true,
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'endDate',
+							label: __('End Date'),
+							fieldType: 'datetimepicker',
+							required: true,
+							wrapper: EndDateFieldWrapper,
+							formControlProps: adjacentFormItemProps,
 						},
 					],
 				},
@@ -110,29 +110,25 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 					title: __('Details'),
 					fields: [
 						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'capacity',
-									label: __('Capacity'),
-									fieldType: 'number',
-									parseAsInfinity: true,
-									min: -1,
-									info:
-										__(
-											'The maximum number of registrants that can attend the event at this particular date.'
-										) +
-										'\n' +
-										__('Set to 0 to close registration or leave blank for no limit.'),
-									width: 'small',
-								},
-								{
-									name: 'isTrashed',
-									label: __('Trash'),
-									fieldType: 'switch',
-								},
-							],
+							name: 'capacity',
+							label: __('Capacity'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							min: -1,
+							info:
+								__(
+									'The maximum number of registrants that can attend the event at this particular date.'
+								) +
+								'\n' +
+								__('Set to 0 to close registration or leave blank for no limit.'),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'isTrashed',
+							label: __('Trash'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
 						},
 					],
 				},

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -100,17 +100,23 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 					title: __('Ticket Sales'),
 					fields: [
 						{
-							name: 'startDate',
-							label: __('Start Date'),
-							fieldType: 'datetimepicker',
-							required: true,
-						},
-						{
-							name: 'endDate',
-							label: __('End Date'),
-							fieldType: 'datetimepicker',
-							required: true,
-							wrapper: EndDateFieldWrapper,
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'startDate',
+									label: __('Start Date'),
+									fieldType: 'datetimepicker',
+									required: true,
+								},
+								{
+									name: 'endDate',
+									label: __('End Date'),
+									fieldType: 'datetimepicker',
+									required: true,
+									wrapper: EndDateFieldWrapper,
+								},
+							],
 						},
 					],
 				},
@@ -120,63 +126,75 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 					title: __('Details'),
 					fields: [
 						{
-							name: 'quantity',
-							label: __('Quantity For Sale'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000000,
-							min: -1,
-							info:
-								__('The maximum number of this ticket available for sale.') +
-								'\n' +
-								__('Set to 0 to stop sales, or leave blank for no limit.'),
-							width: 'small',
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'quantity',
+									label: __('Quantity For Sale'),
+									fieldType: 'number',
+									parseAsInfinity: true,
+									max: 1000000,
+									min: -1,
+									info:
+										__('The maximum number of this ticket available for sale.') +
+										'\n' +
+										__('Set to 0 to stop sales, or leave blank for no limit.'),
+									width: 'small',
+								},
+								{
+									name: 'uses',
+									label: __('Number of Uses'),
+									fieldType: 'number',
+									parseAsInfinity: true,
+									max: 1000,
+									min: 0,
+									info:
+										__(
+											'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
+										) +
+										'\n' +
+										__(
+											'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
+										),
+									width: 'small',
+								},
+							],
 						},
 						{
-							name: 'uses',
-							label: __('Number of Uses'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000,
-							min: 0,
-							info:
-								__(
-									'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
-								) +
-								'\n' +
-								__(
-									'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
-								),
-							width: 'small',
-						},
-						{
-							name: 'min',
-							label: __('Minimum Quantity'),
-							fieldType: 'number',
-							max: 1000000,
-							min: 0,
-							info:
-								__(
-									'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-								) +
-								'\n' +
-								__('Leave blank for no minimum.'),
-							width: 'small',
-						},
-						{
-							name: 'max',
-							label: __('Maximum Quantity'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000000,
-							min: -1,
-							info:
-								__(
-									'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-								) +
-								'\n' +
-								__('Leave blank for no maximum.'),
-							width: 'small',
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'min',
+									label: __('Minimum Quantity'),
+									fieldType: 'number',
+									max: 1000000,
+									min: 0,
+									info:
+										__(
+											'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+										) +
+										'\n' +
+										__('Leave blank for no minimum.'),
+									width: 'small',
+								},
+								{
+									name: 'max',
+									label: __('Maximum Quantity'),
+									fieldType: 'number',
+									parseAsInfinity: true,
+									max: 1000000,
+									min: -1,
+									info:
+										__(
+											'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+										) +
+										'\n' +
+										__('Leave blank for no maximum.'),
+									width: 'small',
+								},
+							],
 						},
 						{
 							name: 'visibility',
@@ -186,18 +204,24 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 							options: VISIBILITY_OPTIONS,
 						},
 						{
-							name: 'isRequired',
-							label: __('Required Ticket'),
-							fieldType: 'switch',
-							info: __(
-								'If enabled, the ticket must be selected and will appear first in frontend ticket lists.'
-							),
-							width: 'small',
-						},
-						{
-							name: 'isTrashed',
-							label: __('Trash'),
-							fieldType: 'switch',
+							name: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'isRequired',
+									label: __('Required Ticket'),
+									fieldType: 'switch',
+									info: __(
+										'If enabled, the ticket must be selected and will appear first in frontend ticket lists.'
+									),
+									width: 'small',
+								},
+								{
+									name: 'isTrashed',
+									label: __('Trash'),
+									fieldType: 'switch',
+								},
+							],
 						},
 					],
 				},

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -34,6 +34,10 @@ export const FIELD_NAMES: Array<keyof Ticket> = [
 const decorators = [startAndEndDateFixer];
 const VISIBILITY_OPTIONS = getEEDomData('eventEditor').ticketMeta.visibilityOptions;
 
+const adjacentFormItemProps = {
+	className: 'ee-form-item-pair',
+};
+
 export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFormConfig => {
 	const ticket = useTicketItem({ id });
 
@@ -100,23 +104,19 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 					title: __('Ticket Sales'),
 					fields: [
 						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'startDate',
-									label: __('Start Date'),
-									fieldType: 'datetimepicker',
-									required: true,
-								},
-								{
-									name: 'endDate',
-									label: __('End Date'),
-									fieldType: 'datetimepicker',
-									required: true,
-									wrapper: EndDateFieldWrapper,
-								},
-							],
+							name: 'startDate',
+							label: __('Start Date'),
+							fieldType: 'datetimepicker',
+							required: true,
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'endDate',
+							label: __('End Date'),
+							fieldType: 'datetimepicker',
+							required: true,
+							wrapper: EndDateFieldWrapper,
+							formControlProps: adjacentFormItemProps,
 						},
 					],
 				},
@@ -126,75 +126,83 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 					title: __('Details'),
 					fields: [
 						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'quantity',
-									label: __('Quantity For Sale'),
-									fieldType: 'number',
-									parseAsInfinity: true,
-									max: 1000000,
-									min: -1,
-									info:
-										__('The maximum number of this ticket available for sale.') +
-										'\n' +
-										__('Set to 0 to stop sales, or leave blank for no limit.'),
-									width: 'small',
-								},
-								{
-									name: 'uses',
-									label: __('Number of Uses'),
-									fieldType: 'number',
-									parseAsInfinity: true,
-									max: 1000,
-									min: 0,
-									info:
-										__(
-											'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
-										) +
-										'\n' +
-										__(
-											'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
-										),
-									width: 'small',
-								},
-							],
+							name: 'quantity',
+							label: __('Quantity For Sale'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							max: 1000000,
+							min: -1,
+							info:
+								__('The maximum number of this ticket available for sale.') +
+								'\n' +
+								__('Set to 0 to stop sales, or leave blank for no limit.'),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
 						},
 						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'min',
-									label: __('Minimum Quantity'),
-									fieldType: 'number',
-									max: 1000000,
-									min: 0,
-									info:
-										__(
-											'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-										) +
-										'\n' +
-										__('Leave blank for no minimum.'),
-									width: 'small',
-								},
-								{
-									name: 'max',
-									label: __('Maximum Quantity'),
-									fieldType: 'number',
-									parseAsInfinity: true,
-									max: 1000000,
-									min: -1,
-									info:
-										__(
-											'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-										) +
-										'\n' +
-										__('Leave blank for no maximum.'),
-									width: 'small',
-								},
-							],
+							name: 'uses',
+							label: __('Number of Uses'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							max: 1000,
+							min: 0,
+							info:
+								__(
+									'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
+								) +
+								'\n' +
+								__(
+									'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
+								),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'min',
+							label: __('Minimum Quantity'),
+							fieldType: 'number',
+							max: 1000000,
+							min: 0,
+							info:
+								__(
+									'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+								) +
+								'\n' +
+								__('Leave blank for no minimum.'),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'max',
+							label: __('Maximum Quantity'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							max: 1000000,
+							min: -1,
+							info:
+								__(
+									'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+								) +
+								'\n' +
+								__('Leave blank for no maximum.'),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'isRequired',
+							label: __('Required Ticket'),
+							fieldType: 'switch',
+							info: __(
+								'If enabled, the ticket must be selected and will appear first in frontend ticket lists.'
+							),
+							width: 'small',
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'isTrashed',
+							label: __('Trash'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
 						},
 						{
 							name: 'visibility',
@@ -202,26 +210,6 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 							fieldType: 'select',
 							info: __('Where the ticket can be viewed throughout the UI.'),
 							options: VISIBILITY_OPTIONS,
-						},
-						{
-							name: '',
-							fieldType: 'group',
-							subFields: [
-								{
-									name: 'isRequired',
-									label: __('Required Ticket'),
-									fieldType: 'switch',
-									info: __(
-										'If enabled, the ticket must be selected and will appear first in frontend ticket lists.'
-									),
-									width: 'small',
-								},
-								{
-									name: 'isTrashed',
-									label: __('Trash'),
-									fieldType: 'switch',
-								},
-							],
 						},
 					],
 				},

--- a/packages/adapters/src/Button/Button.tsx
+++ b/packages/adapters/src/Button/Button.tsx
@@ -10,7 +10,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 		return (
 			<ChakraButton leftIcon={leftIcon} {...props} ref={ref}>
-				{text && <span>{text}</span>}
+				{text && <span className='btn-text'>{text}</span>}
 			</ChakraButton>
 		);
 	}

--- a/packages/styles/src/root/_btn.scss
+++ b/packages/styles/src/root/_btn.scss
@@ -1,9 +1,19 @@
 $btn: (
 	button-background: var(--ee-color-grey-12),
 	button-background-rte: hsla(0, 0%, 75.3%, 0.25),
-	button-box-shadow: (
+	button-box-shadow-soft: (
 		1px 1px 1px rgba(0, 0, 0, 0.25),
-		-1px -1px 1px rgba(255, 255, 255, 0.375),
+		-1px -1px 1px rgba(255, 255, 255, 0.5),
+	),
+	button-box-shadow: (
+		1px 1px 1px rgba(0, 0, 0, 0.375),
+		-1px -1px 1px rgba(255, 255, 255, 0.75),
+	),
+	button-box-shadow-hard: (
+		1px 1px 1px rgba(0, 0, 0, 0.375),
+		2px 2px 5px rgba(0, 0, 0, 0.188),
+		-1px -1px 1px rgba(255, 255, 255, 0.75),
+		-2px -2px 5px rgba(255, 255, 255, 0.375)
 	),
 	button-text-color: var(--ee-text-on-grey-12),
 	button-transparent-background: rgba(192, 192, 192, 0.25),

--- a/packages/ui-components/src/Button/IconButton/style.scss
+++ b/packages/ui-components/src/Button/IconButton/style.scss
@@ -104,9 +104,11 @@
 
 		&--transparent-bg {
 			background-color: var(--ee-button-transparent-background);
+			box-shadow: var(--ee-button-box-shadow-soft);
 		}
 
 		&.ee-btn--tiny {
+			box-shadow: var(--ee-button-box-shadow-soft);
 			height: var(--ee-icon-button-size-tiny);
 			min-height: var(--ee-icon-button-size-tiny);
 			min-width: var(--ee-icon-button-size-tiny);
@@ -115,6 +117,7 @@
 		}
 
 		&.ee-btn--small {
+			box-shadow: var(--ee-button-box-shadow-soft);
 			height: var(--ee-icon-button-size-small);
 			min-height: var(--ee-icon-button-size-small);
 			min-width: var(--ee-icon-button-size-small);
@@ -129,6 +132,7 @@
 		}
 
 		&.ee-btn--big {
+			box-shadow: var(--ee-button-box-shadow-hard);
 			height: var(--ee-icon-button-size-big);
 			min-height: var(--ee-icon-button-size-big);
 			min-width: var(--ee-icon-button-size-big);
@@ -136,6 +140,7 @@
 		}
 
 		&.ee-btn--bigger {
+			box-shadow: var(--ee-button-box-shadow-hard);
 			height: var(--ee-icon-button-size-huge);
 			min-height: var(--ee-icon-button-size-huge);
 			min-width: var(--ee-icon-button-size-huge);

--- a/packages/ui-components/src/Button/_sizes.scss
+++ b/packages/ui-components/src/Button/_sizes.scss
@@ -5,6 +5,7 @@
 		box-sizing: border-box;
 
 		&.ee-btn--micro {
+			box-shadow: var(--ee-button-box-shadow-soft);
 			font-size: var(--ee-font-size-micro);
 			height: var(--ee-icon-button-size-micro);
 			min-height: var(--ee-icon-button-size-smaller);
@@ -27,6 +28,7 @@
 		}
 
 		&.ee-btn--tiny {
+			box-shadow: var(--ee-button-box-shadow-soft);
 			font-size: var(--ee-font-size-tiny);
 			height: var(--ee-icon-button-size-tiny);
 			min-height: var(--ee-icon-button-size-smaller);
@@ -49,6 +51,7 @@
 
 		&.ee-btn--small,
 		&.ee-btn--smaller {
+			box-shadow: var(--ee-button-box-shadow-soft);
 			line-height: var(--ee-font-size-small);
 			height: var(--ee-icon-button-size-small);
 			line-height: var(--ee-icon-button-size-tiny);
@@ -82,6 +85,7 @@
 		}
 
 		&.ee-btn--small {
+			box-shadow: var(--ee-button-box-shadow);
 			// height: var(--ee-icon-button-size-small);
 			// line-height: var(--ee-font-size-tiny);
 			// min-height: var(--ee-font-size-small);
@@ -113,6 +117,7 @@
 
 		&.ee-btn--big,
 		&.ee-btn--bigger {
+			box-shadow: var(--ee-button-box-shadow-hard);
 			font-size: var(--ee-font-size-big);
 			height: var(--ee-icon-button-size-big);
 			min-height: var(--ee-icon-button-size-bigger);
@@ -151,6 +156,7 @@
 		}
 
 		&.ee-btn--huge {
+			box-shadow: var(--ee-button-box-shadow-hard);
 			font-size: var(--ee-font-size-bigger);
 			height: var(--ee-icon-button-size-huge);
 			min-height: var(--ee-icon-button-size-huge);

--- a/packages/ui-components/src/Button/style.scss
+++ b/packages/ui-components/src/Button/style.scss
@@ -93,6 +93,11 @@
 			font-family: var(--ee-admin-font-family);
 			font-size: var(--ee-font-size-default);
 			font-weight: 600;
+			margin: 0;
+
+			&.btn-text {
+				margin: 0 var(--ee-margin-tiny);
+			}
 		}
 
 		svg {
@@ -102,7 +107,7 @@
 
 		&--has-icon,
 		&:not(.ee-noIcon) {
-			span {
+			span.btn-text {
 				margin: 0 var(--ee-margin-tiny);
 			}
 		}

--- a/packages/ui-components/src/Button/style.scss
+++ b/packages/ui-components/src/Button/style.scss
@@ -64,7 +64,6 @@
 		text-decoration: none;
 		text-align: center;
 		text-shadow: var(--ee-text-shadow-inset-light);
-		vertical-align: middle;
 		width: fit-content;
 		@include transition(all linear 50ms);
 

--- a/packages/ui-components/src/FormBuilder/FormElement/FormElement.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElement.tsx
@@ -1,10 +1,5 @@
-import { useCallback } from 'react';
 import classNames from 'classnames';
 
-import { __ } from '@eventespresso/i18n';
-import { More } from '@eventespresso/icons';
-
-import { IconButton } from '../../Button';
 import { FormElementInput } from './FormElementInput';
 import { FormElementToolbar } from './FormElementToolbar';
 import { FormElementTabs } from './Tabs';
@@ -13,26 +8,13 @@ import { useFormState } from '../state';
 import type { FormElementProps } from '../types';
 
 export const FormElement: React.FC<FormElementProps> = ({ element }) => {
-	const { isElementOpen, toggleOpenElement } = useFormState();
+	const { isElementOpen } = useFormState();
 	const active = isElementOpen(element.UUID);
 	const wrapperClass = classNames('ee-form-element__wrapper', active && 'ee-form-element__wrapper--active');
-
-	const onToggle = useCallback(() => toggleOpenElement(element.UUID), [element.UUID, toggleOpenElement]);
-
 	return (
 		<div className={wrapperClass}>
 			<div className='ee-form-element'>
 				<FormElementInput element={element} />
-				<IconButton
-					active={active}
-					borderless
-					className='ee-form-element__menu-button'
-					icon={More}
-					onClick={onToggle}
-					size='small'
-					tooltip={__('click to view form element toolbar and settings')}
-					transparentBg
-				/>
 				<FormElementToolbar element={element} />
 			</div>
 			<FormElementTabs element={element} />

--- a/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
@@ -32,7 +32,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					icon={SettingsOutlined}
 					onClick={onToggle}
 					size='small'
-					tooltip={__('click to view form element settings')}
+					tooltip={__('form element settings')}
 					transparentBg
 				/>
 				<IconButton
@@ -41,7 +41,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					size='smaller'
 					onClick={onCopy}
 					tabIndex={tabIndex}
-					tooltip={__('click to copy this form element')}
+					tooltip={__('copy form element')}
 					transparentBg
 				/>
 				<IconButton
@@ -50,7 +50,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					size='smaller'
 					// onClick={onSave}
 					tabIndex={tabIndex}
-					tooltip={__('click to save this form element for use in other forms')}
+					tooltip={__('save form element for use in other forms')}
 					transparentBg
 				/>
 				<IconButton
@@ -59,7 +59,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					size='smaller'
 					onClick={onDelete}
 					tabIndex={tabIndex}
-					tooltip={__('click to delete this form element')}
+					tooltip={__('delete form element')}
 					transparentBg
 				/>
 				<IconButton
@@ -68,7 +68,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					className='ee-drag-handle'
 					size='smaller'
 					tabIndex={tabIndex}
-					tooltip={__('click, hold, and drag to reorder this form element')}
+					tooltip={__('click, hold, and drag to reorder form element')}
 					transparentBg
 				/>
 			</div>

--- a/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
-import classNames from 'classnames';
 
 import { __ } from '@eventespresso/i18n';
-import { Copy, DragHandle, Save, Trash } from '@eventespresso/icons';
+import { Copy, DragHandle, Save, SettingsOutlined, Trash } from '@eventespresso/icons';
 
 import { IconButton } from '../../Button';
 import { ELEMENT_BLOCKS_INDEXED } from '../constants';
@@ -11,26 +10,37 @@ import { useFormState } from '../state';
 import type { FormElementProps } from '../types';
 
 export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
-	const { isElementOpen, deleteElement, copyElement } = useFormState();
+	const { copyElement, deleteElement, isElementOpen, toggleOpenElement } = useFormState();
 
 	const active = isElementOpen(element.UUID);
-
-	const menuClass = classNames('ee-form-element__menu', active && 'ee-form-element__menu--active');
-
 	const elementTypeLabel = ELEMENT_BLOCKS_INDEXED[element.type]?.label || '';
 
-	const onDelete = useCallback(() => deleteElement(element.UUID), [deleteElement, element.UUID]);
 	const onCopy = useCallback(() => copyElement(element.UUID), [copyElement, element.UUID]);
+	const onDelete = useCallback(() => deleteElement(element.UUID), [deleteElement, element.UUID]);
+	const onToggle = useCallback(() => toggleOpenElement(element.UUID), [element.UUID, toggleOpenElement]);
 
-	const tools = active && (
-		<>
+	const tabIndex = active ? 0 : -1;
+
+	return (
+		<div className='ee-form-element__toolbar'>
 			<div className='ee-form-element__type'>{elementTypeLabel}</div>
-			<div className='ee-form-element__actions'>
+			<div className='ee-form-element__toolbar-actions'>
+				<IconButton
+					active={active}
+					borderless
+					className='ee-form-element__menu-button'
+					icon={SettingsOutlined}
+					onClick={onToggle}
+					size='small'
+					tooltip={__('click to view form element settings')}
+					transparentBg
+				/>
 				<IconButton
 					icon={Copy}
 					borderless
 					size='smaller'
 					onClick={onCopy}
+					tabIndex={tabIndex}
 					tooltip={__('click to copy this form element')}
 					transparentBg
 				/>
@@ -38,7 +48,8 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					icon={Save}
 					borderless
 					size='smaller'
-					// onClick={onDelete}
+					// onClick={onSave}
+					tabIndex={tabIndex}
 					tooltip={__('click to save this form element for use in other forms')}
 					transparentBg
 				/>
@@ -47,6 +58,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					borderless
 					size='smaller'
 					onClick={onDelete}
+					tabIndex={tabIndex}
 					tooltip={__('click to delete this form element')}
 					transparentBg
 				/>
@@ -55,12 +67,11 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 					borderless
 					className='ee-drag-handle'
 					size='smaller'
+					tabIndex={tabIndex}
 					tooltip={__('click, hold, and drag to reorder this form element')}
 					transparentBg
 				/>
 			</div>
-		</>
+		</div>
 	);
-
-	return <div className={menuClass}>{tools}</div>;
 };

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSection.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSection.tsx
@@ -1,10 +1,5 @@
-import { useCallback } from 'react';
 import classNames from 'classnames';
 
-import { __ } from '@eventespresso/i18n';
-import { More } from '@eventespresso/icons';
-
-import { IconButton } from '../../Button';
 import { FormElement } from '../FormElement';
 import { FormSectionSidebar } from './FormSectionSidebar';
 import { FormSectionToolbar } from './FormSectionToolbar';
@@ -14,27 +9,15 @@ import { useFormState } from '../state';
 import type { FormSectionProps } from '../types';
 
 export const FormSection: React.FC<FormSectionProps> = ({ formSection }) => {
-	const { isElementOpen, toggleOpenElement, getElements } = useFormState();
+	const { isElementOpen, getElements } = useFormState();
 
 	const active = isElementOpen(formSection.UUID);
 	const fieldsetClass = classNames('ee-form-section', active && 'ee-form-section--active');
 
-	const onToggle = useCallback(() => toggleOpenElement(formSection.UUID), [formSection.UUID, toggleOpenElement]);
-
 	return (
 		<fieldset className={fieldsetClass}>
-			<div className={'ee-form-section__wrapper'}>
+			<div className={'ee-form-section__header'}>
 				<h4 className='ee-form-section__name'>{formSection.adminLabel || formSection.name}</h4>
-				<IconButton
-					active={active}
-					borderless
-					className='ee-form-section__menu-button'
-					icon={More}
-					onClick={onToggle}
-					size='small'
-					tooltip={__('click to view form section toolbar and settings')}
-					transparentBg
-				/>
 				<FormSectionToolbar formSection={formSection} />
 			</div>
 			<FormSectionTabs formSection={formSection} />

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSectionSidebar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSectionSidebar.tsx
@@ -91,6 +91,8 @@ export const FormSectionSidebar: React.FC<SidebarProps> = ({ className, formSect
 		sidebarOpen && 'ee-form-section__sidebar-toggle--active'
 	);
 
+	const tabIndex = sidebarOpen ? 0 : -1;
+
 	const sidebar = (
 		<div className={sidebarClass}>
 			<Heading as='h5'>{__('Add Form Element')}</Heading>
@@ -106,8 +108,15 @@ export const FormSectionSidebar: React.FC<SidebarProps> = ({ className, formSect
 					options={existingFormSections}
 					onChangeValue={onChangeSection}
 					size='small'
+					tabIndex={tabIndex}
 				/>
-				<Button buttonText={__('Add')} onClick={onAddExistingSection} buttonType='primary' size='small' />
+				<Button
+					buttonText={__('Add')}
+					onClick={onAddExistingSection}
+					buttonType='primary'
+					size='small'
+					tabIndex={tabIndex}
+				/>
 			</div>
 			<div className={sidebarItemClass}>
 				<Select
@@ -116,17 +125,25 @@ export const FormSectionSidebar: React.FC<SidebarProps> = ({ className, formSect
 					options={ELEMENT_BLOCKS_OPTIONS}
 					onChangeValue={onChangeElement}
 					size='small'
+					tabIndex={tabIndex}
 				/>
-				<Button buttonText={__('Add')} onClick={onAddElement} buttonType='primary' size='small' />
+				<Button
+					buttonText={__('Add')}
+					onClick={onAddElement}
+					buttonType='primary'
+					size='small'
+					tabIndex={tabIndex}
+				/>
 			</div>
 			<div className={sidebarItemClass}>
-				<Button buttonText={__('Cancel')} onClick={toggleSidebar} size='small' />
+				<Button buttonText={__('Cancel')} onClick={toggleSidebar} size='small' tabIndex={tabIndex} />
 			</div>
 		</div>
 	);
 
 	return (
 		<>
+			{sidebar}
 			<Button
 				buttonText={__('Add Form Element')}
 				className={toggleClass}
@@ -134,7 +151,6 @@ export const FormSectionSidebar: React.FC<SidebarProps> = ({ className, formSect
 				onClick={toggleSidebar}
 				size='small'
 			/>
-			{sidebar}
 		</>
 	);
 };

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
-import classNames from 'classnames';
 
 import { __ } from '@eventespresso/i18n';
-import { Copy, DragHandle, Save, Trash } from '@eventespresso/icons';
+import { Copy, DragHandle, Save, SettingsOutlined, Trash } from '@eventespresso/icons';
 
 import { IconButton } from '../../Button';
 import { useFormState } from '../state';
@@ -10,57 +9,66 @@ import { useFormState } from '../state';
 import type { FormSectionProps } from '../types';
 
 export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) => {
-	const { isElementOpen, deleteSection, copySection } = useFormState();
+	const { copySection, deleteSection, isElementOpen, toggleOpenElement } = useFormState();
 
 	const active = isElementOpen(formSection.UUID);
 
-	const onDelete = useCallback(() => deleteSection(formSection.UUID), [deleteSection, formSection.UUID]);
 	const onCopy = useCallback(() => copySection(formSection.UUID), [copySection, formSection.UUID]);
+	const onDelete = useCallback(() => deleteSection(formSection.UUID), [deleteSection, formSection.UUID]);
+	const onToggle = useCallback(() => toggleOpenElement(formSection.UUID), [formSection.UUID, toggleOpenElement]);
 
-	const toolbarClass = classNames(
-		'ee-form-section__toolbar',
-		'ee-form-section_toolbar__actions',
-		active && 'ee-form-section__toolbar--active'
-	);
+	const tabIndex = active ? 0 : -1;
 
 	return (
-		active && (
-			<div className={toolbarClass}>
-				<div className='ee-form-section__toolbar-item ee-form-section__toolbar-item--align-end'>
-					<IconButton
-						icon={Copy}
-						borderless
-						size='smaller'
-						onClick={onCopy}
-						tooltip={__('click to copy this form section')}
-						transparentBg
-					/>
-					<IconButton
-						icon={Save}
-						borderless
-						size='smaller'
-						// onClick={onSave}
-						tooltip={__('click to save this form section for use in other forms')}
-						transparentBg
-					/>
-					<IconButton
-						icon={Trash}
-						borderless
-						onClick={onDelete}
-						size='small'
-						tooltip={__('click to delete this form section')}
-						transparentBg
-					/>
-					<IconButton
-						icon={DragHandle}
-						borderless
-						className='ee-drag-handle'
-						size='small'
-						tooltip={__('click, hold, and drag to reorder this form section')}
-						transparentBg
-					/>
-				</div>
+		<div className={'ee-form-section__toolbar'}>
+			<div className='ee-form-section__toolbar-actions'>
+				<IconButton
+					icon={SettingsOutlined}
+					active={active}
+					borderless
+					className='ee-form-section__menu-button'
+					onClick={onToggle}
+					size='smaller'
+					tooltip={__('click to view form section settings')}
+					transparentBg
+				/>
+				<IconButton
+					icon={Copy}
+					borderless
+					onClick={onCopy}
+					size='smaller'
+					tabIndex={tabIndex}
+					tooltip={__('click to copy this form section')}
+					transparentBg
+				/>
+				<IconButton
+					icon={Save}
+					borderless
+					// onClick={onSave}
+					size='smaller'
+					tabIndex={tabIndex}
+					tooltip={__('click to save this form section for use in other forms')}
+					transparentBg
+				/>
+				<IconButton
+					icon={Trash}
+					borderless
+					onClick={onDelete}
+					size='small'
+					tabIndex={tabIndex}
+					tooltip={__('click to delete this form section')}
+					transparentBg
+				/>
+				<IconButton
+					icon={DragHandle}
+					borderless
+					className='ee-drag-handle'
+					size='small'
+					tabIndex={tabIndex}
+					tooltip={__('click, hold, and drag to reorder this form section')}
+					transparentBg
+				/>
 			</div>
-		)
+		</div>
 	);
 };

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
@@ -29,7 +29,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					className='ee-form-section__menu-button'
 					onClick={onToggle}
 					size='smaller'
-					tooltip={__('click to view form section settings')}
+					tooltip={__('form section settings')}
 					transparentBg
 				/>
 				<IconButton
@@ -38,7 +38,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					onClick={onCopy}
 					size='smaller'
 					tabIndex={tabIndex}
-					tooltip={__('click to copy this form section')}
+					tooltip={__('copy form section')}
 					transparentBg
 				/>
 				<IconButton
@@ -47,7 +47,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					// onClick={onSave}
 					size='smaller'
 					tabIndex={tabIndex}
-					tooltip={__('click to save this form section for use in other forms')}
+					tooltip={__('save form section for use in other forms')}
 					transparentBg
 				/>
 				<IconButton
@@ -56,7 +56,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					onClick={onDelete}
 					size='small'
 					tabIndex={tabIndex}
-					tooltip={__('click to delete this form section')}
+					tooltip={__('delete form section')}
 					transparentBg
 				/>
 				<IconButton
@@ -65,7 +65,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					className='ee-drag-handle'
 					size='small'
 					tabIndex={tabIndex}
-					tooltip={__('click, hold, and drag to reorder this form section')}
+					tooltip={__('click, hold, and drag to reorder form section')}
 					transparentBg
 				/>
 			</div>

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -72,7 +72,7 @@
 					flex-flow: column wrap;
 					justify-content: flex-start;
 					margin: 0;
-					padding: var(--ee-padding-tiny) 0;
+					padding: var(--ee-padding-tiny) var(--ee-padding-smaller);
 					transition: all 250ms ease-in-out;
 					width: auto;
 

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -29,15 +29,21 @@
 		.ee-form {
 			&-section {
 				border: none;
+				border-radius: var(--ee-border-radius-small);
+				box-sizing: border-box;
 				display: flex;
   				flex-direction: column;
 				margin:  0;
 				padding: var(--ee-padding-micro) var(--ee-padding-tiny);
 				position: relative;
+				width: 100%;
 
-				&__wrapper {
+				&__header {
+					align-content: center;
+					align-items: center;
 					display: flex;
 					flex-flow: row wrap;
+					justify-content: space-between;
 				}
 
 				&__name {
@@ -52,26 +58,8 @@
 					width: auto;
 				}
 
-				&__menu-button {
-					margin: var(--ee-margin-small) var(--ee-margin-tiny);
-					opacity: 0;
-				}
-
-				&--active {
-					background: var(--ee-color-grey-14);
-				}
-
-				.ee-form-section__menu-button:focus,
-				&:hover .ee-form-section__menu-button,
-				&--active .ee-form-section__menu-button,
-				.ee-form-section__sidebar-toggle:focus,
-				&:hover .ee-form-section__sidebar-toggle,
-				&--active .ee-form-section__sidebar-toggle {
-					opacity: 1 !important;
-				}
-
 				&-edit-btn.ee-btn {
-					bottom: -1.5rem;
+					bottom: var(--ee-padding-default);
 					position: absolute;
 					right: 0;
 				}
@@ -82,76 +70,50 @@
 					box-sizing: border-box;
 					display: flex;
 					flex-flow: column wrap;
-					height: 0;
 					justify-content: flex-start;
 					margin: 0;
-					opacity: 0;
 					padding: var(--ee-padding-tiny) 0;
 					transition: all 250ms ease-in-out;
 					width: auto;
 
 					@include min767px {
 						flex-flow: row wrap;
-						margin-left: var(--ee-margin-big);
-
-						[dir='rtl'] & {
-							margin-right: var(--ee-margin-big);
-						}
 					}
 
-					@include min850px {
-						margin-left: var(--ee-margin-extreme);
-
-						[dir='rtl'] & {
-							margin-right: var(--ee-margin-extreme);
-						}
-					}
-
-					margin-right: unset;
-
-					[dir='rtl'] & {
-						margin-left: unset;
-
-					}
-
-					&--active {
-						height: auto;
-						opacity: 1;
-					}
-
-					&-item {
+					.ee-input__wrapper {
 						align-items: center;
-						display: flex;
-						flex-flow: row wrap;
-						margin: 0 var(--ee-margin-tiny);
+						flex-flow: row nowrap;
+						padding: var(--ee-padding-tiny) var(--ee-padding-micro);
 
-						.ee-input__wrapper {
-							align-items: center;
-							flex-flow: row nowrap;
-							padding: var(--ee-padding-tiny) var(--ee-padding-micro);
+						label {
+							padding-right: var(--ee-padding-micro);
+						}
+					}
 
-							label {
-								padding-right: var(--ee-padding-micro);
-							}
+					button {
+						margin: var(--ee-margin-tiny) var(--ee-margin-micro);
+						opacity: 0;
+
+						&:focus {
+							opacity: 1;
 						}
 
-						button {
-							margin: var(--ee-margin-tiny) var(--ee-margin-micro);
+						&.ee-drag-handle {
+							cursor: move;
 						}
 					}
 				}
 
-				// for specific toolbars
-				&_toolbar {
-					&__actions {
-						margin-left: auto;
-						margin-right: unset;
+				&--active {
+					background: var(--ee-color-grey-14);
+				}
 
-						[dir='rtl'] & {
-							margin-left: unset;
-							margin-right: auto;
-						}
-					}
+				&:hover .ee-form-section__toolbar button,
+				&--active .ee-form-section__toolbar button,
+				.ee-form-section__sidebar-toggle:focus,
+				&:hover .ee-form-section__sidebar-toggle,
+				&--active .ee-form-section__sidebar-toggle {
+					opacity: 1 !important;
 				}
 
 				&__sidebar {
@@ -168,7 +130,6 @@
 					padding:  var(--ee-padding-small) var(--ee-padding-default);
 					position: absolute;
 					right: -480px;
-					bottom: 0;
 					transition: all 375ms ease-in-out;
 					width: auto;
 					z-index: 2;
@@ -217,7 +178,7 @@
 				display: flex;
 				flex-flow: row wrap;
 				height: fit-content;
-				justify-content: flex-start;
+				justify-content: space-between;
 				max-width: 100%;
 				width: 100%;
 
@@ -229,7 +190,7 @@
 					width: 100%;
 
 					@include min600px {
-  						width: calc(60% - var(--ee-icon-button-size-big));
+  						width: 60%;
 					}
 
 					input {
@@ -243,49 +204,28 @@
 					}
 				}
 
-				&__menu {
-					align-content: flex-end;
+				&__toolbar {
+					align-content: center;
 					align-items: center;
 					box-sizing: border-box;
 					display: flex;
 					flex-flow: row wrap;
-					height: 0;
-					justify-content: flex-end;
-					opacity: 0;
-					padding: var(--ee-padding-tiny) 0 0 ;
+					justify-content: space-between;
+					padding: var(--ee-padding-small) var(--ee-padding-micro) 0;
 					width: 100%;
 					transition: all 250ms ease-in-out;
 
 					@include min600px {
-						padding: var(--ee-padding-micro);
   						width: 40%;
 					}
 
-					&--active {
-						height: auto;
-						opacity: 1;
-					}
-
-					&-button {
+					button {
 						margin: var(--ee-margin-micro);
 						opacity: 0;
 
 						&:focus {
 							opacity: 1;
 						}
-					}
-				}
-
-				&__actions {
-					align-content: center;
-					align-items: center;
-					display: flex;
-					flex-flow: row wrap;
-					justify-content: flex-end;
-					width: calc((var(--ee-icon-button-size-small) + var(--ee-margin-size-micro) * 2) * 4);
-
-					button {
-						margin: 0 var(--ee-margin-micro);
 
 						&.ee-drag-handle {
 							cursor: move;
@@ -299,31 +239,27 @@
 					color: var(--ee-default-text-color-super-low-contrast);
 					display: flex;
 					justify-content: flex-end;
+					opacity: 0;
 					padding: 0 var(--ee-padding-tiny);
 				}
 
 				&__wrapper {
 					border-radius: 3px;
+					box-sizing: border-box;
 					color: var(--ee-default-text-color);
 					display: flex;
 					flex-flow: column wrap;
 					margin: 0 0 var(--ee-margin-tiny);
 					padding: var(--ee-padding-tiny);
 					transition: all 250ms ease-in-out;
+					width: 100%;
 
-					&:hover {
-						background: var(--ee-color-grey-14);
-
-						.ee-form-element__menu-button {
-							opacity: 1;
-						}
-					}
+					&:hover,
 					&--active {
 						background: var(--ee-color-grey-14);
 
 						.ee-form-element__type,
-						.ee-form-element__actions,
-						.ee-form-element__menu-button {
+						.ee-form-element__toolbar button {
 							opacity: 1;
 						}
 					}

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -23,6 +23,7 @@
 		display: flex;
 		flex-flow: column wrap;
 		margin: 0 0 var(--ee-margin-small);
+		overflow: hidden;
 		padding: var(--ee-padding-small);
 		width: 100%;
 

--- a/packages/ui-components/src/NumberInput/style.scss
+++ b/packages/ui-components/src/NumberInput/style.scss
@@ -43,5 +43,14 @@
 
 	.ee-number-field-stepper {
 		z-index: 0;
+
+		> div {
+			border-color: var(--ee-border-color);
+			border-inline-start-width: var(--ee-border-width);
+
+			+ div {
+				border-top-width: var(--ee-border-width);
+			}
+		}
 	}
 }

--- a/packages/ui-components/src/NumberInput/style.scss
+++ b/packages/ui-components/src/NumberInput/style.scss
@@ -2,6 +2,9 @@
 @import '~@eventespresso/styles/src/mixins/base-styles';
 
 .ee-number-input.ee-number-input {
+	min-width: 48px;
+	width: 50%;
+
 	input {
 		z-index: 0;
 
@@ -21,8 +24,20 @@
 			text-align: center;
 		}
 
+		&-2 {
+			width: 32px;
+		}
 		&-3 {
 			width: 48px;
+		}
+		&-4 {
+			width: 64px;
+		}
+		&-5 {
+			width: 80px;
+		}
+		&-6 {
+			width: 96px;
 		}
 	}
 

--- a/packages/ui-components/src/Tabs/style.scss
+++ b/packages/ui-components/src/Tabs/style.scss
@@ -59,6 +59,19 @@
 				}
 			}
 
+			&:focus,
+			&[data-focus] {
+				border-top-color: var(--ee-color-grey-8);
+				box-shadow: none;
+				color: var(--ee-default-text-color-super-high-contrast);
+
+				svg.ee-svg.ee-svg {
+					path {
+						color: var(--ee-default-text-color);
+					}
+				}
+			}
+
 			&[data-selected],
 			&[aria-selected="true"] {
 				background: var(--ee-background-color);
@@ -75,11 +88,18 @@
 						fill: var(--ee-background-color);
 					}
 				}
-			}
 
-			&:focus,
-			&[data-focus] {
-				box-shadow: none;
+				&:focus,
+				&[data-focus] {
+					border-top-color: var(--ee-color-primary-low-contrast);
+					color: var(--ee-default-text-color-high-contrast);
+
+					svg.ee-svg.ee-svg {
+						path {
+							color: var(--ee-default-text-color);
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
I didn't like how the user would need to click multiple times to do things, but I also wanted to keep the UI looking as clean as possible as well as looking as close to the finished form as possible, ie: did not want buttons scattered all over the place.

So this PR:

- moves the button for toggling the settings into the form section and form element toolbars
- hides the toolbars initially but displays them on hover or when a section/element is active
- displays settings buttons on focus but hides others via a negative tabindex (reset when element is active)

the final result looks something like this:

### initial form appearance with no visible controls
![ScreenShot_20210527130619](https://user-images.githubusercontent.com/1751030/119891146-87373180-beed-11eb-87b1-5b61cc1951bb.png)

### upon hovering over a form section
![ScreenShot_20210527130728](https://user-images.githubusercontent.com/1751030/119891225-96b67a80-beed-11eb-9428-4af242d4d2fe.png)

### upon hovering over a form element
![ScreenShot_20210527130815](https://user-images.githubusercontent.com/1751030/119891292-a6ce5a00-beed-11eb-9e72-1e0d17d71c5a.png)
