### PR TITLE
🐛 Fix | Bulk Update Shifting Dates Ahead Does Not Reset Status

### DIFF
--- a/packages/edtr-services/src/apollo/mutations/datetimes/useBulkEditDatetimes.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useBulkEditDatetimes.ts
@@ -6,7 +6,7 @@ import { useDatetimeQueryOptions, useDatetimes } from '../../queries';
 import { BulkUpdateDatetimeInput, BULK_UPDATE_DATETIMES } from './';
 import useOnUpdateDatetime from './useOnUpdateDatetime';
 import { useUpdateDatetimeList } from '../../../hooks';
-import { cacheNodesFromBulkInput } from '../utils';
+import { cacheNodesFromBulkInput, updateDatetimeFlags } from '../utils';
 import type { DatetimeEdge, Datetime } from '../../types';
 import { SINGULAR_ENTITY_NAME } from '../../../constants';
 
@@ -30,7 +30,7 @@ const useBulkEditDatetimes = (): BulkEditDatetimes => {
 
 	const updateEntityList = useCallback(
 		(input: BulkUpdateDatetimeInput) => () => {
-			const nodes = cacheNodesFromBulkInput(input, allDatetimes);
+			const nodes = cacheNodesFromBulkInput(input, allDatetimes).map(updateDatetimeFlags);
 
 			const espressoDatetimes: DatetimeEdge = {
 				nodes,

--- a/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
@@ -10,7 +10,7 @@ import { useTicketQueryOptions, useTickets } from '../../queries';
 import { useUpdateTicketList } from '../../../hooks';
 import { BulkUpdateTicketInput, BULK_UPDATE_TICKETS } from './';
 import { SINGULAR_ENTITY_NAME } from '../../../constants';
-import { cacheNodesFromBulkInput } from '../utils';
+import { cacheNodesFromBulkInput, updateTicketFlags } from '../utils';
 import useOnUpdateTicket from './useOnUpdateTicket';
 
 interface BulkEditTickets {
@@ -34,7 +34,7 @@ const useBulkEditTickets = (): BulkEditTickets => {
 
 	const updateEntityList = useCallback(
 		(input: BulkUpdateTicketInput) => () => {
-			const nodes = cacheNodesFromBulkInput(input, allTickets);
+			const nodes = cacheNodesFromBulkInput(input, allTickets).map(updateTicketFlags);
 
 			const espressoTickets: TicketEdge = {
 				nodes,

--- a/packages/edtr-services/src/apollo/mutations/utils.ts
+++ b/packages/edtr-services/src/apollo/mutations/utils.ts
@@ -1,4 +1,12 @@
-import { entitiesWithGuIdInArray, entitiesWithGuIdNotInArray } from '@eventespresso/predicates';
+import {
+	entitiesWithGuIdInArray,
+	entitiesWithGuIdNotInArray,
+	isActive,
+	isExpired,
+	isOnSale,
+	isPending,
+	isUpcoming,
+} from '@eventespresso/predicates';
 import type { AnyObject } from '@eventespresso/utils';
 import { shiftDate } from '@eventespresso/dates';
 import type { EntityId } from '@eventespresso/data';
@@ -96,4 +104,31 @@ export const cacheNodesFromBulkDelete = <E extends Datetime | Ticket | Price>(
 	});
 
 	return nodes;
+};
+
+/**
+ * Updates the boolean date related flags for the given datetime
+ * based upon the (possible updated) other fields
+ */
+export const updateDatetimeFlags = (date: Datetime): Datetime => {
+	return {
+		...date,
+		isActive: isActive(date, true),
+		isExpired: isExpired(date, true),
+		isUpcoming: isUpcoming(date, true),
+	};
+};
+
+/**
+ * Updates the boolean date related flags for the given ticket
+ * based upon the (possible updated) other fields
+ */
+export const updateTicketFlags = (ticket: Ticket): Ticket => {
+	return {
+		...ticket,
+		isExpired: isExpired(ticket, true),
+		isFree: !ticket.price,
+		isOnSale: isOnSale(ticket, true),
+		isPending: isPending(ticket, true),
+	};
 };

--- a/packages/predicates/src/common/isExpired/index.ts
+++ b/packages/predicates/src/common/isExpired/index.ts
@@ -11,6 +11,6 @@ import { NOW as now } from '@eventespresso/constants';
  * @param entity The entity object
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-export const isExpired = (entity: Ticket | Datetime, ignoreFlag?: boolean): boolean => {
+export const isExpired = (entity: Ticket | Datetime, ignoreFlag = false): boolean => {
 	return (!ignoreFlag && isBooleanTrue(entity.isExpired)) || diff('minutes', parseISO(entity.endDate), now) < 0;
 };

--- a/packages/predicates/src/common/isExpired/index.ts
+++ b/packages/predicates/src/common/isExpired/index.ts
@@ -5,5 +5,12 @@ import { isBooleanTrue } from '@eventespresso/utils';
 import { diff } from '@eventespresso/dates';
 import { NOW as now } from '@eventespresso/constants';
 
-export const isExpired = (entity: Ticket | Datetime): boolean =>
-	isBooleanTrue(entity.isExpired) || diff('minutes', parseISO(entity.endDate), now) < 0;
+/**
+ * Whether an entity is expired, based on its end date
+ *
+ * @param entity The entity object
+ * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
+ */
+export const isExpired = (entity: Ticket | Datetime, ignoreFlag?: boolean): boolean => {
+	return (!ignoreFlag && isBooleanTrue(entity.isExpired)) || diff('minutes', parseISO(entity.endDate), now) < 0;
+};

--- a/packages/predicates/src/common/isTrashed/index.ts
+++ b/packages/predicates/src/common/isTrashed/index.ts
@@ -1,4 +1,5 @@
-import { compose, not, propEq } from 'ramda';
+import * as R from 'ramda';
+
 import type { EntityFieldPred as EFP } from '@eventespresso/utils';
 
 /**
@@ -6,6 +7,6 @@ import type { EntityFieldPred as EFP } from '@eventespresso/utils';
  * @param {Object} entity object
  * @return {boolean} true if ticket is trashed
  */
-export const isTrashed: EFP<'isTrashed', boolean> = propEq('isTrashed', true);
+export const isTrashed: EFP<'isTrashed', boolean> = R.propEq('isTrashed', true);
 
-export const isNotTrashed: EFP<'isTrashed', boolean> = compose(not, isTrashed);
+export const isNotTrashed: EFP<'isTrashed', boolean> = R.complement(isTrashed);

--- a/packages/predicates/src/datetimes/index.ts
+++ b/packages/predicates/src/datetimes/index.ts
@@ -9,6 +9,7 @@ export { default as isInMonth } from './isInMonth';
 export { default as isInYear } from './isInYear';
 export { default as isDateSoldOut } from './isSoldOut';
 export { default as isUpcoming } from './isUpcoming';
+export { default as isSoldOut } from './isSoldOut';
 
 export { default as sortDates } from './sorters';
 

--- a/packages/predicates/src/datetimes/isActive.ts
+++ b/packages/predicates/src/datetimes/isActive.ts
@@ -11,7 +11,7 @@ import { NOW as now } from '@eventespresso/constants';
  * @param date The datetime object
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-const isActive = (date: Datetime, ignoreFlag?: boolean): boolean => {
+const isActive = (date: Datetime, ignoreFlag = false): boolean => {
 	return (
 		(!ignoreFlag && isBooleanTrue(date.isActive)) ||
 		(diff('seconds', parseISO(date.startDate), now) < 0 && diff('seconds', parseISO(date.endDate), now) > 0)

--- a/packages/predicates/src/datetimes/isActive.ts
+++ b/packages/predicates/src/datetimes/isActive.ts
@@ -5,8 +5,17 @@ import { isBooleanTrue } from '@eventespresso/utils';
 import { diff } from '@eventespresso/dates';
 import { NOW as now } from '@eventespresso/constants';
 
-const isActive = (date: Datetime): boolean =>
-	isBooleanTrue(date.isActive) ||
-	(diff('seconds', parseISO(date.startDate), now) < 0 && diff('seconds', parseISO(date.endDate), now) > 0);
+/**
+ * Whether a datetime is active, based on its start and end date
+ *
+ * @param date The datetime object
+ * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
+ */
+const isActive = (date: Datetime, ignoreFlag?: boolean): boolean => {
+	return (
+		(!ignoreFlag && isBooleanTrue(date.isActive)) ||
+		(diff('seconds', parseISO(date.startDate), now) < 0 && diff('seconds', parseISO(date.endDate), now) > 0)
+	);
+};
 
 export default isActive;

--- a/packages/predicates/src/datetimes/isUpcoming.ts
+++ b/packages/predicates/src/datetimes/isUpcoming.ts
@@ -5,7 +5,14 @@ import { isBooleanTrue } from '@eventespresso/utils';
 import { diff } from '@eventespresso/dates';
 import { NOW as now } from '@eventespresso/constants';
 
-const isUpcoming = (date: Datetime): boolean =>
-	isBooleanTrue(date.isUpcoming) || diff('seconds', parseISO(date.startDate), now) > 0;
+/**
+ * Whether a datetime is upcoming, based on its start date
+ *
+ * @param date The datetime object
+ * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
+ */
+const isUpcoming = (date: Datetime, ignoreFlag?: boolean): boolean => {
+	return (!ignoreFlag && isBooleanTrue(date.isUpcoming)) || diff('seconds', parseISO(date.startDate), now) > 0;
+};
 
 export default isUpcoming;

--- a/packages/predicates/src/datetimes/isUpcoming.ts
+++ b/packages/predicates/src/datetimes/isUpcoming.ts
@@ -11,7 +11,7 @@ import { NOW as now } from '@eventespresso/constants';
  * @param date The datetime object
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-const isUpcoming = (date: Datetime, ignoreFlag?: boolean): boolean => {
+const isUpcoming = (date: Datetime, ignoreFlag = false): boolean => {
 	return (!ignoreFlag && isBooleanTrue(date.isUpcoming)) || diff('seconds', parseISO(date.startDate), now) > 0;
 };
 

--- a/packages/predicates/src/tickets/filters/allOnSaleAndPending/index.ts
+++ b/packages/predicates/src/tickets/filters/allOnSaleAndPending/index.ts
@@ -1,10 +1,11 @@
 import { anyPass, filter } from 'ramda';
+
 import isOnSale from '../../isOnSale';
 import isPending from '../../isPending';
 import type { TicketFilterFn } from '../types';
 
 const allOnSaleAndPending: TicketFilterFn = (tickets) => {
-	const isOnSaleOrIsPending = anyPass([isOnSale, isPending]);
+	const isOnSaleOrIsPending = anyPass<any>([isOnSale, isPending]);
 	const onSaleAndPending = filter(isOnSaleOrIsPending, tickets);
 	return onSaleAndPending;
 };

--- a/packages/predicates/src/tickets/filters/pendingOnly/index.ts
+++ b/packages/predicates/src/tickets/filters/pendingOnly/index.ts
@@ -1,8 +1,10 @@
+import * as R from 'ramda';
+
 import isPending from '../../isPending';
 import type { TicketFilterFn } from '../types';
 
 const pendingOnly: TicketFilterFn = (tickets) => {
-	return tickets.filter(isPending);
+	return R.filter(isPending, tickets);
 };
 
 export default pendingOnly;

--- a/packages/predicates/src/tickets/isOnSale/index.ts
+++ b/packages/predicates/src/tickets/isOnSale/index.ts
@@ -11,7 +11,7 @@ import type { Ticket } from '@eventespresso/edtr-services';
  * @param ticket The ticket object
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-const isOnSale = (ticket: Ticket, ignoreFlag?: boolean): boolean => {
+const isOnSale = (ticket: Ticket, ignoreFlag = false): boolean => {
 	return (
 		(!ignoreFlag && isBooleanTrue(ticket.isOnSale)) ||
 		(diff('minutes', parseISO(ticket.startDate), now) < 0 && diff('minutes', parseISO(ticket.endDate), now) > 0)

--- a/packages/predicates/src/tickets/isOnSale/index.ts
+++ b/packages/predicates/src/tickets/isOnSale/index.ts
@@ -5,8 +5,17 @@ import { diff } from '@eventespresso/dates';
 import { NOW as now } from '@eventespresso/constants';
 import type { Ticket } from '@eventespresso/edtr-services';
 
-const isOnSale = (ticket: Ticket): boolean =>
-	isBooleanTrue(ticket.isOnSale) ||
-	(diff('minutes', parseISO(ticket.startDate), now) < 0 && diff('minutes', parseISO(ticket.endDate), now) > 0);
+/**
+ * Whether a ticket is on sale, based on its start and end date
+ *
+ * @param ticket The ticket object
+ * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
+ */
+const isOnSale = (ticket: Ticket, ignoreFlag?: boolean): boolean => {
+	return (
+		(!ignoreFlag && isBooleanTrue(ticket.isOnSale)) ||
+		(diff('minutes', parseISO(ticket.startDate), now) < 0 && diff('minutes', parseISO(ticket.endDate), now) > 0)
+	);
+};
 
 export default isOnSale;

--- a/packages/predicates/src/tickets/isPending/index.ts
+++ b/packages/predicates/src/tickets/isPending/index.ts
@@ -6,12 +6,14 @@ import { NOW as now } from '@eventespresso/constants';
 import type { Ticket } from '@eventespresso/edtr-services';
 
 /**
- * @function
- * @param {Object} ticket object
- * @return {boolean} 	true if ticket is not yet available for purchase,
- * 						but will be at some date in the future
+ * Whether a ticket is not yet available for purchase,
+ * but will be at some date in the future, based on its start date
+ *
+ * @param ticket The ticket object
+ * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-const isPending = (ticket: Ticket): boolean =>
-	isBooleanTrue(ticket.isPending) || diff('minutes', parseISO(ticket.startDate), now) > 0;
+const isPending = (ticket: Ticket, ignoreFlag?: boolean): boolean => {
+	return (!ignoreFlag && isBooleanTrue(ticket.isPending)) || diff('minutes', parseISO(ticket.startDate), now) > 0;
+};
 
 export default isPending;

--- a/packages/predicates/src/tickets/isPending/index.ts
+++ b/packages/predicates/src/tickets/isPending/index.ts
@@ -12,7 +12,7 @@ import type { Ticket } from '@eventespresso/edtr-services';
  * @param ticket The ticket object
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
-const isPending = (ticket: Ticket, ignoreFlag?: boolean): boolean => {
+const isPending = (ticket: Ticket, ignoreFlag = false): boolean => {
 	return (!ignoreFlag && isBooleanTrue(ticket.isPending)) || diff('minutes', parseISO(ticket.startDate), now) > 0;
 };
 


### PR DESCRIPTION
This PR fixes the issue of date status not changed after bulk edit. The reason for that the bug was that the boolean flags for the entities were not updated which resulted in stale status information being displayed:
- It enhances boolean predicates related to dates
- Creates utils to update flags on bulk edit
- Wires everything up
- Adds some miscellaneous improvements