### PR TITLE
Form builder state improvements

### DIFF
--- a/packages/form-builder/src/state/types.ts
+++ b/packages/form-builder/src/state/types.ts
@@ -8,6 +8,8 @@ import type { FormStateProviderProps } from '../context';
 export interface FormState {
 	sections: AnyObject<FormSection>;
 	elements: AnyObject<FormElement>;
+	deletedSections: Array<string>;
+	deletedElements: Array<string>;
 	isDirty: boolean;
 	openElement?: string;
 }

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -63,6 +63,9 @@ export interface FormElement {
 	wpUser?: number;
 	// This is the current input value if needed.
 	value?: any;
+	// These are the purity flags which can be used for mutations
+	isNew?: boolean;
+	isModified?: boolean;
 }
 
 export type FormSectionStatus = 'active' | 'archived' | 'default' | 'shared' | 'trashed';
@@ -82,7 +85,15 @@ export interface FormSection {
 	showDescription?: boolean;
 	status?: FormSectionStatus;
 	wpUser?: number;
+	// These are the purity flags which can be used for mutations
+	isNew?: boolean;
+	isModified?: boolean;
 }
+
+export type FormBuilderData = {
+	sections: Array<FormSection>;
+	elements: Array<FormElement>;
+};
 
 export interface FormBuilderProps {
 	bodyClassName?: string;
@@ -90,6 +101,7 @@ export interface FormBuilderProps {
 	contentClassName?: string;
 	header?: React.ReactNode;
 	sidebarClassName?: string;
+	onSave?: (data: FormBuilderData) => void;
 }
 
 interface CommonProps {


### PR DESCRIPTION
This PR adds some improvements to form builder state to make mutations easier for the consumer components.

See #854 