### PR TITLE
Form Builder | Hide rules tabs

### DIFF
--- a/packages/form-builder/src/FormElement/Tabs/FormElementTabs.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/FormElementTabs.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { Check, CheckList, Palette, SettingsOutlined } from '@eventespresso/icons';
+import { Check, Palette, SettingsOutlined } from '@eventespresso/icons';
 import { Collapsible, Tabs, TabList, TabPanels, Tab, TabPanel } from '@eventespresso/ui-components';
 import { getPropsAreEqual } from '@eventespresso/utils';
 
@@ -29,10 +29,10 @@ export const FormElementTabs = memo<FormElementProps>(({ element }) => {
 						<Check className='ee-tab-icon-validation' />
 						{__('Validation')}
 					</Tab>
-					<Tab>
+					{/* <Tab>
 						<CheckList className='ee-tab-icon-rules' />
 						{__('Rules')}
-					</Tab>
+					</Tab> */}
 				</TabList>
 				<TabPanels>
 					<TabPanel>
@@ -44,9 +44,9 @@ export const FormElementTabs = memo<FormElementProps>(({ element }) => {
 					<TabPanel>
 						<Validation element={element} />
 					</TabPanel>
-					<TabPanel>
+					{/* <TabPanel>
 						<p>dont be bad person</p>
-					</TabPanel>
+					</TabPanel> */}
 				</TabPanels>
 			</Tabs>
 		</Collapsible>

--- a/packages/form-builder/src/FormSection/Tabs/FormSectionTabs.tsx
+++ b/packages/form-builder/src/FormSection/Tabs/FormSectionTabs.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { CheckList, Palette, SettingsOutlined } from '@eventespresso/icons';
+import { Palette, SettingsOutlined } from '@eventespresso/icons';
 import { Collapsible, Tabs, TabList, TabPanels, Tab, TabPanel } from '@eventespresso/ui-components';
 import { getPropsAreEqual } from '@eventespresso/utils';
 
@@ -24,10 +24,10 @@ export const FormSectionTabs = memo<FormSectionProps>(({ formSection }) => {
 						<Palette className='ee-tab-icon-palette' />
 						{__('Styles')}
 					</Tab>
-					<Tab>
+					{/* <Tab>
 						<CheckList className='ee-tab-icon-rules' />
 						{__('Rules')}
-					</Tab>
+					</Tab> */}
 				</TabList>
 				<TabPanels>
 					<TabPanel>
@@ -36,9 +36,9 @@ export const FormSectionTabs = memo<FormSectionProps>(({ formSection }) => {
 					<TabPanel>
 						<Styles formSection={formSection} />
 					</TabPanel>
-					<TabPanel>
+					{/* <TabPanel>
 						<p>dont be bad person</p>
-					</TabPanel>
+					</TabPanel> */}
 				</TabPanels>
 			</Tabs>
 		</Collapsible>


### PR DESCRIPTION
This PR simply hides the rules tabs for sections and elements.

Closes #950 