### PR TITLE
Fix HTML Elements botched up content

### DIFF
--- a/packages/form-builder/src/FormElement/FormElementInput.tsx
+++ b/packages/form-builder/src/FormElement/FormElementInput.tsx
@@ -67,7 +67,7 @@ export const FormElementInput = memo<FormElementProps>(({ element }) => {
 				inputProps.max = element.attributes?.max;
 				break;
 			case 'HTML':
-				inputProps.value = element.attributes?.placeholder;
+				inputProps.value = element.attributes?.html;
 				inputProps.toolbarHidden = true;
 				inputProps.readonly = true;
 				inputProps.isDisabled = true;

--- a/packages/form-builder/src/FormElement/Tabs/Settings.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/Settings.tsx
@@ -34,9 +34,8 @@ export const Settings: React.FC<FormElementProps> = ({ element }) => {
 				<>
 					<RTEWithLabel
 						label={__('content')}
-						defaultValue={element.attributes?.placeholder}
-						// lets save the content to `placeholder` field because that field will be unused here
-						onChangeValue={onChangeValue('attributes.placeholder')}
+						defaultValue={element.attributes?.html}
+						onChangeValue={onChangeValue('attributes.html')}
 					/>
 				</>
 			) : (

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -64,6 +64,7 @@ export type FormAttributes = {
 	minDate?: Date;
 	pattern?: string;
 	placeholder?: string;
+	html?: string; // this is for HTML elements
 };
 
 export type FormHelpText = {


### PR DESCRIPTION
This PR fixes the broken HTML after it's saved. This PR saves the content to `attributes.html` which is handled via special sanitization server-side (see https://github.com/eventespresso/event-espresso-core/pull/3471)

Fixes #959