### PR TITLE
Fix Ticket capabilities not saving within EDTR

### DIFF
--- a/domains/wpUser/src/hooks/useTicketUpdateInput.ts
+++ b/domains/wpUser/src/hooks/useTicketUpdateInput.ts
@@ -11,7 +11,7 @@ const filterName: keyof Filters = 'eventEditor.ticket.mutationInput';
  */
 const useTicketUpdateInput = (): void => {
 	useEffect(() => {
-		hooks.addFilter(filterName, NAMESPACE, ({ capabilityRequired, customCapabilityRequired, ...input }) => {
+		hooks.addFilter(filterName, NAMESPACE, (input, { capabilityRequired, customCapabilityRequired } = {}) => {
 			switch (true) {
 				// if capabilityRequired is not being updated
 				case typeof capabilityRequired !== 'string':

--- a/packages/e2e-tests/utils/admin/event-editor/editEntityCard.ts
+++ b/packages/e2e-tests/utils/admin/event-editor/editEntityCard.ts
@@ -17,7 +17,7 @@ export const editEntityCard = async ({ capacity, entityType, name, quantity }: P
 		await page.type(`${entityList} .entity-card-details__name .ee-inline-edit__input`, name);
 
 		const waitForListUpdate = await parser.createWaitForListUpdate();
-		await page.click(parser.getRootSelector()); // click outside of the inline input
+		await page.keyboard.press('Enter');
 		await waitForListUpdate();
 	}
 
@@ -26,7 +26,7 @@ export const editEntityCard = async ({ capacity, entityType, name, quantity }: P
 		await page.type(`${entityList} .ee-entity-details__value .ee-inline-edit__input`, capacity || quantity);
 
 		const waitForListUpdate = await parser.createWaitForListUpdate();
-		await page.click(parser.getRootSelector()); // click outside of the inline input
+		await page.keyboard.press('Enter');
 		await waitForListUpdate();
 	}
 };

--- a/packages/edtr-services/src/ioc/index.ts
+++ b/packages/edtr-services/src/ioc/index.ts
@@ -1,5 +1,5 @@
 import { getHooks } from '@eventespresso/ioc';
-import type { MutationType, ApolloCache, Entity, EntityId } from '@eventespresso/data';
+import type { MutationType, ApolloCache, Entity } from '@eventespresso/data';
 import type { OptionsType } from '@eventespresso/adapters';
 import type { BulkEdit } from '@eventespresso/services';
 import type { ButtonProps } from '@eventespresso/ui-components';
@@ -24,7 +24,7 @@ export type Filters = {
 	'eventEditor.ticketForm.sections': [sections: TicketFormConfig['sections'], ticket: Ticket];
 	'eventEditor.dateForm.initalValues': [initialValues: DateFormShape, datetime: Datetime];
 	'eventEditor.dateForm.sections': [sections: DateFormConfig['sections'], datetime: Datetime];
-	'eventEditor.ticket.mutationInput': [input: Record<string, any>, entityId?: EntityId];
+	'eventEditor.ticket.mutationInput': [input: Record<string, any>, rawInput?: Record<string, any>];
 	'eventEditor.datetimes.bulkEdit.actions': [actions: OptionsType];
 	'eventEditor.addSingleDate.button': [button: JSX.Element, isOnlyButton: boolean];
 	'eventEditor.addSingleDate.buttonProps': [props: Partial<ButtonProps>, isOnlyButton: boolean];

--- a/packages/tpc/src/hooks/useMutateTicket.ts
+++ b/packages/tpc/src/hooks/useMutateTicket.ts
@@ -42,7 +42,7 @@ const useMutateTicket = (): Callback => {
 			const mutationInput = hooks.applyFilters(
 				'eventEditor.ticket.mutationInput',
 				normalizedTicketFields,
-				ticket.id
+				ticket
 			);
 
 			let mutationResult: TicketMutationResult;


### PR DESCRIPTION
This PR fixes #980 

**Next:** The ticket caps are saved to the database but are not reflected in EDTR after page reload because the capability data is missing in WP User Addon DOM data. The reason for that is described in https://github.com/eventespresso/eea-wpuser-integration/issues/40