### PR TITLE
Fix REM UI Issues Closes #902

### DIFF
--- a/domains/rem/src/ui/Tickets/ticketSalesEndFields.ts
+++ b/domains/rem/src/ui/Tickets/ticketSalesEndFields.ts
@@ -1,0 +1,60 @@
+import { pick } from 'ramda';
+
+import { __ } from '@eventespresso/i18n';
+import { intervalsToOptions, DATE_INTERVALS } from '@eventespresso/dates';
+
+import type { Intervals } from '@eventespresso/dates';
+import type { FieldProps } from '@eventespresso/form';
+
+const unitOptions = intervalsToOptions(
+	pick<Intervals, keyof Intervals>(['months', 'weeks', 'days', 'hours', 'minutes'], DATE_INTERVALS)
+);
+
+export const ticketSalesEndFields: Array<FieldProps> = [
+	{
+		label: __('Duration'),
+		name: 'unitValue',
+		fieldType: 'number',
+		required: true,
+		min: 0,
+	},
+	{
+		name: 'unit',
+		label: __('Unit'),
+		fieldType: 'select',
+		required: true,
+		options: unitOptions,
+	},
+	{
+		name: 'position',
+		label: __('Position'),
+		fieldType: 'select',
+		required: true,
+		options: [
+			{
+				label: __('before'),
+				value: 'before',
+			},
+			{
+				label: __('after'),
+				value: 'after',
+			},
+		],
+	},
+	{
+		name: 'startOrEnd',
+		label: __('Start/ end'),
+		fieldType: 'select',
+		required: true,
+		options: [
+			{
+				label: __('start'),
+				value: 'start',
+			},
+			{
+				label: __('end'),
+				value: 'end',
+			},
+		],
+	},
+];

--- a/domains/rem/src/ui/Tickets/ticketSalesStartFields.ts
+++ b/domains/rem/src/ui/Tickets/ticketSalesStartFields.ts
@@ -1,0 +1,60 @@
+import { pick } from 'ramda';
+
+import { __ } from '@eventespresso/i18n';
+import { intervalsToOptions, DATE_INTERVALS } from '@eventespresso/dates';
+
+import type { Intervals } from '@eventespresso/dates';
+import type { FieldProps } from '@eventespresso/form';
+
+const unitOptions = intervalsToOptions(
+	pick<Intervals, keyof Intervals>(['months', 'weeks', 'days', 'hours', 'minutes'], DATE_INTERVALS)
+);
+
+export const ticketSalesStartFields: Array<FieldProps> = [
+	{
+		label: __('Duration'),
+		name: 'unitValue',
+		fieldType: 'number',
+		required: true,
+		min: 1,
+	},
+	{
+		name: 'unit',
+		label: __('Unit'),
+		fieldType: 'select',
+		required: true,
+		options: unitOptions,
+	},
+	{
+		name: 'position',
+		label: __('Position'),
+		fieldType: 'select',
+		required: true,
+		options: [
+			{
+				label: __('before'),
+				value: 'before',
+			},
+			{
+				label: __('after'),
+				value: 'after',
+			},
+		],
+	},
+	{
+		name: 'startOrEnd',
+		label: __('Start/ end'),
+		fieldType: 'select',
+		required: true,
+		options: [
+			{
+				label: __('start'),
+				value: 'start',
+			},
+			{
+				label: __('end'),
+				value: 'end',
+			},
+		],
+	},
+];

--- a/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
+++ b/domains/rem/src/ui/Tickets/useTicketFormConfig.ts
@@ -1,74 +1,21 @@
 import { useMemo } from 'react';
-import { pick } from 'ramda';
 
 import { __ } from '@eventespresso/i18n';
-import { intervalsToOptions, DATE_INTERVALS } from '@eventespresso/dates';
 import { getEEDomData, useTimeZoneTime } from '@eventespresso/services';
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { Ticket } from '@eventespresso/edtr-services';
 
+import { ticketSalesEndFields } from './ticketSalesEndFields';
+import { ticketSalesStartFields } from './ticketSalesStartFields';
 import { validate } from './formValidation';
 
-import type { EspressoFormProps, FieldProps } from '@eventespresso/form';
-import type { Intervals } from '@eventespresso/dates';
+import type { EspressoFormProps } from '@eventespresso/form';
 import type { RemTicket } from '../../data';
 import { normalizeTicketForRem } from '../../utils';
 
 type TicketFormConfig = EspressoFormProps<RemTicket>;
 
-const unitOptions = intervalsToOptions(
-	pick<Intervals, keyof Intervals>(['months', 'weeks', 'days', 'hours', 'minutes'], DATE_INTERVALS)
-);
-
-const ticketSalesFields: Array<FieldProps> = [
-	{
-		label: __('Duration'),
-		name: 'unitValue',
-		fieldType: 'number',
-		required: true,
-		min: 1,
-	},
-	{
-		name: 'unit',
-		label: __('Unit'),
-		fieldType: 'select',
-		required: true,
-		options: unitOptions,
-	},
-	{
-		name: 'position',
-		label: __('Position'),
-		fieldType: 'select',
-		required: true,
-		options: [
-			{
-				label: __('before'),
-				value: 'before',
-			},
-			{
-				label: __('after'),
-				value: 'after',
-			},
-		],
-	},
-	{
-		name: 'startOrEnd',
-		label: __('Start/ end'),
-		fieldType: 'select',
-		required: true,
-		options: [
-			{
-				label: __('start'),
-				value: 'start',
-			},
-			{
-				label: __('end'),
-				value: 'end',
-			},
-		],
-	},
-];
 const VISIBILITY_OPTIONS = getEEDomData('eventEditor').ticketMeta.visibilityOptions;
 
 const useTicketFormConfig = (ticket?: RemTicket | Ticket, config?: Partial<TicketFormConfig>): TicketFormConfig => {
@@ -131,7 +78,7 @@ const useTicketFormConfig = (ticket?: RemTicket | Ticket, config?: Partial<Ticke
 							label: '',
 							fieldType: 'group',
 							conditions: [{ field: 'isShared', compare: '=', value: false }],
-							subFields: ticketSalesFields,
+							subFields: ticketSalesStartFields,
 						},
 					],
 				},
@@ -152,7 +99,7 @@ const useTicketFormConfig = (ticket?: RemTicket | Ticket, config?: Partial<Ticke
 							label: '',
 							fieldType: 'group',
 							conditions: [{ field: 'isShared', compare: '=', value: false }],
-							subFields: ticketSalesFields,
+							subFields: ticketSalesEndFields,
 						},
 					],
 				},

--- a/domains/rem/src/utils/misc.ts
+++ b/domains/rem/src/utils/misc.ts
@@ -98,7 +98,7 @@ export const normalizeTicketForRem = (
 			position: 'before',
 			startOrEnd: 'start',
 			unit: 'days',
-			unitValue: 1,
+			unitValue: 0,
 		},
 		ticketSalesDates: {
 			startDate,

--- a/packages/rrule-generator/src/components/RRuleGenerator/styles.scss
+++ b/packages/rrule-generator/src/components/RRuleGenerator/styles.scss
@@ -18,7 +18,6 @@
 		min-height: var(--ee-icon-button-size);
 		outline: none;
 		padding: 0.5rem 1rem;
-		white-space: pre;
 
 		&-label {
 			color: white;


### PR DESCRIPTION
this PR:

- fixes word wrapping in the rRule text banner as described in #902 
- allows ticket sales end fields in REM editor to accept 0 and sets default value to that. This better aligns the default value for that field with the typical user use case, as described in #901 