### PR TITLE
Form Builder | Element/input settings

### DIFF
--- a/packages/form-builder/src/FormElement/Tabs/InputType.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/InputType.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+import * as R from 'ramda';
+
+import { __ } from '@eventespresso/i18n';
+import { SelectWithLabel, useConfirmationDialog } from '@eventespresso/ui-components';
+
+import type { FormElementProps } from '../../types';
+import { ELEMENT_BLOCKS_OPTIONS } from '../../constants';
+import { useUpdateElement } from '../useUpdateElement';
+
+const options = ELEMENT_BLOCKS_OPTIONS.filter(R.complement(R.propEq('value', 'FORM_SECTION')));
+
+export const InputType: React.FC<FormElementProps> = ({ element }) => {
+	const onUpdateValue = useUpdateElement(element);
+	const [currentType, setCurrentType] = useState(element.type);
+
+	const { confirmationDialog, onOpen } = useConfirmationDialog({
+		title: __('Change input type'),
+		message: __('Some configurations might be lost. Are you sure you want to change the input type?'),
+		onConfirm: () => onUpdateValue('type')(currentType),
+		onCancel: () => setCurrentType(element.type), // restore the selected value on cancel
+	});
+
+	const onChangeValue = useCallback((type) => {
+		setCurrentType(type);
+	}, []);
+
+	useEffect(() => {
+		if (currentType && element.type !== currentType) {
+			onOpen();
+		}
+	}, [currentType, element.type, onOpen]);
+
+	return (
+		<>
+			<SelectWithLabel
+				id={`${element.id}-input-type`}
+				// pass key to ensure that the component state is reset when type is changed
+				key={element.type}
+				label={__('type')}
+				options={options}
+				value={currentType}
+				onChangeValue={onChangeValue}
+				size='small'
+			/>
+			{confirmationDialog}
+		</>
+	);
+};

--- a/packages/form-builder/src/FormElement/Tabs/Settings.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/Settings.tsx
@@ -6,6 +6,7 @@ import type { FormElementProps } from '../../types';
 import FieldOptions from './FieldOptions';
 import { FIELDS_WITH_OPTIONS } from '../../constants';
 import { useUpdateElement } from '../useUpdateElement';
+import { InputType } from './InputType';
 
 const RTEWithLabel = withLabel(SimpleTextEditor);
 
@@ -14,15 +15,20 @@ export const Settings: React.FC<FormElementProps> = ({ element }) => {
 
 	return (
 		<>
+			{
+				// HTML doesn't need a public label
+				element.type !== 'HTML' && (
+					<TextInputWithLabel
+						label={__('public label')}
+						onChangeValue={onChangeValue('label.publicLabel')}
+						value={element.label?.publicLabel}
+					/>
+				)
+			}
 			<TextInputWithLabel
 				label={__('admin label')}
 				onChangeValue={onChangeValue('label.adminLabel')}
 				value={element.label?.adminLabel}
-			/>
-			<SwitchWithLabel
-				label={__('admin only')}
-				onChangeValue={onChangeValue('adminOnly')}
-				isChecked={element.adminOnly}
 			/>
 			{element.type === 'HTML' ? (
 				<>
@@ -35,24 +41,26 @@ export const Settings: React.FC<FormElementProps> = ({ element }) => {
 				</>
 			) : (
 				<>
-					<TextInputWithLabel
-						label={__('public label')}
-						onChangeValue={onChangeValue('label.publicLabel')}
-						value={element.label?.publicLabel}
-					/>
-					{FIELDS_WITH_OPTIONS.includes(element.type) && (
+					{FIELDS_WITH_OPTIONS.includes(element.type) ? (
 						<FieldOptions element={element} label={__('options')} />
+					) : (
+						<TextInputWithLabel
+							label={__('placeholder')}
+							onChangeValue={onChangeValue('attributes.placeholder')}
+							value={element.attributes?.placeholder}
+						/>
 					)}
-					<TextInputWithLabel
-						label={__('placeholder')}
-						onChangeValue={onChangeValue('attributes.placeholder')}
-						value={element.attributes?.placeholder}
+					<SwitchWithLabel
+						label={__('admin only')}
+						onChangeValue={onChangeValue('adminOnly')}
+						isChecked={element.adminOnly}
 					/>
 					<TextInputWithLabel
 						label={__('help text')}
 						onChangeValue={onChangeValue('helpText.helpText')}
 						value={element.helpText?.helpText}
 					/>
+					<InputType element={element} />
 				</>
 			)}
 		</>


### PR DESCRIPTION
This PR enhances the settings tab for Form Builder elements:
- Add Input type change option to settings
- Reorders element settings inputs

See #950 