### PR TITLE
Form Builder | Add phone format validation

### DIFF
--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,5 +1,5 @@
 export type CommonInputEvent<T = Element> = React.ChangeEvent<T> | React.FormEvent<T>;
 
-export interface CommonInputProps<T = Element, V = React.ReactText | boolean> {
+export interface CommonInputProps<T = Element, V = React.ReactText> {
 	onChangeValue?: (value: V, event?: CommonInputEvent<T>) => void;
 }

--- a/packages/form-builder/src/FormElement/FormElementInput.tsx
+++ b/packages/form-builder/src/FormElement/FormElementInput.tsx
@@ -64,7 +64,7 @@ export const FormElementInput = memo<FormElementProps>(({ element }) => {
 			case 'TEL':
 			case 'TEXT':
 			case 'URL':
-				inputProps.type = element.type;
+				inputProps.type = element.type.toLowerCase();
 				break;
 			case 'EMAIL_CONFIRMATION':
 				inputProps.type = 'email';

--- a/packages/form-builder/src/FormElement/Tabs/Validation.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/Validation.tsx
@@ -1,11 +1,17 @@
 import { __ } from '@eventespresso/i18n';
-import { NumberInputWithLabel, SwitchWithLabel, TextInputWithLabel, withLabel } from '@eventespresso/ui-components';
+import {
+	NumberInputWithLabel,
+	SelectWithLabel,
+	SwitchWithLabel,
+	TextInputWithLabel,
+	withLabel,
+} from '@eventespresso/ui-components';
 import { DatePicker, TimePicker } from '@eventespresso/dates';
 
 import { useUpdateElement } from '../useUpdateElement';
 
 import type { FormElementProps } from '../../types';
-import { isDateField, isNumericField, isTextField, isFieldOfType } from '../../utils';
+import { isDateField, isNumericField, isTextField, isFieldOfType, isTelField } from '../../utils';
 
 const DatePickerWithLabel = withLabel(DatePicker);
 const TimePickerWithLabel = withLabel(TimePicker);
@@ -14,6 +20,29 @@ const monthFieldProps = {
 	showMonthYearPicker: true,
 	dateFormat: 'MM/yyyy',
 };
+
+const formatOptions = [
+	{
+		value: 'de_DE',
+		label: __('Germany'),
+	},
+	{
+		value: 'fr_FR',
+		label: __('France'),
+	},
+	{
+		value: 'en_UK',
+		label: __('United Kingdom'),
+	},
+	{
+		value: 'en_US',
+		label: __('United States'),
+	},
+	{
+		value: 'custom',
+		label: __('Custom'),
+	},
+];
 
 export const Validation: React.FC<FormElementProps> = ({ element }) => {
 	const onChangeValue = useUpdateElement(element);
@@ -37,11 +66,23 @@ export const Validation: React.FC<FormElementProps> = ({ element }) => {
 						onChangeValue={onChangeValue('attributes.autocomplete')}
 						isChecked={element.attributes?.autocomplete}
 					/>
-					<TextInputWithLabel
-						label={__('pattern')}
-						onChangeValue={onChangeValue('attributes.pattern')}
-						value={element.attributes?.pattern}
-					/>
+					{isTelField(element) && (
+						<SelectWithLabel
+							id={`${element.id}-format`}
+							label={__('format')}
+							options={formatOptions}
+							value={element.attributes?.format}
+							onChangeValue={onChangeValue('attributes.format')}
+							size='small'
+						/>
+					)}
+					{(!isTelField(element) || element.attributes?.format === 'custom') && (
+						<TextInputWithLabel
+							label={__('pattern')}
+							onChangeValue={onChangeValue('attributes.pattern')}
+							value={element.attributes?.pattern}
+						/>
+					)}
 				</>
 			)}
 			{isNumericField(element) && (

--- a/packages/form-builder/src/FormElement/Tabs/Validation.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/Validation.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@eventespresso/i18n';
 import {
 	NumberInputWithLabel,
-	SelectWithLabel,
+	SelectWithCustomText,
 	SwitchWithLabel,
 	TextInputWithLabel,
 	withLabel,
@@ -21,6 +21,7 @@ const monthFieldProps = {
 	dateFormat: 'MM/yyyy',
 };
 
+// TODO use DOM data to add these options
 const formatOptions = [
 	{
 		value: 'de_DE',
@@ -67,16 +68,17 @@ export const Validation: React.FC<FormElementProps> = ({ element }) => {
 						isChecked={element.attributes?.autocomplete}
 					/>
 					{isTelField(element) && (
-						<SelectWithLabel
+						<SelectWithCustomText
 							id={`${element.id}-format`}
+							customOptionValue='custom'
+							inputLabel={__('custom format')}
 							label={__('format')}
+							onChangeValue={onChangeValue('attributes.pattern')}
 							options={formatOptions}
-							value={element.attributes?.format}
-							onChangeValue={onChangeValue('attributes.format')}
-							size='small'
+							value={element.attributes?.pattern}
 						/>
 					)}
-					{(!isTelField(element) || element.attributes?.format === 'custom') && (
+					{!isTelField(element) && (
 						<TextInputWithLabel
 							label={__('pattern')}
 							onChangeValue={onChangeValue('attributes.pattern')}

--- a/packages/form-builder/src/constants.ts
+++ b/packages/form-builder/src/constants.ts
@@ -37,6 +37,7 @@ export const TEXT_FIELDS: Array<ElementType> = [
 	'EMAIL',
 	'EMAIL_CONFIRMATION',
 	'PASSWORD',
+	'PASSWORD_CONFIRMATION',
 	'TEL',
 	'TEXT',
 	'URL',

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -58,6 +58,7 @@ export type FormStatusFlags = {
 export type FormAttributes = {
 	autocomplete?: boolean;
 	class?: string;
+	format?: string; // for phone numbers
 	max?: number;
 	maxDate?: Date;
 	maxlength?: number;

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -58,7 +58,6 @@ export type FormStatusFlags = {
 export type FormAttributes = {
 	autocomplete?: boolean;
 	class?: string;
-	format?: string; // for phone numbers
 	max?: number;
 	maxDate?: Date;
 	maxlength?: number;

--- a/packages/form-builder/src/utils.ts
+++ b/packages/form-builder/src/utils.ts
@@ -12,3 +12,4 @@ export const isDateField = isFieldOfType(DATE_FIELDS);
 export const isFieldWithOptions = isFieldOfType(FIELDS_WITH_OPTIONS);
 export const isNumericField = isFieldOfType(NUMERIC_FIELDS);
 export const isTextField = isFieldOfType(TEXT_FIELDS);
+export const isTelField = isFieldOfType(['TEL']);

--- a/packages/ui-components/src/Select/SelectWithCustomText.tsx
+++ b/packages/ui-components/src/Select/SelectWithCustomText.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { getOptionValues } from '@eventespresso/utils';
+
+import { SelectWithLabel } from './Select';
+import { TextInputWithLabel } from '../text-input';
+
+export interface SelectWithCustomTextProps extends Omit<React.ComponentProps<typeof SelectWithLabel>, 'onChange'> {
+	inputLabel?: string;
+	inputProps?: React.ComponentProps<typeof TextInputWithLabel>;
+	customOptionValue?: React.ReactText;
+}
+
+/**
+ * A composite component to provide a select dropdown and a text input
+ * The text input will be shown when `customOptionValue` is selected from the dropdown
+ * or if the `defaultValue` or `value` is not among the provided options
+ */
+export const SelectWithCustomText: React.FC<SelectWithCustomTextProps> = ({
+	defaultValue,
+	inputLabel,
+	inputProps,
+	onChangeValue,
+	options,
+	customOptionValue,
+	value,
+	...props
+}) => {
+	// This is the initial value, both for controlled and un-controlled usage
+	const initialValue = value || defaultValue;
+	// This is the current value that will be sent back to the consumer
+	const [currentValue, setCurrentValue] = useState(initialValue);
+	// Collect all the option value keys
+	const optionValues = useMemo(() => getOptionValues(options), [options]);
+	// This is the value for custom text input.
+	// This is maintained separately to retain the value if the user changes the dropdown
+	// and then again selects `customOptionValue`
+	const [inputValue, setInputValue] = useState(() => {
+		// If `initialValue` is NOT in the provided dropdown options,
+		// it means some custom value has been passed, we will use it as the initial input value
+		// otherwise an option from the available options is passed, thus we set the input to empty string
+		return !optionValues.includes(initialValue as string) ? initialValue : '';
+	});
+	// This is the value that gets passed to the select dropdown
+	// If `currentValue` is NOT in the provided dropdown options,
+	// it means some custom value has been entered, thus we will set the selected value to `customOptionValue`
+	const val4Select = !optionValues.includes(currentValue as string) ? customOptionValue : currentValue;
+
+	const onChangeCurrentValue = useCallback(
+		(newValue) => {
+			setCurrentValue(newValue);
+			// If the new value equals to `customOptionValue`, we will pass the custom input value
+			const changedValue = newValue === customOptionValue ? inputValue : newValue;
+			onChangeValue?.(changedValue as string);
+		},
+		[customOptionValue, inputValue, onChangeValue]
+	);
+
+	const onChangeInput = useCallback(
+		(newValue) => {
+			setInputValue(newValue);
+			onChangeCurrentValue(newValue);
+		},
+		[onChangeCurrentValue]
+	);
+
+	return (
+		<>
+			<SelectWithLabel options={options} value={val4Select} onChangeValue={onChangeCurrentValue} {...props} />
+
+			{customOptionValue === val4Select && (
+				<TextInputWithLabel
+					label={inputLabel}
+					{...inputProps}
+					onChangeValue={onChangeInput}
+					value={inputValue}
+				/>
+			)}
+		</>
+	);
+};

--- a/packages/ui-components/src/Select/index.stories.tsx
+++ b/packages/ui-components/src/Select/index.stories.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import type { Story, Meta } from '@storybook/react/types-6-0';
 
-import { Select } from '../';
+import { Select, SelectWithCustomText } from '../';
 import type { SelectProps } from './types';
 
 export default {
@@ -50,5 +50,62 @@ export const SelectControlled: SelectStory = () => {
 			<option value='Option 2'>Option 2</option>
 			<option value='Option 3'>Option 3</option>
 		</Select>
+	);
+};
+
+const formatOptions = [
+	{
+		value: 'de_DE',
+		label: 'Germany',
+	},
+	{
+		value: 'fr_FR',
+		label: 'France',
+	},
+	{
+		value: 'en_UK',
+		label: 'United Kingdom',
+	},
+	{
+		value: 'en_US',
+		label: 'United States',
+	},
+	{
+		value: 'custom',
+		label: 'Custom',
+	},
+];
+
+export const SelectWithText: SelectStory = () => {
+	return (
+		<SelectWithCustomText
+			// defaultValue='(\+91)?[6-9][0-9]{9}'
+			defaultValue='en_US'
+			inputLabel='Custom pattern'
+			label='Phone number pattern'
+			onChangeValue={console.log}
+			options={formatOptions}
+			customOptionValue='custom'
+		/>
+	);
+};
+
+export const SelectWithTextControlled: SelectStory = () => {
+	const [value, setValue] = useState<React.ReactText>('en_US');
+
+	const onChangeValue = useCallback((newValue) => {
+		setValue(newValue);
+		console.log({ newValue });
+	}, []);
+
+	return (
+		<SelectWithCustomText
+			value={value}
+			inputLabel='Custom pattern'
+			label='Phone number pattern'
+			onChangeValue={onChangeValue}
+			options={formatOptions}
+			customOptionValue='custom'
+		/>
 	);
 };

--- a/packages/ui-components/src/Select/index.ts
+++ b/packages/ui-components/src/Select/index.ts
@@ -1,4 +1,5 @@
 export * from './Select';
 export * from './MultiSelect';
+export * from './SelectWithCustomText';
 
 export * from './types';


### PR DESCRIPTION
This PR adds phone format field to Phone number input for Form Builder. It also adds `SelectWithCustomText` component.

See #950 

![demo](https://user-images.githubusercontent.com/18226415/125447989-30f9b17e-c275-448b-8a62-7bc1b9f3573f.gif)


![demo](https://user-images.githubusercontent.com/18226415/125641241-dc1ddb6d-c506-40d3-b900-85d0a3c0625b.gif)
