### PR TITLE
Use extracted checkout and node/yarn action

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,9 +16,8 @@ jobs:
         steps:
             - uses: dorny/paths-filter@v2
               id: filter
-              base: master
               with:
-                  base: ${{ github.ref }}
+                  base: master
                   filters: |
                       js:
                         - 'domains/**'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,7 @@ jobs:
         steps:
             - uses: dorny/paths-filter@v2
               id: filter
+              base: master
               with:
                   base: ${{ github.ref }}
                   filters: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,28 +30,11 @@ jobs:
         name: ${{ matrix.task }}
         needs: what-is-hit
         steps:
-            - name: Checkout the commit
-              uses: actions/checkout@v2
+            - name: Checkout and yarn
+              uses: eventespresso/actions/packages/checkout-and-yarn@main
               with:
                   # To make sure all history is fetched for jest --changedSince to work as expected
                   fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }} # 0 for test, 1 otherwise
-
-            - name: Set up Node
-              uses: actions/setup-node@v2
-              with:
-                  node-version: lts/*
-
-            - name: Cache dependencies
-              id: cache-deps
-              uses: actions/cache@v2
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-            - name: Install dependencies
-              # install deps only if lockfile has changed
-              if: steps.cache-deps.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
 
             - name: Set test CLI args
               if: ${{ matrix.task == 'test' }}
@@ -95,23 +78,8 @@ jobs:
             matrix: ${{ fromJSON(needs.list-e2e-specs.outputs.specs) }}
             fail-fast: false
         steps:
-            - uses: actions/checkout@v2
-
-            - name: Set up Node
-              uses: actions/setup-node@v2
-              with:
-                  node-version: lts/*
-
-            - name: Cache dependencies
-              id: cache-deps
-              uses: actions/cache@v2
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-            - name: Install dependencies
-              if: steps.cache-deps.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
+            - name: Checkout and yarn
+              uses: eventespresso/actions/packages/checkout-and-yarn@main
 
             - name: Download build artifact
               # Download artifact only if running after build job

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,7 +31,7 @@ jobs:
         needs: what-is-hit
         steps:
             - name: Checkout and yarn
-              uses: eventespresso/actions/packages/checkout-and-yarn@checkout-and-yarn-action
+              uses: eventespresso/actions/packages/checkout-and-yarn@main
               with:
                   # To make sure all history is fetched for jest --changedSince to work as expected
                   fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }} # 0 for test, 1 otherwise
@@ -79,7 +79,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout and yarn
-              uses: eventespresso/actions/packages/checkout-and-yarn@checkout-and-yarn-action
+              uses: eventespresso/actions/packages/checkout-and-yarn@main
 
             - name: Download build artifact
               # Download artifact only if running after build job

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,8 @@
 name: Pull Request checks
 
-on: [pull_request]
+on:
+    push:
+        branches: [reusable-workflow]
 
 env:
     PLAYWRIGHT_BROWSERS_PATH: 0 # See https://playwright.dev/docs/ci/#caching-browsers
@@ -31,7 +33,7 @@ jobs:
         needs: what-is-hit
         steps:
             - name: Checkout and yarn
-              uses: eventespresso/actions/packages/checkout-and-yarn@main
+              uses: eventespresso/actions/packages/checkout-and-yarn@checkout-and-yarn-action
               with:
                   # To make sure all history is fetched for jest --changedSince to work as expected
                   fetch-depth: ${{ ( matrix.task != 'test' && 1 ) || 0 }} # 0 for test, 1 otherwise
@@ -79,7 +81,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout and yarn
-              uses: eventespresso/actions/packages/checkout-and-yarn@main
+              uses: eventespresso/actions/packages/checkout-and-yarn@checkout-and-yarn-action
 
             - name: Download build artifact
               # Download artifact only if running after build job

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,8 +1,6 @@
 name: Pull Request checks
 
-on:
-    push:
-        branches: [reusable-workflow]
+on: [pull_request]
 
 env:
     PLAYWRIGHT_BROWSERS_PATH: 0 # See https://playwright.dev/docs/ci/#caching-browsers
@@ -17,7 +15,7 @@ jobs:
             - uses: dorny/paths-filter@v2
               id: filter
               with:
-                  base: master
+                  base: ${{ github.ref }}
                   filters: |
                       js:
                         - 'domains/**'

--- a/packages/e2e-tests/jest.playwright.config.ts
+++ b/packages/e2e-tests/jest.playwright.config.ts
@@ -4,7 +4,7 @@ import type { Config } from '@jest/types';
 
 import { moduleNameMapper } from '../../jest.config';
 
-// E2E tests are run with packages/e2e-tests as Node CWD, so we need to adjust the paths.
+// E2E tests are run with packages/e2e-tests as Node CWD, so we need to adjust the paths...
 const e2eModuleNameMapper = map<any, any>(replace('<rootDir>', '<rootDir>/../..'), moduleNameMapper);
 
 dotenv.config();


### PR DESCRIPTION
This PR uses the extracted composite action to checkout the commit and set up node to avoid unnecessary repetition.