### PR TITLE
Replace UUIDv4s with CUIDs

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/data/useDataStateReducer.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/data/useDataStateReducer.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { assocPath, omit, path } from 'ramda';
+
+import { uuid } from '@eventespresso/utils';
 
 import { DataStateReducer, StateInitializer, DataState, DefaultTicket } from './types';
 
@@ -20,7 +21,7 @@ const useDataStateReducer = (initializer: StateInitializer): DataStateReducer =>
 				case 'ADD_TICKET':
 				case 'UPDATE_TICKET':
 					// use id to update and uuid to add new
-					ticketId = id || uuidv4();
+					ticketId = id || uuid();
 					existingTicket = path(['tickets', ticketId], state);
 					// we need to make the id inside ticket and in tickets object same
 					newState = assocPath(

--- a/domains/rem/src/data/useFormStateReducer.ts
+++ b/domains/rem/src/data/useFormStateReducer.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { assocPath, omit, without } from 'ramda';
+
+import { uuid } from '@eventespresso/utils';
 
 import { FormStateReducer, StateInitializer, FormState } from './types';
 
@@ -63,7 +64,7 @@ const useFormStateReducer = (initializer: StateInitializer): FormStateReducer =>
 				case 'ADD_TICKET':
 				case 'UPDATE_TICKET':
 					// use id to update and uuid to add new
-					ticketId = id || uuidv4();
+					ticketId = id || uuid();
 					// we need to make the id inside ticket and in tickets object same
 					newState = assocPath(['tickets', ticketId], { ...ticket, id: ticketId }, state);
 					break;

--- a/eslint/levels.js
+++ b/eslint/levels.js
@@ -1,6 +1,6 @@
 module.exports = [
-	/* LEVEL 1 */ ['constants', 'i18n', 'events', 'ioc', 'toaster'],
-	/* LEVEL 2 */ ['data', 'dates', 'hooks', 'icons', 'plugins', 'slot-fill', 'registry', 'styles', 'storage', 'utils'],
+	/* LEVEL 1 */ ['constants', 'i18n', 'events', 'ioc', 'toaster', 'utils'],
+	/* LEVEL 2 */ ['data', 'dates', 'hooks', 'icons', 'plugins', 'slot-fill', 'registry', 'styles', 'storage'],
 	/* LEVEL 3 */ ['adapters'],
 	/* LEVEL 4 */ ['ui-components'],
 	/* LEVEL 5 */ ['rich-text-editor'],

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
 		"classnames": "^2.3.1",
 		"ramda": "^0.27.1",
 		"react": "^17.0.2",
-		"react-dom": "^17.0.2",
-		"uuid": "^8.3.2"
+		"react-dom": "^17.0.2"
 	},
 	"devDependencies": {
 		"@babel/core": "7.13.15",
@@ -110,7 +109,6 @@
 		"@types/ramda": "^0.27.40",
 		"@types/react": "^17.0.3",
 		"@types/react-dom": "^17.0.3",
-		"@types/uuid": "^8.3.0",
 		"@typescript-eslint/eslint-plugin": "^4.22.0",
 		"@typescript-eslint/parser": "^4.22.0",
 		"@wordpress/babel-plugin-makepot": "^4.1.2",

--- a/packages/data/src/mutations/useMutationWithFeedback.ts
+++ b/packages/data/src/mutations/useMutationWithFeedback.ts
@@ -1,10 +1,11 @@
 import { useCallback, useRef } from 'react';
 import { MutationTuple, OperationVariables, useMutation } from '@apollo/client';
 import { DocumentNode } from 'graphql';
-import { v4 as uuidv4 } from 'uuid';
+
+import type { SystemNotificationsToaster } from '@eventespresso/toaster';
+import { uuid } from '@eventespresso/utils';
 
 import type { MutationType } from './types';
-import type { SystemNotificationsToaster } from '@eventespresso/toaster';
 
 interface MutationWithFeedbackArgs {
 	typeName: string; // e.g. "Datetime", "Ticket", "PriceType"
@@ -19,7 +20,7 @@ type MutationWithFeedback = <TData = any, TVariables = OperationVariables>(
 
 const useMutationWithFeedback: MutationWithFeedback = ({ typeName, mutation, mutationType, toaster }) => {
 	// generate a toaster key that sustains re-renders
-	const toasterKey = useRef(uuidv4());
+	const toasterKey = useRef(uuid());
 
 	const key = toasterKey.current;
 

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useOptimisticResponse.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { MutationType, MutationInput } from '@eventespresso/data';
 import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
-import { ucFirst } from '@eventespresso/utils';
+import { ucFirst, uuid } from '@eventespresso/utils';
 import type { Datetime } from '../../types';
 import { useLazyDatetime } from '../../queries';
 
@@ -41,7 +40,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 			};
 
 			const datetime = getDatetime(input.id);
-			const cacheId = `temp:${uuidv4()}`;
+			const cacheId = `temp:${uuid()}`;
 
 			switch (mutationType) {
 				case MutationType.Create:

--- a/packages/edtr-services/src/apollo/mutations/events/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/events/useOptimisticResponse.ts
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { MutationType, MutationInput } from '@eventespresso/data';
-import { ucFirst, removeNullAndUndefined } from '@eventespresso/utils';
+import { ucFirst, removeNullAndUndefined, uuid } from '@eventespresso/utils';
 
 import type { Event } from '../../types';
 import { useEvent } from '../../queries';
@@ -10,7 +9,7 @@ import { useEvent } from '../../queries';
 export const EVENT_DEFAULTS: Event = {
 	id: '',
 	dbId: 0,
-	cacheId: uuidv4(),
+	cacheId: uuid(),
 	allowDonations: false,
 	allowOverflow: false,
 	altRegPage: '',
@@ -56,7 +55,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 						...espressoEvent,
 						...event,
 						...filteredInput,
-						cacheId: uuidv4(),
+						cacheId: uuid(),
 					};
 					// if manager is being updated
 					if (input?.manager) {

--- a/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useOptimisticResponse.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { MutationType, MutationInput } from '@eventespresso/data';
 import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@eventespresso/constants';
-import { ucFirst } from '@eventespresso/utils';
+import { ucFirst, uuid } from '@eventespresso/utils';
 
 import type { Ticket } from '../../';
 import { useLazyTicket } from '../../queries';
@@ -51,7 +50,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 				__typename: 'EspressoTicket',
 			};
 			const ticket = getTicket(input.id);
-			const cacheId = `temp:${uuidv4()}`;
+			const cacheId = `temp:${uuid()}`;
 
 			switch (mutationType) {
 				case MutationType.Create:

--- a/packages/edtr-services/src/apollo/mutations/utils.ts
+++ b/packages/edtr-services/src/apollo/mutations/utils.ts
@@ -1,9 +1,8 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { entitiesWithGuIdInArray, entitiesWithGuIdNotInArray } from '@eventespresso/predicates';
 import type { AnyObject } from '@eventespresso/utils';
 import { shiftDate } from '@eventespresso/dates';
 import type { EntityId } from '@eventespresso/data';
+import { uuid } from '@eventespresso/utils';
 
 import { BulkUpdateInput, BulkEditFormBaseShape } from './types';
 import { Datetime, Ticket, Price } from '../types';
@@ -67,7 +66,7 @@ export const cacheNodesFromBulkInput = <T extends UpdateDatetimeInput | UpdateTi
 			...node,
 			...input.sharedInput,
 			...uniqueInputs[node.id],
-			cacheId: uuidv4(),
+			cacheId: uuid(),
 		};
 	});
 
@@ -92,7 +91,7 @@ export const cacheNodesFromBulkDelete = <E extends Datetime | Ticket | Price>(
 		return {
 			...node,
 			isTrashed: true,
-			cacheId: uuidv4(),
+			cacheId: uuid(),
 		};
 	});
 

--- a/packages/registry/src/subscription/SubscriptionManager.ts
+++ b/packages/registry/src/subscription/SubscriptionManager.ts
@@ -1,6 +1,7 @@
 import { assocPath, omit, pathOr } from 'ramda';
-import { v4 as uuidv4 } from 'uuid';
 import invariant from 'invariant';
+
+import { uuid } from '@eventespresso/utils';
 
 import type {
 	ServiceRegistry,
@@ -33,7 +34,7 @@ class SubscriptionManager<D extends string, S extends string, SR extends Service
 	public subscribe: SMI<SR>['subscribe'] = (callback, options) => {
 		invariant(typeof callback === 'function', 'subscribe `callback` must be a function');
 
-		const subscriptionId = uuidv4();
+		const subscriptionId = uuid();
 
 		this.updateSubscription({ id: subscriptionId, callback, options, action: 'add' });
 

--- a/packages/rrule-generator/src/state/useRRuleStateReducer.ts
+++ b/packages/rrule-generator/src/state/useRRuleStateReducer.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { assocPath } from 'ramda';
-import { v4 as uuidv4 } from 'uuid';
+
+import { uuid } from '@eventespresso/utils';
 
 import { RRuleStateReducer, StateInitializer } from './types';
 
@@ -26,7 +27,7 @@ const useRRuleStateReducer = (initializer: StateInitializer): RRuleStateReducer 
 
 			// dispatching 'SET_DATA' means the state didn't change as a result of user action
 			// it was set/reset, so, we won't update the hash in that case
-			const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuidv4() };
+			const state = type === 'SET_DATA' ? prevState : { ...prevState, hash: uuid() };
 
 			switch (type) {
 				case 'SET_START_DATE':

--- a/packages/rrule-generator/src/utils/misc.ts
+++ b/packages/rrule-generator/src/utils/misc.ts
@@ -1,9 +1,10 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { setSeconds } from 'date-fns';
 
 import { NOW } from '@eventespresso/constants';
 import { setTimeToNoon } from '@eventespresso/dates';
+import { uuid } from '@eventespresso/utils';
+
 import { RRuleStateManager as RSM, RRuleState } from '../state';
 import { DEFAULT_CONFIG } from '../context';
 
@@ -30,7 +31,7 @@ export const getDefaultRRuleState = (config = DEFAULT_CONFIG): RRuleState => {
 	// if time picker is enabled, set the seconds to 0, otherwise set the time to noon
 	const date = config?.enableTimepicker ? setSeconds(NOW, 0) : setTimeToNoon(NOW);
 	return {
-		hash: uuidv4(),
+		hash: uuid(),
 		start: {
 			date,
 		},

--- a/packages/tpc/src/buttons/AddPriceModifierButtonData.tsx
+++ b/packages/tpc/src/buttons/AddPriceModifierButtonData.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 
-import { v4 as uuidv4 } from 'uuid';
+import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
+import { uuid } from '@eventespresso/utils';
 
 import AddPriceModifierButton from './AddPriceModifierButton';
-import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
 import type { PriceModifierProps, TpcPriceModifier } from '../types';
 import { usePriceModifier } from '../hooks';
 import defaultPrice from '../defaultPriceModifier';
@@ -18,7 +18,7 @@ const AddPriceModifierButtonData: React.FC<Partial<PriceModifierProps>> = ({ ind
 	const addPriceModifier = useCallback(() => {
 		const newPrice: TpcPriceModifier = {
 			...defaultPriceModifier,
-			id: uuidv4(),
+			id: uuid(),
 			isBasePrice: baseType.isBasePrice,
 			isDiscount: baseType.isDiscount,
 			isPercent: baseType.isPercent,

--- a/packages/tpc/src/data/test/data.addPrice.test.ts
+++ b/packages/tpc/src/data/test/data.addPrice.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { v4 as uuidv4 } from 'uuid';
 import { last } from 'ramda';
 
-import { useDataState } from '../';
 import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
+import { uuid } from '@eventespresso/utils';
+
+import { useDataState } from '../';
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
@@ -33,7 +34,7 @@ describe('TPC:data.addPrice', () => {
 		// const { baseType, dataState, defaultPriceModifier } = result.current;
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,
@@ -76,7 +77,7 @@ describe('TPC:data.addPrice', () => {
 		act(() => result.current.dataState.reset());
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,

--- a/packages/tpc/src/data/test/data.calculations.test.ts
+++ b/packages/tpc/src/data/test/data.calculations.test.ts
@@ -1,13 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { v4 as uuidv4 } from 'uuid';
 import { last } from 'ramda';
 
-import { useDataState } from '../';
 import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
+import { getBasePrice } from '@eventespresso/predicates';
+import { uuid } from '@eventespresso/utils';
+
+import { useDataState } from '../';
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
-import { getBasePrice } from '@eventespresso/predicates';
 import { calculateBasePrice, calculateTicketTotal } from '../../utils';
 import { actWait } from '@eventespresso/utils/src/test';
 
@@ -33,7 +34,7 @@ describe('TPC:data.calculations', () => {
 		act(() => result.current.dataState.reset());
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,
@@ -94,7 +95,7 @@ describe('TPC:data.calculations', () => {
 		act(() => result.current.dataState.reset());
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,

--- a/packages/tpc/src/data/test/data.deletePrice.test.ts
+++ b/packages/tpc/src/data/test/data.deletePrice.test.ts
@@ -1,8 +1,9 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { v4 as uuidv4 } from 'uuid';
 import { last } from 'ramda';
 
 import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
+import { uuid } from '@eventespresso/utils';
+
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import { useDataState } from '../';
@@ -59,7 +60,7 @@ describe('TPC:data.deletePrice', () => {
 		act(() => result.current.dataState.reset());
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,

--- a/packages/tpc/src/data/test/data.updatePrice.test.ts
+++ b/packages/tpc/src/data/test/data.updatePrice.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { v4 as uuidv4 } from 'uuid';
 import { last, head } from 'ramda';
 
 import { useDataState } from '../';
 import { usePriceTypeForPrice } from '@eventespresso/edtr-services';
+import { uuid } from '@eventespresso/utils';
+
 import { usePriceModifier } from '../../hooks';
 import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
@@ -30,7 +31,7 @@ describe('TPC:data.updatePrice', () => {
 		act(() => result.current.dataState.reset());
 
 		// generate an id for the price
-		const newPriceId = uuidv4();
+		const newPriceId = uuid();
 
 		const newPrice = {
 			...result.current.defaultPriceModifier,

--- a/packages/tpc/src/hooks/usePrepTemplatePrices.ts
+++ b/packages/tpc/src/hooks/usePrepTemplatePrices.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { isBasePrice, sortByPriceOrderIdAsc, isDefaultTax } from '@eventespresso/predicates';
 import { Price } from '@eventespresso/edtr-services';
+import { uuid } from '@eventespresso/utils';
 
 import { TpcPriceModifier } from '../types';
 import usePriceToTpcModifier from './usePriceToTpcModifier';
@@ -37,7 +37,7 @@ const usePrepTemplatePrices = (): PrepTemplatePrices => {
 				return {
 					// clone it
 					...priceModifier,
-					id: uuidv4(),
+					id: uuid(),
 					dbId: 0,
 					isNew: true,
 					// avoid default price getting duplicated

--- a/packages/tpc/src/utils/test/utils.ts
+++ b/packages/tpc/src/utils/test/utils.ts
@@ -1,5 +1,6 @@
 import { compose, applyTo, ifElse, map } from 'ramda';
-import { v4 as uuid } from 'uuid';
+
+import { uuid } from '@eventespresso/utils';
 
 import { TpcPriceModifier } from '../../types';
 import defaultPrice from '../../defaultPriceModifier';

--- a/packages/ui-components/src/EspressoTable/ResponsiveTable.tsx
+++ b/packages/ui-components/src/EspressoTable/ResponsiveTable.tsx
@@ -1,10 +1,9 @@
 import { useRef } from 'react';
 
 import classNames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 
 import { useMemoStringify } from '@eventespresso/hooks';
-import { isEmpty } from '@eventespresso/utils';
+import { isEmpty, uuid } from '@eventespresso/utils';
 import Table from './Table';
 import TableHeader from './TableHeader';
 import TableBody from './TableBody';
@@ -29,7 +28,7 @@ export const ResponsiveTable: React.FC<ResponsiveTableProps> = ({
 }) => {
 	const primaryHeader = headerRows.find((row) => row.primary === true);
 	// avoid the ID getting changed on every render
-	const defaultId = useRef(uuidv4()).current;
+	const defaultId = useRef(uuid()).current;
 	const instanceId = props.instanceId || defaultId;
 	const isScrollable = !!metaData?.isScrollable;
 	const hasRowHeaders = !!metaData?.hasRowHeaders;

--- a/packages/ui-components/src/FormBuilder/state/useFormStateReducer.ts
+++ b/packages/ui-components/src/FormBuilder/state/useFormStateReducer.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { omit, over, lensPath, mergeLeft, set, compose } from 'ramda';
+
+import { uuid } from '@eventespresso/utils';
 
 import { FormStateReducer, StateInitializer, FormState } from './types';
 import { DEFAULT_SECTION, DEFAULT_ELEMENT } from '../constants';
@@ -17,7 +18,7 @@ export const useFormStateReducer = (initializer: StateInitializer): FormStateRed
 		(state, action) => {
 			const { UUID, afterUuid, section, element, type, openElement } = action;
 			// Generate a fresh UUID for new/copied elements/sections
-			const newUuid = uuidv4();
+			const newUuid = uuid();
 
 			// List of predicates that will be applied/composed to the state to produce the new state
 			// Each case below provides that list of predicates

--- a/packages/ui-components/src/FormBuilder/state/utils.ts
+++ b/packages/ui-components/src/FormBuilder/state/utils.ts
@@ -1,5 +1,6 @@
 import { findIndex, propEq, insert, prop, indexBy } from 'ramda';
-import { v4 as uuidv4 } from 'uuid';
+
+import { uuid } from '@eventespresso/utils';
 
 import { FormState } from './types';
 import { sortByOrder, setOrderByIndex } from '../utils';
@@ -61,7 +62,7 @@ export const copySectionElements = (copyFromSectionId: string, newSectionId: str
 	// Lets get all the elements that belong to the copied section
 	sectionElements = Object.values(state.elements).filter(propEq('belongsTo', copyFromSectionId));
 	// Change the UUID and belongsTo for all the elements
-	sectionElements = sectionElements.map((elem) => ({ ...elem, UUID: uuidv4(), belongsTo: newSectionId }));
+	sectionElements = sectionElements.map((elem) => ({ ...elem, UUID: uuid(), belongsTo: newSectionId }));
 
 	return {
 		...state,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,6 +13,9 @@
 		"update-deps": "npx ncu -p yarn -u",
 		"lint-fix": "eslint ./src/**/*.{ts,tsx} --fix"
 	},
+	"dependencies": {
+		"cuid": "^2.1.8"
+	},
 	"sideEffects": false,
 	"license": "GPL-3.0",
 	"gitHead": "66fae0230a22c100153cb05f5a624305efc5a8d9"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,3 +17,5 @@ export * from './text';
 export * from './types';
 
 export { cancelClickEvent } from './cancelClickEvent';
+
+export { default as uuid } from 'cuid';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5080,11 +5080,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/wait-on@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@types/wait-on/-/wait-on-5.2.0.tgz#f9096b7bd0c9c03052d6d402ae5cd51714480b2d"
@@ -8990,6 +8985,11 @@ csstype@^3.0.2, csstype@^3.0.3, csstype@^3.0.6:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
   integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
+
+cuid@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
+  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This PR:
- Replaces `uuid` package with `cuid` package
- Exposes `cuid` as `uuid` via `utils` package
- replaces all usages of `uuid` `v4` by the exposed `uuid` util
- Closes #890 