### PR TITLE
Fix ticket meta data loading

### DIFF
--- a/domains/wpUser/src/hooks/useTicketFormInitialValues.ts
+++ b/domains/wpUser/src/hooks/useTicketFormInitialValues.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { hooks, useTicketsMeta, Filters } from '@eventespresso/edtr-services';
 import { getOptionValues } from '@eventespresso/utils';
 import { useMemoStringify } from '@eventespresso/hooks';
+import { getEEDomData } from '@eventespresso/services';
 
 import { NAMESPACE } from '../constants';
 import useCapabilityOptions from './useCapabilityOptions';
@@ -22,9 +23,20 @@ const useTicketFormInitialValues = (): void => {
 		hooks.removeFilter(filterName, NAMESPACE);
 
 		hooks.addFilter(filterName, NAMESPACE, (initialValues, ticket) => {
+			const ticketID = ticket?.id;
+			console.log('%c ticketID', 'color: cyan;', ticketID);
 			// ticket the value from meta. It will be empty for new tickets
-			let capabilityRequired = getMetaValue<string>(ticket?.id, 'capabilityRequired', 'none');
+			let capabilityRequired = getMetaValue<string>(ticketID, 'capabilityRequired', 'none');
 			let customCapabilityRequired = '';
+
+			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
+			console.log('%c customCapabilityRequired', 'color: HotPink;', customCapabilityRequired);
+
+			const ticketMeta = getEEDomData('wpUserData')?.ticketMeta;
+			console.log('%c ticketMeta', 'color: LimeGreen;', ticketMeta);
+			capabilityRequired = ticketMeta?.[ticketID]?.capabilityRequired || capabilityRequired;
+
+			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
 
 			// if capabilityRequired has some unknown value
 			// it means, custom option should be selected
@@ -32,6 +44,9 @@ const useTicketFormInitialValues = (): void => {
 				customCapabilityRequired = `${capabilityRequired}`;
 				capabilityRequired = 'custom';
 			}
+
+			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
+			console.log('%c customCapabilityRequired', 'color: HotPink;', customCapabilityRequired);
 
 			return {
 				...initialValues,

--- a/domains/wpUser/src/hooks/useTicketFormInitialValues.ts
+++ b/domains/wpUser/src/hooks/useTicketFormInitialValues.ts
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { hooks, useTicketsMeta, Filters } from '@eventespresso/edtr-services';
 import { getOptionValues } from '@eventespresso/utils';
 import { useMemoStringify } from '@eventespresso/hooks';
-import { getEEDomData } from '@eventespresso/services';
 
 import { NAMESPACE } from '../constants';
 import useCapabilityOptions from './useCapabilityOptions';
@@ -23,20 +22,9 @@ const useTicketFormInitialValues = (): void => {
 		hooks.removeFilter(filterName, NAMESPACE);
 
 		hooks.addFilter(filterName, NAMESPACE, (initialValues, ticket) => {
-			const ticketID = ticket?.id;
-			console.log('%c ticketID', 'color: cyan;', ticketID);
 			// ticket the value from meta. It will be empty for new tickets
-			let capabilityRequired = getMetaValue<string>(ticketID, 'capabilityRequired', 'none');
+			let capabilityRequired = getMetaValue<string>(ticket?.id, 'capabilityRequired', 'none');
 			let customCapabilityRequired = '';
-
-			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
-			console.log('%c customCapabilityRequired', 'color: HotPink;', customCapabilityRequired);
-
-			const ticketMeta = getEEDomData('wpUserData')?.ticketMeta;
-			console.log('%c ticketMeta', 'color: LimeGreen;', ticketMeta);
-			capabilityRequired = ticketMeta?.[ticketID]?.capabilityRequired || capabilityRequired;
-
-			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
 
 			// if capabilityRequired has some unknown value
 			// it means, custom option should be selected
@@ -44,9 +32,6 @@ const useTicketFormInitialValues = (): void => {
 				customCapabilityRequired = `${capabilityRequired}`;
 				capabilityRequired = 'custom';
 			}
-
-			console.log('%c capabilityRequired', 'color: HotPink;', capabilityRequired);
-			console.log('%c customCapabilityRequired', 'color: HotPink;', customCapabilityRequired);
 
 			return {
 				...initialValues,

--- a/domains/wpUser/src/services/apollo/initialization/useCacheRehydration.ts
+++ b/domains/wpUser/src/services/apollo/initialization/useCacheRehydration.ts
@@ -11,7 +11,7 @@ import useCacheRehydrationData from './useCacheRehydrationData';
 const useCacheRehydration = (): boolean => {
 	const [isRehydrated] = useIsRehydrated();
 
-	const { ticketsMeta } = useCacheRehydrationData();
+	const { ticketMeta } = useCacheRehydrationData();
 
 	const { mergeMetaMap } = useTicketsMeta();
 
@@ -24,11 +24,11 @@ const useCacheRehydration = (): boolean => {
 		}
 		// it's possible that other addons may add their meta,
 		// so we will merge it instead of resetting it
-		mergeMetaMap(ticketsMeta);
+		mergeMetaMap(ticketMeta);
 
 		// switch the flag
 		initialized.current = true;
-	}, [isRehydrated, mergeMetaMap, ticketsMeta]);
+	}, [isRehydrated, mergeMetaMap, ticketMeta]);
 
 	return initialized.current;
 };

--- a/domains/wpUser/src/types.ts
+++ b/domains/wpUser/src/types.ts
@@ -1,6 +1,6 @@
 import type { EntityMetaMap } from '@eventespresso/services';
 
-export type TicketsMeta = EntityMetaMap;
+export type ticketMeta = EntityMetaMap;
 
 export type CapabilityOptions = {
 	[optgroup: string]: {
@@ -10,5 +10,5 @@ export type CapabilityOptions = {
 
 export interface WpUserData {
 	capabilityOptions?: CapabilityOptions;
-	ticketsMeta?: TicketsMeta;
+	ticketMeta?: ticketMeta;
 }


### PR DESCRIPTION
Fix ticket meta loading by changing `ticketsMeta` to `ticketMeta` in WPUA DOM data.

Fixes #980

