### PR TITLE
Improve Multi-Option Input Styles

### DIFF
--- a/packages/ui-components/src/Checkbox/style.scss
+++ b/packages/ui-components/src/Checkbox/style.scss
@@ -1,5 +1,26 @@
-.ee-checkbox {
+.ee-checkbox.ee-checkbox {
+	margin: var(--ee-margin-smaller) var(--ee-margin-nano);
+
 	.chakra-checkbox__control {
 		border-color: var(--ee-border-color);
+
+		&[data-checked] {
+			background: var(--ee-color-primary);
+			border-color: var(--ee-color-primary);
+			color: var(--ee-text-on-primary);
+		}
+	}
+
+	span:not(.chakra-checkbox__control) {
+		white-space: nowrap;
+	}
+
+	+ .ee-checkbox {
+			margin-left: var(--ee-margin-bigger);
+			margin-inline-start: var(--ee-margin-bigger);
+
+			[dir='rtl'] & {
+				margin-right: var(--ee-margin-bigger);
+			}
 	}
 }

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/FieldOptions.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/FieldOptions.tsx
@@ -7,9 +7,7 @@ import { Textarea } from '../../../Textarea';
 import { withLabel } from '../../../withLabel';
 import { useUpdateElement } from '../useUpdateElement';
 
-const TextAreaWithLabel = withLabel(Textarea);
-
-export const FieldOptions: React.FC<FormElementProps> = ({ element }) => {
+const FieldOptions: React.FC<FormElementProps> = ({ element }) => {
 	const [currentValue, setCurrentValue] = useState(() => {
 		// Convert options array to multiline string
 		return (element.options || []).reduce((prev, cur) => `${prev}\n${cur.value}`, '').trim();
@@ -28,17 +26,21 @@ export const FieldOptions: React.FC<FormElementProps> = ({ element }) => {
 
 	return (
 		<>
-			<TextAreaWithLabel
+			<Textarea
 				aria-describedby={`${element.UUID}-options-desc`}
+				className='ee-field-options'
 				id={`${element.UUID}-options`}
-				label={__('options')}
 				onBlur={updateValue}
 				onChangeValue={setCurrentValue}
 				placeholder={`Apple\nBanana\nMango`}
 				value={currentValue}
 				rows={10}
 			/>
-			<p id={`${element.UUID}-options-desc`}>{__('value on each line will become an option for the input.')}</p>
+			<p id={`${element.UUID}-options-desc`} className='ee-field-options__desc'>
+				{__('value on each line will become an option for the input.')}
+			</p>
 		</>
 	);
 };
+
+export default withLabel(FieldOptions);

--- a/packages/ui-components/src/FormBuilder/FormElement/Tabs/Settings.tsx
+++ b/packages/ui-components/src/FormBuilder/FormElement/Tabs/Settings.tsx
@@ -3,7 +3,7 @@ import { __ } from '@eventespresso/i18n';
 import { TextInput } from '../../../text-input';
 import { withLabel } from '../../../withLabel';
 import type { FormElementProps } from '../../types';
-import { FieldOptions } from './FieldOptions';
+import FieldOptions from './FieldOptions';
 import { FIELDS_WITH_OPTIONS } from '../../constants';
 import { useUpdateElement } from '../useUpdateElement';
 
@@ -24,7 +24,7 @@ export const Settings: React.FC<FormElementProps> = ({ element }) => {
 				onChangeValue={onChangeValue('publicLabel')}
 				value={element.publicLabel}
 			/>
-			{FIELDS_WITH_OPTIONS.includes(element.type) && <FieldOptions element={element} />}
+			{FIELDS_WITH_OPTIONS.includes(element.type) && <FieldOptions element={element} label={__('options')} />}
 			<TextWithLabel
 				label={__('placeholder')}
 				onChangeValue={onChangeValue('placeholder')}

--- a/packages/ui-components/src/FormBuilder/styles.scss
+++ b/packages/ui-components/src/FormBuilder/styles.scss
@@ -307,6 +307,13 @@
 						}
 					}
 				}
+
+				.ee-field-options {
+					&__desc {
+						font-size: var(--ee-font-size-default);
+						margin: var(--ee-margin-micro) var(--ee-margin-smaller) 0;
+					}
+				}
 			}
 		}
 	}

--- a/packages/ui-components/src/Radio/style.scss
+++ b/packages/ui-components/src/Radio/style.scss
@@ -3,24 +3,38 @@
 .ee-radio {
 	&.ee-radio {
 		border-color: var(--ee-border-color);
-		border-radius: 50%;
+		border-radius: var(--ee-border-radius-full);
 		height: var(--ee-font-size-default);
 		width: var(--ee-font-size-default);
+
+		&[data-checked] {
+			background: var(--ee-color-primary);
+			border-color: var(--ee-color-primary);
+			color: var(--ee-text-on-primary);
+		}
 	}
 
-	&__wrapper {
+	&__wrapper.ee-radio__wrapper {
 		margin: var(--ee-margin-smaller) var(--ee-margin-nano);
 
 		label {
 			display: flex;
 
 			span:not(.ee-radio) {
-				font-weight: 500;
 				white-space: nowrap;
 
 				[dir='rtl'] & {
 					margin-left: var(--ee-margin-tiny);
 				}
+			}
+		}
+
+		+ .ee-radio__wrapper {
+			margin-left: var(--ee-margin-bigger);
+			margin-inline-start: var(--ee-margin-bigger);
+
+			[dir='rtl'] & {
+				margin-right: var(--ee-margin-bigger);
 			}
 		}
 	}


### PR DESCRIPTION
this PR:

- improves colors and spacing for radio button and checkbox input types
- improves font size and spacing for field option desc
- moves p tag for field option desc inside of input wrapper by changing where `withLabel` HOC is used
- adds classes to field options and field options desc

final result looks something like:

![ScreenShot_20210603130228](https://user-images.githubusercontent.com/1751030/120705131-4b134c00-c46c-11eb-8b68-5a5887a1b9bd.png)
