### PR TITLE
Update Save Section UI Styles

### DIFF
--- a/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
@@ -28,7 +28,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 				<IconButton
 					active={active}
 					borderless
-					className='ee-form-element__menu-button'
+					className='ee-form-element__menu-button ee-form-element__toolbar-button'
 					icon={SettingsOutlined}
 					onClick={onToggle}
 					size='small'
@@ -38,6 +38,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 				<IconButton
 					icon={Copy}
 					borderless
+					className='ee-form-element__toolbar-button'
 					size='smaller'
 					onClick={onCopy}
 					tabIndex={tabIndex}
@@ -47,6 +48,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 				<IconButton
 					icon={Trash}
 					borderless
+					className='ee-form-element__toolbar-button'
 					size='smaller'
 					onClick={onDelete}
 					tabIndex={tabIndex}
@@ -56,7 +58,7 @@ export const FormElementToolbar: React.FC<FormElementProps> = ({ element }) => {
 				<IconButton
 					icon={DragHandle}
 					borderless
-					className='ee-drag-handle'
+					className='ee-drag-handle ee-form-element__toolbar-button'
 					size='smaller'
 					tabIndex={tabIndex}
 					tooltip={__('click, hold, and drag to reorder form element')}

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
@@ -27,7 +27,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 					icon={SettingsOutlined}
 					active={active}
 					borderless
-					className='ee-form-section__menu-button'
+					className='ee-form-section__menu-button ee-form-section__toolbar-button'
 					onClick={onToggle}
 					size='smaller'
 					tooltip={__('form section settings')}
@@ -36,6 +36,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 				<IconButton
 					icon={Copy}
 					borderless
+					className='ee-form-section__toolbar-button'
 					onClick={onCopy}
 					size='smaller'
 					tabIndex={tabIndex}
@@ -46,6 +47,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 				<IconButton
 					icon={Trash}
 					borderless
+					className='ee-form-section__toolbar-button'
 					onClick={onDelete}
 					size='small'
 					tabIndex={tabIndex}
@@ -55,7 +57,7 @@ export const FormSectionToolbar: React.FC<FormSectionProps> = ({ formSection }) 
 				<IconButton
 					icon={DragHandle}
 					borderless
-					className='ee-drag-handle'
+					className='ee-drag-handle ee-form-section__toolbar-button'
 					size='small'
 					tabIndex={tabIndex}
 					tooltip={__('click, hold, and drag to reorder form section')}

--- a/packages/ui-components/src/FormBuilder/FormSection/SaveSection.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/SaveSection.tsx
@@ -52,20 +52,16 @@ export const SaveSection: React.FC<FormSectionProps> = ({ formSection }) => {
 				<Radio value='default' aria-describedby={`${id}-default-desc`}>
 					{__('default')}
 				</Radio>
+				<p id={`${id}-default-desc`}>
+					{__(' a copy of this form section will be automatically added to ALL new events')}
+				</p>
 				<Radio value='shared' aria-describedby={`${id}-shared-desc`}>
 					{__('shared')}
 				</Radio>
+				<p id={`${id}-shared-desc`}>
+					{__('a copy of this form section will be saved for use in other events but not loaded by default')}
+				</p>
 			</RadioGroup>
-			<ul>
-				<li id={`${id}-default-desc`}>
-					{__('default: a copy of this form section will be automatically added to ALL new events')}
-				</li>
-				<li id={`${id}-shared-desc`}>
-					{__(
-						'shared: a copy of this form section will be saved for use in other events but not loaded by default'
-					)}
-				</li>
-			</ul>
 		</PopoverForm>
 	);
 };

--- a/packages/ui-components/src/FormBuilder/FormSection/SaveSection.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/SaveSection.tsx
@@ -25,6 +25,7 @@ export const SaveSection: React.FC<FormSectionProps> = ({ formSection }) => {
 			<IconButton
 				{...props}
 				borderless
+				className='ee-form-section__toolbar-button'
 				icon={Save}
 				onClick={onOpen}
 				size='smaller'

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -109,19 +109,11 @@
 							position: relative;
 							right: var(--ee-margin-default);
 							top: calc(var(--ee-margin-huge) * -1);
-							width: 22rem;
+							width: 20rem;
 
 							[dir='rtl'] & {
 								left: var(--ee-margin-default);
 								right: unset;
-							}
-						}
-
-						ul {
-							margin: var(--ee-margin-tiny) 0;
-
-							li {
-								margin-bottom: var(--ee-margin-small);
 							}
 						}
 					}

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -91,7 +91,7 @@
 						}
 					}
 
-					button {
+					.ee-form-section__toolbar-button {
 						margin: var(--ee-margin-tiny) var(--ee-margin-micro);
 						opacity: 0;
 
@@ -103,17 +103,31 @@
 							cursor: move;
 						}
 					}
+
+					.ee-popover {
+						&__content[role=dialog] {
+							width: 22rem;
+						}
+
+						ul {
+							margin: var(--ee-margin-tiny) 0;
+
+							li {
+								margin-bottom: var(--ee-margin-small);
+							}
+						}
+					}
 				}
 
 				&--active {
 					background: var(--ee-color-grey-14);
 				}
 
-				&:hover .ee-form-section__toolbar button,
-				&--active .ee-form-section__toolbar button,
 				.ee-form-section__sidebar-toggle:focus,
 				&:hover .ee-form-section__sidebar-toggle,
-				&--active .ee-form-section__sidebar-toggle {
+				&--active .ee-form-section__sidebar-toggle,
+				&:hover .ee-form-section__toolbar .ee-form-section__toolbar-button,
+				&--active .ee-form-section__toolbar .ee-form-section__toolbar-button {
 					opacity: 1 !important;
 				}
 
@@ -220,7 +234,7 @@
   						width: 40%;
 					}
 
-					button {
+					.ee-form-element__toolbar-button {
 						margin: var(--ee-margin-micro);
 						opacity: 0;
 
@@ -260,7 +274,7 @@
 						background: var(--ee-color-grey-14);
 
 						.ee-form-element__type,
-						.ee-form-element__toolbar button {
+						.ee-form-element__toolbar .ee-form-element__toolbar-button {
 							opacity: 1;
 						}
 					}

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -106,7 +106,15 @@
 
 					.ee-popover {
 						&__content[role=dialog] {
+							position: relative;
+							right: var(--ee-margin-default);
+							top: calc(var(--ee-margin-huge) * -1);
 							width: 22rem;
+
+							[dir='rtl'] & {
+								left: var(--ee-margin-default);
+								right: unset;
+							}
 						}
 
 						ul {

--- a/packages/ui-components/src/Popover/PopoverForm/PopoverForm.tsx
+++ b/packages/ui-components/src/Popover/PopoverForm/PopoverForm.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import classNames from 'classnames';
 
 import { __ } from '@eventespresso/i18n';
-import { Save } from '@eventespresso/icons';
+import { SaveOutlined } from '@eventespresso/icons';
 import { Divider } from '@eventespresso/adapters';
 import { useDisclosure } from '@eventespresso/hooks';
 
@@ -43,7 +43,7 @@ export const PopoverForm: React.FC<PopoverFormProps> = ({
 			<Button
 				buttonText={submitLabel || __('save')}
 				buttonType={ButtonType.PRIMARY}
-				icon={Save}
+				icon={SaveOutlined}
 				isDisabled={isSubmitDisabled}
 				noMargin
 				onClick={onSave}

--- a/packages/ui-components/src/Popover/style.scss
+++ b/packages/ui-components/src/Popover/style.scss
@@ -28,7 +28,11 @@
 		}
 
 		header {
+			border-bottom-color: var(--ee-border-color);
+			border-bottom-width: var(--ee-border-width);
 			margin: 0 0 var(--ee-margin-smaller);
+			padding-inline-end: 0;
+			padding-inline-start: 0;
 		}
 
 		&:focus {
@@ -38,5 +42,16 @@
 		.chakra-popover__arrow {
 			display: none;
 		}
+
+		buton,
+		.ee-btn-base.ee-btn {
+			align-self: flex-end;
+			opacity: 1;
+		}
+	}
+
+	&-form__content {
+		display: flex;
+  		flex-direction: column;
 	}
 }

--- a/packages/ui-components/src/Popover/style.scss
+++ b/packages/ui-components/src/Popover/style.scss
@@ -28,7 +28,7 @@
 		}
 
 		header {
-			border-bottom-color: var(--ee-border-color);
+			border-bottom-color: var(--ee-button-background);
 			border-bottom-width: var(--ee-border-width);
 			margin: 0 0 var(--ee-margin-smaller);
 			padding-inline-end: 0;
@@ -53,5 +53,9 @@
 	&-form__content {
 		display: flex;
   		flex-direction: column;
+
+		  hr {
+			margin: var(--ee-margin-smaller) 0;
+		  }
 	}
 }

--- a/packages/ui-components/src/Radio/style.scss
+++ b/packages/ui-components/src/Radio/style.scss
@@ -1,12 +1,16 @@
 @import '~@eventespresso/styles/src/mixins/breakpoints';
 
-.ee-radio.ee-radio {
-	border-color: var(--ee-border-color);
-	border-radius: 50%;
-	height: var(--ee-font-size-default);
-	width: var(--ee-font-size-default);
+.ee-radio {
+	&.ee-radio {
+		border-color: var(--ee-border-color);
+		border-radius: 50%;
+		height: var(--ee-font-size-default);
+		width: var(--ee-font-size-default);
+	}
 
 	&__wrapper {
+		margin: var(--ee-margin-smaller) var(--ee-margin-tiny);
+
 		label {
 			display: flex;
 		}

--- a/packages/ui-components/src/Radio/style.scss
+++ b/packages/ui-components/src/Radio/style.scss
@@ -9,17 +9,18 @@
 	}
 
 	&__wrapper {
-		margin: var(--ee-margin-smaller) var(--ee-margin-tiny);
+		margin: var(--ee-margin-smaller) var(--ee-margin-nano);
 
 		label {
 			display: flex;
-		}
 
-		.chakra-radio__label {
-			white-space: nowrap;
+			span:not(.ee-radio) {
+				font-weight: 500;
+				white-space: nowrap;
 
-			[dir='rtl'] & {
-				margin-left: var(--ee-margin-tiny);
+				[dir='rtl'] & {
+					margin-left: var(--ee-margin-tiny);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR:

- adds a bit of whitespace to the save section popover form
- fixes button opacities

end result looks something like:

![ScreenShot_20210531145042](https://user-images.githubusercontent.com/1751030/120244762-faa7ae80-c21f-11eb-8f22-aa45f07f9b4b.png)
