### PR TITLE
Blocks | EventField color settings and types

### DIFF
--- a/domains/core/admin/blocks/src/event-attendees/index.tsx
+++ b/domains/core/admin/blocks/src/event-attendees/index.tsx
@@ -17,5 +17,4 @@ registerBlockType<EventAttendeesAttributes>('eventespresso/event-attendees', {
 	save() {
 		return null;
 	},
-	// TODO migrate attributes to use GUID
 });

--- a/domains/core/admin/blocks/src/event/DisplayField.tsx
+++ b/domains/core/admin/blocks/src/event/DisplayField.tsx
@@ -6,10 +6,11 @@ import { __ } from '@eventespresso/i18n';
 import { useEvent } from '@blocksServices/apollo';
 import { SelectEvent } from './controls/SelectEvent';
 import { SelectField } from './controls/SelectField';
+import { EventFieldEditProps } from './types';
 
 const controlWrapperStyle: CSSProperties = { flexDirection: 'column' };
 
-export const DisplayField: React.FC<any> = (props) => {
+export const DisplayField: React.FC<EventFieldEditProps> = (props) => {
 	const { attributes } = props;
 	const { data, error, loading } = useEvent(attributes.event);
 
@@ -33,23 +34,23 @@ export const DisplayField: React.FC<any> = (props) => {
 	}
 
 	if (loading) {
-		return (
-			<Placeholder>
-				<Spinner />
-			</Placeholder>
-		);
+		return <Spinner />;
 	}
 
 	if (error) {
 		return <Placeholder>{__('An unknown error occurred while fetching event details.')}</Placeholder>;
 	}
 
+	const value = data?.espressoEvent?.[attributes.field] || '';
+
 	return (
-		<div
-			style={attributes.style}
-			// field can be HTML (e.g. Event description)
-			// eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-			dangerouslySetInnerHTML={{ __html: data?.espressoEvent?.[attributes.field] || '' }}
-		/>
+		<>
+			<div
+				style={attributes.style}
+				// field can be HTML (e.g. Event description)
+				// eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+				dangerouslySetInnerHTML={{ __html: value }}
+			/>
+		</>
 	);
 };

--- a/domains/core/admin/blocks/src/event/controls/SelectEvent.tsx
+++ b/domains/core/admin/blocks/src/event/controls/SelectEvent.tsx
@@ -5,8 +5,9 @@ import { __ } from '@eventespresso/i18n';
 import { useEvents } from '@blocksServices/apollo';
 import { buildEntitySelectOptions } from '@blocksServices/utils';
 import { Select as SelectControl } from '../../adapters';
+import { EventFieldEditProps } from '../types';
 
-export const SelectEvent: React.FC<any> = ({ attributes, setAttributes }) => {
+export const SelectEvent: React.FC<EventFieldEditProps> = ({ attributes, setAttributes }) => {
 	const { event } = attributes;
 
 	const { data, loading, error } = useEvents();

--- a/domains/core/admin/blocks/src/event/controls/SelectField.tsx
+++ b/domains/core/admin/blocks/src/event/controls/SelectField.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { __ } from '@eventespresso/i18n';
 
 import { Select as SelectControl } from '../../adapters';
+import { EventFieldEditProps } from '../types';
 
 const options = [
 	{
@@ -23,7 +24,7 @@ const options = [
 	},
 ];
 
-export const SelectField: React.FC<any> = ({ attributes, setAttributes }) => {
+export const SelectField: React.FC<EventFieldEditProps> = ({ attributes, setAttributes }) => {
 	const { field } = attributes;
 
 	const onChange = useCallback((field): void => setAttributes({ field }), [setAttributes]);

--- a/domains/core/admin/blocks/src/event/controls/index.tsx
+++ b/domains/core/admin/blocks/src/event/controls/index.tsx
@@ -1,16 +1,39 @@
-import { InspectorControls, BlockControls, AlignmentToolbar, FontSizePicker } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	BlockControls,
+	AlignmentToolbar,
+	FontSizePicker,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
 import { __ } from '@eventespresso/i18n';
 import { PanelBody } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useMemo } from '@wordpress/element';
 
 import { SelectEvent } from './SelectEvent';
 import { SelectField } from './SelectField';
 import { useOnChangeStyle } from './useOnChangeStyle';
+import { EventFieldAttributes, EventFieldEditProps } from '../types';
 
-export const Controls: React.FC<any> = (props) => {
+export const Controls: React.FC<EventFieldEditProps> = (props) => {
 	const { attributes, setAttributes } = props;
 
-	const onChange = useOnChangeStyle(attributes, setAttributes);
+	const onChange = useOnChangeStyle<EventFieldAttributes>(attributes, setAttributes);
+
+	const colorSettings = useMemo<PanelColorSettings.Props['colorSettings']>(
+		() => [
+			{
+				value: attributes.style.color,
+				onChange: onChange('color'),
+				label: __('Text Color'),
+			},
+			{
+				value: attributes.style.backgroundColor,
+				onChange: onChange('backgroundColor'),
+				label: __('Background Color'),
+			},
+		],
+		[attributes.style.backgroundColor, attributes.style.color, onChange]
+	);
 
 	return (
 		<Fragment>
@@ -19,9 +42,10 @@ export const Controls: React.FC<any> = (props) => {
 					<SelectEvent {...props} />
 					<SelectField {...props} />
 				</PanelBody>
-				<PanelBody title={__('Style')}>
-					<FontSizePicker value={attributes.style.fontSize} onChange={onChange('fontSize')} />
+				<PanelBody title={__('Typography')} initialOpen={false}>
+					<FontSizePicker value={attributes.style.fontSize as number} onChange={onChange('fontSize')} />
 				</PanelBody>
+				<PanelColorSettings title={__('Color')} colorSettings={colorSettings} initialOpen={false} />
 			</InspectorControls>
 			<BlockControls>
 				<AlignmentToolbar value={attributes.style.textAlign} onChange={onChange('textAlign')} />

--- a/domains/core/admin/blocks/src/event/controls/useOnChangeStyle.ts
+++ b/domains/core/admin/blocks/src/event/controls/useOnChangeStyle.ts
@@ -2,16 +2,16 @@ import type { CSSProperties } from 'react';
 
 import { useCallback } from '@wordpress/element';
 
-export const useOnChangeStyle = <T extends Record<string, any>>(
+export const useOnChangeStyle = <T extends { style?: CSSProperties }>(
 	attributes: T,
 	setAttributes: (attrs: Partial<T>) => void
 ) => {
 	return useCallback(
 		(key: keyof CSSProperties) => (value: any) => {
 			const previousStyle = attributes.style || {};
-			const newStyle = { ...previousStyle, [key]: value };
+			const newStyle: CSSProperties = { ...previousStyle, [key]: value };
 
-			setAttributes({ style: newStyle } as any);
+			setAttributes({ style: newStyle } as T);
 		},
 		[attributes.style, setAttributes]
 	);

--- a/domains/core/admin/blocks/src/event/edit.tsx
+++ b/domains/core/admin/blocks/src/event/edit.tsx
@@ -1,8 +1,10 @@
 import { withDataProvider } from '@eventespresso/data';
+
 import { Controls } from './controls';
 import { DisplayField } from './DisplayField';
+import { EventFieldEditProps } from './types';
 
-const EventAttendeesEdit: React.FC = (props) => {
+const EventAttendeesEdit: React.FC<EventFieldEditProps> = (props) => {
 	return (
 		<>
 			<DisplayField {...props} />

--- a/domains/core/admin/blocks/src/event/index.tsx
+++ b/domains/core/admin/blocks/src/event/index.tsx
@@ -2,8 +2,9 @@ import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@eventespresso/i18n';
 
 import Edit from './edit';
+import { EventFieldAttributes } from './types';
 
-registerBlockType('eventespresso/event-field', {
+registerBlockType<EventFieldAttributes>('eventespresso/event-field', {
 	title: __('Event Field'),
 	description: __('Displays the selected field of an event'),
 	icon: 'editor-paragraph',
@@ -27,5 +28,4 @@ registerBlockType('eventespresso/event-field', {
 	save() {
 		return null;
 	},
-	// TODO migrate attributes to use GUID
 });

--- a/domains/core/admin/blocks/src/event/types.ts
+++ b/domains/core/admin/blocks/src/event/types.ts
@@ -1,0 +1,16 @@
+import type { CSSProperties } from 'react';
+import { BlockEditProps } from '@wordpress/blocks';
+
+import type { EntityId, Entity } from '@eventespresso/data';
+
+import { Event } from '@blocksServices/apollo';
+
+export type EventField = Exclude<keyof Event, keyof Entity>;
+
+export interface EventFieldAttributes {
+	event: EntityId;
+	field: EventField;
+	style: CSSProperties;
+}
+
+export type EventFieldEditProps = BlockEditProps<EventFieldAttributes>;


### PR DESCRIPTION
This PR adds color settings for event field block and also adds TS types to the components

See #270 

![demo](https://user-images.githubusercontent.com/18226415/127011870-b836c968-ada3-4f34-acc6-61b63d2d9483.gif)
