### PR TITLE
Add Confirm Popover to Form Builder Delete Buttons

### DIFF
--- a/packages/ui-components/src/Confirm/types.ts
+++ b/packages/ui-components/src/Confirm/types.ts
@@ -10,5 +10,6 @@ export interface ConfirmProps {
 }
 
 export interface ConfirmPropsWithButton extends ConfirmProps {
+	asIconButton?: boolean;
 	buttonProps: ButtonProps;
 }

--- a/packages/ui-components/src/Confirm/useConfirmWithButton.tsx
+++ b/packages/ui-components/src/Confirm/useConfirmWithButton.tsx
@@ -1,19 +1,21 @@
 import classNames from 'classnames';
 import { __ } from '@eventespresso/i18n';
 
-import { Button } from '../';
+import { Button, IconButton } from '../Button';
 import { iconBtnClassName } from '../Button/IconButton';
 import useConfirmationDialog from './useConfirmationDialog';
 import type { ConfirmPropsWithButton } from './types';
 
-const useConfirmWithButton: React.FC<ConfirmPropsWithButton> = ({ buttonProps, ...props }) => {
+const useConfirmWithButton: React.FC<ConfirmPropsWithButton> = ({ buttonProps, asIconButton, ...props }) => {
 	const title = props.title || __('Please confirm this action.');
 	const { confirmationDialog, onOpen } = useConfirmationDialog({ ...props, title });
-	const btnClassName = classNames(buttonProps.icon && iconBtnClassName, buttonProps.className);
+	const btnClassName = classNames(!asIconButton && buttonProps.icon && iconBtnClassName, buttonProps.className);
+
+	const Component = asIconButton ? IconButton : Button;
 
 	return (
 		<>
-			<Button {...buttonProps} className={btnClassName} onClick={onOpen} />
+			<Component {...buttonProps} className={btnClassName} onClick={onOpen} />
 			{confirmationDialog}
 		</>
 	);

--- a/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElementToolbar.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { Copy, DragHandle, SettingsOutlined, Trash } from '@eventespresso/icons';
 
-import { IconButton } from '../../Button';
+import { IconButton, ButtonProps } from '../../Button';
+import { ConfirmDelete } from '../../Confirm';
 import { ELEMENT_BLOCKS_INDEXED } from '../constants';
 import { useFormState } from '../state';
 
@@ -20,6 +21,19 @@ export const FormElementToolbar: React.FC<FormElementToolbarProps> = ({ element,
 	const onToggle = useCallback(() => toggleOpenElement({ openElement: UUID }), [UUID, toggleOpenElement]);
 
 	const tabIndex = active ? 0 : -1;
+
+	const deleteButtonProps = useMemo<ButtonProps>(
+		() => ({
+			icon: Trash,
+			borderless: true,
+			className: 'ee-form-element__toolbar-button',
+			size: 'smaller',
+			tabIndex,
+			tooltip: __('delete form element'),
+			transparentBg: true,
+		}),
+		[tabIndex]
+	);
 
 	return (
 		<div className='ee-form-element__toolbar'>
@@ -45,16 +59,7 @@ export const FormElementToolbar: React.FC<FormElementToolbarProps> = ({ element,
 					tooltip={__('copy form element')}
 					transparentBg
 				/>
-				<IconButton
-					icon={Trash}
-					borderless
-					className='ee-form-element__toolbar-button'
-					size='smaller'
-					onClick={onDelete}
-					tabIndex={tabIndex}
-					tooltip={__('delete form element')}
-					transparentBg
-				/>
+				<ConfirmDelete asIconButton onConfirm={onDelete} buttonProps={deleteButtonProps} />
 				<IconButton
 					icon={DragHandle}
 					borderless

--- a/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/FormSectionToolbar.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { Copy, DragHandle, SettingsOutlined, Trash } from '@eventespresso/icons';
 
-import { IconButton } from '../../Button';
+import { IconButton, ButtonProps } from '../../Button';
+import { ConfirmDelete } from '../../Confirm';
 import { useFormState } from '../state';
 import { SaveSection } from './SaveSection';
 
@@ -20,6 +21,19 @@ export const FormSectionToolbar: React.FC<FormSectionToolbarProps> = ({ formSect
 	const onToggle = useCallback(() => toggleOpenElement({ openElement: UUID }), [UUID, toggleOpenElement]);
 
 	const tabIndex = active ? 0 : -1;
+
+	const deleteButtonProps = useMemo<ButtonProps>(
+		() => ({
+			icon: Trash,
+			borderless: true,
+			className: 'ee-form-section__toolbar-button',
+			size: 'small',
+			tabIndex,
+			tooltip: __('delete form section'),
+			transparentBg: true,
+		}),
+		[tabIndex]
+	);
 
 	return (
 		<div className={'ee-form-section__toolbar'}>
@@ -45,16 +59,7 @@ export const FormSectionToolbar: React.FC<FormSectionToolbarProps> = ({ formSect
 					transparentBg
 				/>
 				<SaveSection formSection={formSection} />
-				<IconButton
-					icon={Trash}
-					borderless
-					className='ee-form-section__toolbar-button'
-					onClick={onDelete}
-					size='small'
-					tabIndex={tabIndex}
-					tooltip={__('delete form section')}
-					transparentBg
-				/>
+				<ConfirmDelete asIconButton onConfirm={onDelete} buttonProps={deleteButtonProps} />
 				<IconButton
 					icon={DragHandle}
 					borderless


### PR DESCRIPTION
This PR adds delete confirmation popup to form builder sections and elements.

Closes #892 