### PR TITLE
Form Builder Field options and other improvements

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/registrationForm/RegistrationForm.tsx
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/RegistrationForm.tsx
@@ -28,6 +28,18 @@ const formSections: Array<FormSection> = [
 		status: 'active',
 		wpUser: 1,
 	},
+	{
+		UUID: 'xyz123',
+		appliesTo: 'all',
+		belongsTo: 'Event-1',
+		adminLabel: 'other information',
+		name: 'other information',
+		htmlClass: '',
+		order: 3,
+		relation: 'Event',
+		status: 'active',
+		wpUser: 1,
+	},
 ];
 
 const formElements: Array<FormElement> = [
@@ -234,6 +246,76 @@ const formElements: Array<FormElement> = [
 		requiredText: '',
 		status: 'active',
 		type: 'text',
+		wpUser: 1,
+	},
+	{
+		UUID: 'xyz123-abc',
+		relation: '',
+		adminLabel: 'what can the user code?',
+		adminOnly: false,
+		belongsTo: 'xyz123',
+		helpClass: '',
+		helpText: '',
+		htmlClass: '',
+		order: 5,
+		publicLabel: 'what can you code?',
+		required: false,
+		requiredText: '',
+		status: 'active',
+		type: 'checkbox-multi',
+		options: [
+			{
+				value: 'JS',
+				label: 'JS',
+			},
+			{
+				value: 'TS',
+				label: 'TS',
+			},
+			{
+				value: 'React',
+				label: 'React',
+			},
+			{
+				value: 'PHP',
+				label: 'PHP',
+			},
+		],
+		wpUser: 1,
+	},
+	{
+		UUID: 'xyz123-def',
+		relation: '',
+		adminLabel: 'Which language does the user like the most?',
+		adminOnly: false,
+		belongsTo: 'xyz123',
+		helpClass: '',
+		helpText: '',
+		htmlClass: '',
+		order: 5,
+		publicLabel: 'Which language do you like the most?',
+		required: false,
+		requiredText: '',
+		status: 'active',
+		type: 'radio',
+		options: [
+			{
+				value: 'JS',
+				label: 'JS',
+			},
+			{
+				value: 'TS',
+				label: 'TS',
+			},
+			{
+				value: 'React',
+				label: 'React',
+			},
+			{
+				value: 'PHP',
+				label: 'PHP',
+			},
+		],
 		wpUser: 1,
 	},
 ];

--- a/packages/adapters/src/Textarea/types.ts
+++ b/packages/adapters/src/Textarea/types.ts
@@ -1,4 +1,6 @@
 import type { TextareaProps as ChakraTextareaProps } from '@chakra-ui/react';
 import { CommonInputProps } from '../types';
 
-export interface TextareaProps extends Omit<ChakraTextareaProps, 'sizes'>, CommonInputProps<HTMLTextAreaElement> {}
+export interface TextareaProps
+	extends Omit<ChakraTextareaProps, 'sizes'>,
+		CommonInputProps<HTMLTextAreaElement, string> {}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,5 +1,7 @@
 export { Clickable } from 'reakit/Clickable';
 export type { ClickableProps } from 'reakit/Clickable';
+export type { StackProps } from '@chakra-ui/react';
+export { Stack } from '@chakra-ui/react';
 
 export * from './AlertDialog';
 export * from './Banner';

--- a/packages/ui-components/src/Checkbox/MultiCheckbox.tsx
+++ b/packages/ui-components/src/Checkbox/MultiCheckbox.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 
-import { CheckboxGroup } from '@eventespresso/adapters';
+import { CheckboxGroup, Stack } from '@eventespresso/adapters';
 
 import { Checkbox } from './Checkbox';
 import { MultiCheckboxProps } from './types';
 
-export const MultiCheckbox: React.FC<MultiCheckboxProps> = ({ options = [], ...props }) => {
+export const MultiCheckbox: React.FC<MultiCheckboxProps> = ({ options = [], direction = 'row', ...props }) => {
 	const children = useMemo(() => {
 		return options.map(({ label, value, ...rest }, index) => (
 			<Checkbox {...rest} key={`${value}${index}`} value={value}>
@@ -14,5 +14,9 @@ export const MultiCheckbox: React.FC<MultiCheckboxProps> = ({ options = [], ...p
 		));
 	}, [options]);
 
-	return <CheckboxGroup {...props}>{children}</CheckboxGroup>;
+	return (
+		<CheckboxGroup {...props}>
+			<Stack direction={direction}>{children}</Stack>
+		</CheckboxGroup>
+	);
 };

--- a/packages/ui-components/src/Checkbox/types.ts
+++ b/packages/ui-components/src/Checkbox/types.ts
@@ -1,5 +1,6 @@
-import type { CheckboxGroupProps, OptionProps } from '@eventespresso/adapters';
+import type { CheckboxGroupProps, OptionProps, StackProps } from '@eventespresso/adapters';
 
 export interface MultiCheckboxProps extends CheckboxGroupProps {
 	options?: Array<Omit<OptionProps, 'options'>>;
+	direction?: StackProps['direction'];
 }

--- a/packages/ui-components/src/FormBuilder/FormElement/FormElementInput.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/FormElementInput.tsx
@@ -5,10 +5,10 @@ import type { AnyObject } from '@eventespresso/utils';
 
 import { MappedElement } from './MappedElement';
 import type { FormElementProps } from '../types';
-import { useFormState } from '../state';
+import { useUpdateElement } from './useUpdateElement';
 
 export const FormElementInput: React.FC<FormElementProps> = ({ element }) => {
-	const { updateElement } = useFormState();
+	const onChangeValue = useUpdateElement(element);
 
 	const props = useMemo(() => {
 		let inputProps: AnyObject = {
@@ -36,7 +36,7 @@ export const FormElementInput: React.FC<FormElementProps> = ({ element }) => {
 					...inputProps,
 					// Datepicker has to be controlled, so we need to pass the value and onChange
 					value: element.value,
-					onChange: (value: Date) => updateElement({ UUID: element.UUID, element: { value } }),
+					onChange: onChangeValue('value'),
 				};
 				switch (element.type) {
 					// TODO update formats from site config
@@ -67,7 +67,7 @@ export const FormElementInput: React.FC<FormElementProps> = ({ element }) => {
 				break;
 		}
 		return inputProps;
-	}, [element, updateElement]);
+	}, [element, onChangeValue]);
 
 	return (
 		<FormControl className='ee-form-element__input' isRequired={element.required}>

--- a/packages/ui-components/src/FormBuilder/FormElement/MappedElement.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/MappedElement.tsx
@@ -25,7 +25,7 @@ export const MappedElement: React.FC<MappedElementProps> = ({ type, id, label, .
 			break;
 		case 'date':
 		case 'datetime-local':
-			Component = withLabel(DatePicker);
+			Component = DatePicker;
 			break;
 		case 'email':
 		case 'email-confirmation':
@@ -33,22 +33,22 @@ export const MappedElement: React.FC<MappedElementProps> = ({ type, id, label, .
 		case 'tel':
 		case 'text':
 		case 'url':
-			Component = withLabel(TextInput);
+			Component = TextInput;
 			break;
 		case 'html':
 		case 'textarea':
 		case 'textarea-html':
-			Component = withLabel(Textarea);
+			Component = Textarea;
 			break;
 		case 'integer':
 		case 'decimal':
-			Component = withLabel(NumberInput);
+			Component = NumberInput;
 			break;
 		case 'month':
 		case 'month-select':
 		case 'week':
 		case 'year-select':
-			Component = withLabel(DatePicker);
+			Component = DatePicker;
 			break;
 		case 'radio':
 			Component = RadioGroup;
@@ -68,6 +68,8 @@ export const MappedElement: React.FC<MappedElementProps> = ({ type, id, label, .
 			Component = DefaultComponent;
 			break;
 	}
+
+	Component = withLabel(Component);
 
 	return <Component id={id} {...props} label={label} />;
 };

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/FieldOptions.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/FieldOptions.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useState } from 'react';
+
+import { __ } from '@eventespresso/i18n';
+
+import { FormElementProps } from '../../types';
+import { Textarea } from '../../../Textarea';
+import { withLabel } from '../../../withLabel';
+import { useUpdateElement } from '../useUpdateElement';
+
+const TextAreaWithLabel = withLabel(Textarea);
+
+export const FieldOptions: React.FC<FormElementProps> = ({ element }) => {
+	const [currentValue, setCurrentValue] = useState(() => {
+		// Convert options array to multiline string
+		return (element.options || []).reduce((prev, cur) => `${prev}\n${cur.value}`, '').trim();
+	});
+	const updateElement = useUpdateElement(element);
+
+	const updateValue = useCallback(() => {
+		// Split the given string by new line to create an option from each line
+		const options = currentValue
+			.trim()
+			.split(/[\n\r]/)
+			.map((value) => ({ value, label: value }));
+
+		updateElement('options')(options);
+	}, [currentValue, updateElement]);
+
+	return (
+		<>
+			<TextAreaWithLabel
+				aria-describedby={`${element.UUID}-options-desc`}
+				id={`${element.UUID}-options`}
+				label={__('options')}
+				onBlur={updateValue}
+				onChangeValue={setCurrentValue}
+				placeholder={`Apple\nBanana\nMango`}
+				value={currentValue}
+				rows={10}
+			/>
+			<p id={`${element.UUID}-options-desc`}>{__('value on each line will become an option for the input.')}</p>
+		</>
+	);
+};

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/FormElementTabs.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/FormElementTabs.tsx
@@ -4,13 +4,13 @@ import { __ } from '@eventespresso/i18n';
 import { Check, CheckList, Palette, SettingsOutlined } from '@eventespresso/icons';
 
 import { Collapsible } from '../../../Collapsible';
-import type { SettingsProps } from '../../types';
+import type { FormElementProps } from '../../types';
 import { Settings } from './Settings';
 import { Styles } from './Styles';
 import { Validation } from './Validation';
 import { useFormState } from '../../state';
 
-export const FormElementTabs: React.FC<SettingsProps> = ({ element }) => {
+export const FormElementTabs: React.FC<FormElementProps> = ({ element }) => {
 	const { isElementOpen } = useFormState();
 	return (
 		<Collapsible show={isElementOpen({ UUID: element.UUID })}>

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/Settings.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/Settings.tsx
@@ -1,23 +1,17 @@
-import { useCallback } from 'react';
-
 import { __ } from '@eventespresso/i18n';
 
 import { TextInput } from '../../../text-input';
 import { withLabel } from '../../../withLabel';
-import type { FormElement, SettingsProps } from '../../types';
-import { useFormState } from '../../state';
+import type { FormElementProps } from '../../types';
+import { FieldOptions } from './FieldOptions';
+import { FIELDS_WITH_OPTIONS } from '../../constants';
+import { useUpdateElement } from '../useUpdateElement';
 
 const TextWithLabel = withLabel(TextInput);
 
-export const Settings: React.FC<SettingsProps> = ({ element }) => {
-	const { updateElement } = useFormState();
+export const Settings: React.FC<FormElementProps> = ({ element }) => {
+	const onChangeValue = useUpdateElement(element);
 
-	const onChangeValue = useCallback(
-		(field: keyof FormElement) => (value) => {
-			updateElement({ UUID: element.UUID, element: { [field]: value } });
-		},
-		[element.UUID, updateElement]
-	);
 	return (
 		<>
 			<TextWithLabel
@@ -30,6 +24,7 @@ export const Settings: React.FC<SettingsProps> = ({ element }) => {
 				onChangeValue={onChangeValue('publicLabel')}
 				value={element.publicLabel}
 			/>
+			{FIELDS_WITH_OPTIONS.includes(element.type) && <FieldOptions element={element} />}
 			<TextWithLabel
 				label={__('placeholder')}
 				onChangeValue={onChangeValue('placeholder')}

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/Styles.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/Styles.tsx
@@ -1,28 +1,19 @@
-import { useCallback } from 'react';
-
 import { __ } from '@eventespresso/i18n';
 
 import { TextInput } from '../../../text-input';
 import { withLabel } from '../../../withLabel';
 import { Textarea } from '../../../Textarea';
-import { useFormState } from '../../state';
+import { useUpdateElement } from '../useUpdateElement';
 
-import type { FormElement, SettingsProps } from '../../types';
+import type { FormElementProps } from '../../types';
 
 const TextWithLabel = withLabel(TextInput);
 const TextAreaWithLabel = withLabel(Textarea);
 
-export const Styles: React.FC<SettingsProps> = ({ element }) => {
-	const { updateElement } = useFormState();
+export const Styles: React.FC<FormElementProps> = ({ element }) => {
+	const onChangeValue = useUpdateElement(element);
 
-	const onChangeValue = useCallback(
-		(field: keyof FormElement) => (value) => {
-			updateElement({ UUID: element.UUID, element: { [field]: value } });
-		},
-		[element.UUID, updateElement]
-	);
 	return (
-		// TODO wire up the values from data state
 		<>
 			<TextWithLabel
 				label={__('label css class')}

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/Validation.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/Validation.tsx
@@ -1,29 +1,21 @@
-import { useCallback } from 'react';
-
 import { __ } from '@eventespresso/i18n';
 
 import { TextInput } from '../../../text-input';
 import { NumberInput } from '../../../NumberInput';
 import { withLabel } from '../../../withLabel';
 import { Switch } from '../../../Switch';
-import { useFormState } from '../../state';
+import { useUpdateElement } from '../useUpdateElement';
 
-import type { SettingsProps, ElementType, FormElement } from '../../types';
+import type { FormElementProps, ElementType } from '../../types';
 
 const TextWithLabel = withLabel(TextInput);
 const NumberWithLabel = withLabel(NumberInput);
 
 const numericFields: Array<ElementType> = ['integer', 'decimal'];
 
-export const Validation: React.FC<SettingsProps> = ({ element }) => {
-	const { updateElement } = useFormState();
+export const Validation: React.FC<FormElementProps> = ({ element }) => {
+	const onChangeValue = useUpdateElement(element);
 
-	const onChangeValue = useCallback(
-		(field: keyof FormElement) => (value) => {
-			updateElement({ UUID: element.UUID, element: { [field]: value } });
-		},
-		[element.UUID, updateElement]
-	);
 	return (
 		<>
 			<Switch label={__('required')} onChangeValue={onChangeValue('required')} isChecked={element.required} />

--- a/packages/ui-components/src/FormBuilder/FormElement/useUpdateElement.ts
+++ b/packages/ui-components/src/FormBuilder/FormElement/useUpdateElement.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import type { FormElement } from '../types';
+import { useFormState } from '../state';
+
+type OnChangeValue = (field: keyof FormElement) => (value: any) => void;
+
+/**
+ * Returns an onChange handler for field inputs of an element settings
+ */
+export const useUpdateElement = (element: FormElement): OnChangeValue => {
+	const { updateElement } = useFormState();
+
+	return useCallback<OnChangeValue>(
+		(field) => (value) => {
+			updateElement({ UUID: element.UUID, element: { [field]: value } });
+		},
+		[element.UUID, updateElement]
+	);
+};

--- a/packages/ui-components/src/FormBuilder/FormSection/Tabs/FormSectionTabs.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/Tabs/FormSectionTabs.tsx
@@ -5,10 +5,10 @@ import { Tabs, TabList, TabPanels, Tab, TabPanel } from '../../../Tabs';
 import { useFormState } from '../../state';
 import { Styles } from './Styles';
 import { Collapsible } from '../../../';
-import type { SettingsProps } from '../../types';
+import type { FormSectionProps } from '../../types';
 import { Settings } from './Settings';
 
-export const FormSectionTabs: React.FC<SettingsProps> = ({ formSection }) => {
+export const FormSectionTabs: React.FC<FormSectionProps> = ({ formSection }) => {
 	const { isElementOpen } = useFormState();
 	return (
 		<Collapsible show={isElementOpen({ UUID: formSection.UUID })}>

--- a/packages/ui-components/src/FormBuilder/FormSection/Tabs/Settings.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/Tabs/Settings.tsx
@@ -1,25 +1,16 @@
-import { useCallback } from 'react';
-
 import { __ } from '@eventespresso/i18n';
 
 import { TextInput } from '../../../text-input';
 import { withLabel } from '../../../withLabel';
 import { Switch } from '../../../Switch';
+import { useUpdateSection } from '../useUpdateSection';
 
-import type { SettingsProps, FormSection } from '../../types';
-import { useFormState } from '../../state';
+import type { FormSectionProps } from '../../types';
 
 const TextWithLabel = withLabel(TextInput);
 
-export const Settings: React.FC<SettingsProps> = ({ formSection }) => {
-	const { updateSection } = useFormState();
-
-	const onChangeValue = useCallback(
-		(field: keyof FormSection) => (value) => {
-			updateSection({ UUID: formSection.UUID, section: { [field]: value } });
-		},
-		[formSection.UUID, updateSection]
-	);
+export const Settings: React.FC<FormSectionProps> = ({ formSection }) => {
+	const onChangeValue = useUpdateSection(formSection);
 
 	return (
 		<>

--- a/packages/ui-components/src/FormBuilder/FormSection/Tabs/Styles.tsx
+++ b/packages/ui-components/src/FormBuilder/FormSection/Tabs/Styles.tsx
@@ -1,26 +1,18 @@
-import { useCallback } from 'react';
-
 import { __ } from '@eventespresso/i18n';
 
 import { TextInput } from '../../../text-input';
 import { withLabel } from '../../../withLabel';
 import { Textarea } from '../../../Textarea';
+import { useUpdateSection } from '../useUpdateSection';
 
-import type { FormSection, SettingsProps } from '../../types';
-import { useFormState } from '../../state';
+import type { FormSectionProps } from '../../types';
 
 const Input = withLabel(TextInput);
 const TextAreaWithLabel = withLabel(Textarea);
 
-export const Styles: React.FC<SettingsProps> = ({ formSection }) => {
-	const { updateSection } = useFormState();
+export const Styles: React.FC<FormSectionProps> = ({ formSection }) => {
+	const onChangeValue = useUpdateSection(formSection);
 
-	const onChangeValue = useCallback(
-		(field: keyof FormSection) => (value) => {
-			updateSection({ UUID: formSection.UUID, section: { [field]: value } });
-		},
-		[formSection.UUID, updateSection]
-	);
 	return (
 		<>
 			<Input label={__('css class')} onChangeValue={onChangeValue('htmlClass')} value={formSection.htmlClass} />

--- a/packages/ui-components/src/FormBuilder/FormSection/useUpdateSection.ts
+++ b/packages/ui-components/src/FormBuilder/FormSection/useUpdateSection.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import type { FormSection } from '../types';
+import { useFormState } from '../state';
+
+type OnChangeValue = (field: keyof FormSection) => (value: any) => void;
+
+/**
+ * Returns an onChange handler for field inputs of a section settings
+ */
+export const useUpdateSection = (formSection: FormSection): OnChangeValue => {
+	const { updateSection } = useFormState();
+
+	return useCallback<OnChangeValue>(
+		(field) => (value) => {
+			updateSection({ UUID: formSection.UUID, section: { [field]: value } });
+		},
+		[formSection.UUID, updateSection]
+	);
+};

--- a/packages/ui-components/src/FormBuilder/constants.ts
+++ b/packages/ui-components/src/FormBuilder/constants.ts
@@ -3,7 +3,7 @@ import { indexBy, prop } from 'ramda';
 import { __ } from '@eventespresso/i18n';
 import type { OptionsType } from '@eventespresso/adapters';
 
-import { ElementBlock, FormSection, FormElement } from './types';
+import { ElementBlock, FormSection, FormElement, ElementType } from './types';
 
 export const SECTIONS_DROPPABLE_ID = 'form-sections';
 
@@ -22,6 +22,9 @@ export const DEFAULT_ELEMENT: FormElement = {
 	order: 1,
 	status: 'active',
 };
+
+// These are the fields that require `options` to be passed to the component
+export const FIELDS_WITH_OPTIONS: Array<ElementType> = ['checkbox-multi', 'radio', 'select'];
 
 export const ELEMENT_BLOCKS: Array<ElementBlock> = [
 	{

--- a/packages/ui-components/src/FormBuilder/types.ts
+++ b/packages/ui-components/src/FormBuilder/types.ts
@@ -111,8 +111,3 @@ export interface FormSectionProps extends CommonProps {
 export interface FormSectionToolbarProps extends FormSectionProps {
 	dragHandleProps: DraggableProvidedDragHandleProps;
 }
-
-export interface SettingsProps {
-	element?: FormElement;
-	formSection?: FormSection;
-}

--- a/packages/ui-components/src/Radio/RadioGroup.tsx
+++ b/packages/ui-components/src/Radio/RadioGroup.tsx
@@ -9,12 +9,12 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({ options = [], direction 
 	const children = useMemo(() => {
 		return options.map(({ label, value, ...rest }, index) => {
 			return (
-				<Radio {...rest} key={`${value}${index}`} value={value}>
+				<Radio id={`${props.id}-${value}`} {...rest} key={`${value}${index}`} value={value}>
 					{label}
 				</Radio>
 			);
 		});
-	}, [options]);
+	}, [options, props.id]);
 
 	return (
 		<RadioGroupAdapter {...props}>

--- a/packages/ui-components/src/Radio/RadioGroup.tsx
+++ b/packages/ui-components/src/Radio/RadioGroup.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 
-import { RadioGroup as RadioGroupAdapter } from '@eventespresso/adapters';
+import { RadioGroup as RadioGroupAdapter, Stack } from '@eventespresso/adapters';
 
 import { Radio } from './Radio';
 import { RadioGroupProps } from './types';
 
-export const RadioGroup: React.FC<RadioGroupProps> = ({ options = [], ...props }) => {
+export const RadioGroup: React.FC<RadioGroupProps> = ({ options = [], direction = 'row', ...props }) => {
 	const children = useMemo(() => {
 		return options.map(({ label, value, ...rest }, index) => {
 			return (
@@ -16,5 +16,9 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({ options = [], ...props }
 		});
 	}, [options]);
 
-	return <RadioGroupAdapter {...props}>{children}</RadioGroupAdapter>;
+	return (
+		<RadioGroupAdapter {...props}>
+			<Stack direction={direction}>{children}</Stack>
+		</RadioGroupAdapter>
+	);
 };

--- a/packages/ui-components/src/Radio/index.stories.tsx
+++ b/packages/ui-components/src/Radio/index.stories.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react';
-import { Stack } from '@chakra-ui/react';
 import type { Meta } from '@storybook/react/types-6-0';
 
-import { RadioGroup } from '@eventespresso/adapters';
+import { RadioGroup } from './RadioGroup';
 import { Radio } from './';
 
 export default {
@@ -10,16 +8,21 @@ export default {
 	title: 'Components/Radio',
 } as Meta;
 
-export const Default = () => {
-	const [value, setValue] = useState<string | number>('1');
+const options = [
+	{
+		value: '1',
+		label: 'First',
+	},
+	{
+		value: '2',
+		label: 'Second',
+	},
+	{
+		value: '3',
+		label: 'Third',
+	},
+];
 
-	return (
-		<RadioGroup onChange={setValue} value={value}>
-			<Stack direction='row'>
-				<Radio value='1'>First</Radio>
-				<Radio value='2'>Second</Radio>
-				<Radio value='3'>Third</Radio>
-			</Stack>
-		</RadioGroup>
-	);
+export const Default = () => {
+	return <RadioGroup options={options} />;
 };

--- a/packages/ui-components/src/Radio/types.ts
+++ b/packages/ui-components/src/Radio/types.ts
@@ -2,10 +2,12 @@ import type {
 	RadioProps as RadioAdapterProps,
 	RadioGroupProps as RadioGroupAdapterProps,
 	OptionProps,
+	StackProps,
 } from '@eventespresso/adapters';
 
 export interface RadioProps extends RadioAdapterProps {}
 
 export interface RadioGroupProps extends Partial<RadioGroupAdapterProps> {
 	options?: Array<Omit<OptionProps, 'options'>>;
+	direction?: StackProps['direction'];
 }


### PR DESCRIPTION
This PR adds options box to generate selectable options for `select`, `radio` and `checkbox` fields. It also add other improvements to fields and sections.

See #854 

![image](https://user-images.githubusercontent.com/18226415/120650949-dfe16e00-c49b-11eb-8ab1-23c76e50968d.png)
