### PR TITLE
Fix TAM Filters E2E Test

### DIFF
--- a/packages/e2e-tests/specs/shared/data.ts
+++ b/packages/e2e-tests/specs/shared/data.ts
@@ -17,7 +17,7 @@ export const data = [
 	{
 		name: '3',
 		// This date is in the current month
-		startDate: sub('minutes', NOW, 10),
+		startDate: NOW,
 		endDate: add('days', NOW, 2),
 	},
 	{


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/eventespresso/barista/issues/954#issuecomment-880047582. It uses `NOW` as the start date which will always be the current month and all the comparisons with `NOW` will be valid. The reason being that `NOW` remains the same throughout the session.

Closes #954 