### PR TITLE
Form Builder | Fix DnD keyboard a11y

### DIFF
--- a/packages/form-builder/src/FormElement/FormElement.tsx
+++ b/packages/form-builder/src/FormElement/FormElement.tsx
@@ -21,7 +21,7 @@ export const FormElement = memo<FormElementProps>(({ element, index }) => {
 			{({ draggableProps, dragHandleProps, innerRef }, { isDragging }) => {
 				const className = classNames(wrapperClass, 'ee-draggable', isDragging && 'ee-draggable--is-dragging');
 				return (
-					<div className={className} {...draggableProps} ref={innerRef}>
+					<div className={className} {...draggableProps} ref={innerRef} {...dragHandleProps}>
 						<div className='ee-form-element'>
 							<FormElementInput element={element} />
 							<FormElementToolbar element={element} dragHandleProps={dragHandleProps} />

--- a/packages/form-builder/src/FormElement/Tabs/FieldOption.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/FieldOption.tsx
@@ -32,7 +32,7 @@ export const FieldOption: React.FC<FieldOptionProps> = ({ index, label, onChange
 					isDragging && 'ee-draggable--is-dragging'
 				);
 				return (
-					<div {...draggableProps} key={`${index}`} ref={innerRef} className={className}>
+					<div {...draggableProps} {...dragHandleProps} key={`${index}`} ref={innerRef} className={className}>
 						<div className='ee-field-option'>
 							<Label id={`ee-field-option-value-${index}`} label={__('value')} hidden={hidden} />
 							<TextInput

--- a/packages/form-builder/src/styles.scss
+++ b/packages/form-builder/src/styles.scss
@@ -312,12 +312,16 @@
 					width: 100%;
 
 					&:hover,
+					&:focus,
 					&--active {
 						background: var(--ee-color-grey-14);
 
 						.ee-form-element__type,
 						.ee-form-element__toolbar .ee-form-element__toolbar-button {
 							opacity: 1;
+						}
+						&:focus {
+							border: 1px solid var(--ee-border-color);
 						}
 					}
 				}


### PR DESCRIPTION
This PR fixes the keyboard a11y for Form Builder DND

See #950 

![demo](https://user-images.githubusercontent.com/18226415/124574033-b2575e00-de67-11eb-8cbd-9ab8c9a2c206.gif)
