### PR TITLE
🔨 Move Toaster Import into useMutationWithFeedback Hook

### DIFF
--- a/domains/eventSmart/admin/upsellEditor/src/services/apollo/mutations/useUpsellAdMutator.ts
+++ b/domains/eventSmart/admin/upsellEditor/src/services/apollo/mutations/useUpsellAdMutator.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { ExecutionResult, MutationType, useMutationWithFeedback } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { __ } from '@eventespresso/i18n';
 
 import type { UpdateUpsellAdInput } from './types';
@@ -14,13 +13,10 @@ interface UpsellAdMutator {
 }
 
 const useUpsellAdMutator = (id = ''): UpsellAdMutator => {
-	const toaster = useSystemNotifications();
-
 	const updateUpsellAd = useMutationWithFeedback({
 		typeName: __('upsell ad'),
 		mutationType: MutationType.Update,
 		mutation: UPDATE_UPSELL_AD,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/domains/rem/src/services/apollo/mutations/recurrences/useRecurrenceMutator.ts
+++ b/domains/rem/src/services/apollo/mutations/recurrences/useRecurrenceMutator.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 
 import { MutationType, MutationFunction, useMutationWithFeedback } from '@eventespresso/data';
 import { useUpdateCallback, TypeName as EdtrTypeName } from '@eventespresso/edtr-services';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { __ } from '@eventespresso/i18n';
 
 import { CREATE_RECURRENCE, UPDATE_RECURRENCE, DELETE_RECURRENCE } from './';
@@ -20,28 +19,22 @@ interface RecurrenceMutator {
 type RM = RecurrenceMutator;
 
 const useRecurrenceMutator = (id = ''): RM => {
-	// create a single toaster instance to share between all mutations
-	const toaster = useSystemNotifications();
-
 	const createRecurrence = useMutationWithFeedback({
 		typeName: __('recurrence'),
 		mutationType: MutationType.Create,
 		mutation: CREATE_RECURRENCE,
-		toaster,
 	});
 
 	const updateRecurrence = useMutationWithFeedback({
 		typeName: __('recurrence'),
 		mutationType: MutationType.Update,
 		mutation: UPDATE_RECURRENCE,
-		toaster,
 	});
 
 	const deleteRecurrence = useMutationWithFeedback({
 		typeName: __('recurrence'),
 		mutationType: MutationType.Delete,
 		mutation: DELETE_RECURRENCE,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/packages/data/src/mutations/useMutationWithFeedback.ts
+++ b/packages/data/src/mutations/useMutationWithFeedback.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react';
 import { MutationTuple, OperationVariables, useMutation } from '@apollo/client';
 import { DocumentNode } from 'graphql';
 
-import type { SystemNotificationsToaster } from '@eventespresso/toaster';
+import { useSystemNotifications } from '@eventespresso/toaster';
 import { uuid } from '@eventespresso/utils';
 import { sprintf, __ } from '@eventespresso/i18n';
 
@@ -12,7 +12,6 @@ interface MutationWithFeedbackArgs {
 	typeName: string; // e.g. "Datetime", "Ticket", "PriceType"
 	mutation: DocumentNode;
 	mutationType: MutationType;
-	toaster: SystemNotificationsToaster;
 }
 
 type MutationWithFeedback = <TData = any, TVariables = OperationVariables>(
@@ -35,11 +34,13 @@ export const MUTATION_STRINGS: { [key in `${ResultType}:${MutationType}`]: strin
 	/* eslint-enable @wordpress/i18n-translator-comments */
 };
 
-const useMutationWithFeedback: MutationWithFeedback = ({ typeName, mutation, mutationType, toaster }) => {
+const useMutationWithFeedback: MutationWithFeedback = ({ typeName, mutation, mutationType }) => {
 	// generate a toaster key that sustains re-renders
 	const toasterKey = useRef(uuid());
 
 	const key = toasterKey.current;
+
+	const toaster = useSystemNotifications();
 
 	/**
 	 * Get the toaster message based upon typeName and mutationType

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useBulkEditDatetimes.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useBulkEditDatetimes.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { useMutationWithFeedback, MutationType } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { useDatetimeQueryOptions, useDatetimes } from '../../queries';
 import { BulkUpdateDatetimeInput, BULK_UPDATE_DATETIMES } from './';
 import useOnUpdateDatetime from './useOnUpdateDatetime';
@@ -17,7 +16,6 @@ interface BulkEditDatetimes {
 const useBulkEditDatetimes = (): BulkEditDatetimes => {
 	const allDatetimes = useDatetimes();
 	const queryOptions = useDatetimeQueryOptions();
-	const toaster = useSystemNotifications();
 	const updateDatetimeList = useUpdateDatetimeList();
 	const onUpdateDatetime = useOnUpdateDatetime();
 
@@ -25,7 +23,6 @@ const useBulkEditDatetimes = (): BulkEditDatetimes => {
 		typeName: SINGULAR_ENTITY_NAME.DATETIME,
 		mutationType: MutationType.Update,
 		mutation: BULK_UPDATE_DATETIMES,
-		toaster,
 	});
 
 	const updateEntityList = useCallback(

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useDatetimeMutator.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useDatetimeMutator.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { MutationType, MutationFunction, useMutationWithFeedback } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 import type { CreateDatetimeInput, UpdateDatetimeInput, DeleteDatetimeInput } from './types';
 import { CREATE_DATETIME, UPDATE_DATETIME, DELETE_DATETIME } from './';
@@ -20,28 +19,22 @@ interface DatetimeMutator {
 type DM = DatetimeMutator;
 
 const useDatetimeMutator = (id = ''): DM => {
-	// create a single toaster instance to share between all mutations
-	const toaster = useSystemNotifications();
-
 	const createDatetime = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.DATETIME,
 		mutationType: MutationType.Create,
 		mutation: CREATE_DATETIME,
-		toaster,
 	});
 
 	const updateDatetime = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.DATETIME,
 		mutationType: MutationType.Update,
 		mutation: UPDATE_DATETIME,
-		toaster,
 	});
 
 	const deleteDatetime = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.DATETIME,
 		mutationType: MutationType.Delete,
 		mutation: DELETE_DATETIME,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/packages/edtr-services/src/apollo/mutations/events/useEventMutator.ts
+++ b/packages/edtr-services/src/apollo/mutations/events/useEventMutator.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { MutationType, MutationFunction, useMutationWithFeedback } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 import type { UpdateEventInput } from './types';
 import { UPDATE_EVENT } from './';
@@ -16,13 +15,10 @@ interface EventMutator {
 type EM = EventMutator;
 
 const useEventMutator = (id = ''): EM => {
-	const toaster = useSystemNotifications();
-
 	const updateEvent = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.EVENT,
 		mutationType: MutationType.Update,
 		mutation: UPDATE_EVENT,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/packages/edtr-services/src/apollo/mutations/prices/usePriceMutator.ts
+++ b/packages/edtr-services/src/apollo/mutations/prices/usePriceMutator.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { MutationType, MutationFunction, useMutationWithFeedback } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 import { TypeName } from '../types';
 import { CREATE_PRICE, UPDATE_PRICE, DELETE_PRICE } from './';
@@ -20,28 +19,22 @@ interface PriceMutator {
 type PM = PriceMutator;
 
 const usePriceMutator = (id = ''): PM => {
-	// create a single toaster instance to share between all mutations
-	const toaster = useSystemNotifications();
-
 	const createPrice = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.PRICE,
 		mutationType: MutationType.Create,
 		mutation: CREATE_PRICE,
-		toaster,
 	});
 
 	const updatePrice = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.PRICE,
 		mutationType: MutationType.Update,
 		mutation: UPDATE_PRICE,
-		toaster,
 	});
 
 	const deletePrice = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.PRICE,
 		mutationType: MutationType.Delete,
 		mutation: DELETE_PRICE,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useBulkEditTickets.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import { identity } from 'ramda';
 
 import { useMutationWithFeedback, MutationType } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import type { TicketPred } from '@eventespresso/predicates';
 
 import type { TicketEdge, Ticket } from '../../types';
@@ -21,7 +20,6 @@ const useBulkEditTickets = (): BulkEditTickets => {
 	// ensure that bulk edit preserves default tickets
 	const allTickets = useTickets(identity as TicketPred);
 	const queryOptions = useTicketQueryOptions();
-	const toaster = useSystemNotifications();
 	const updateTicketList = useUpdateTicketList();
 	const onUpdateTicket = useOnUpdateTicket();
 
@@ -29,7 +27,6 @@ const useBulkEditTickets = (): BulkEditTickets => {
 		typeName: SINGULAR_ENTITY_NAME.TICKET,
 		mutationType: MutationType.Update,
 		mutation: BULK_UPDATE_TICKETS,
-		toaster,
 	});
 
 	const updateEntityList = useCallback(

--- a/packages/edtr-services/src/apollo/mutations/tickets/useTicketMutator.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useTicketMutator.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
 import { MutationType, MutationFunction, useMutationWithFeedback } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 import type { CreateTicketInput, UpdateTicketInput, DeleteTicketInput } from './types';
 import { CREATE_TICKET, UPDATE_TICKET, DELETE_TICKET } from './';
@@ -20,28 +19,22 @@ interface TicketMutator {
 type TM = TicketMutator;
 
 const useTicketMutator = (id = ''): TM => {
-	// create a single toaster instance to share between all mutations
-	const toaster = useSystemNotifications();
-
 	const createTicket = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.TICKET,
 		mutationType: MutationType.Create,
 		mutation: CREATE_TICKET,
-		toaster,
 	});
 
 	const updateTicket = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.TICKET,
 		mutationType: MutationType.Update,
 		mutation: UPDATE_TICKET,
-		toaster,
 	});
 
 	const deleteTicket = useMutationWithFeedback({
 		typeName: SINGULAR_ENTITY_NAME.TICKET,
 		mutationType: MutationType.Delete,
 		mutation: DELETE_TICKET,
-		toaster,
 	});
 
 	const mutationHandler = useMutationHandler();

--- a/packages/edtr-services/src/apollo/mutations/useBulkDeleteEntities.ts
+++ b/packages/edtr-services/src/apollo/mutations/useBulkDeleteEntities.ts
@@ -3,7 +3,6 @@ import { useMutationWithFeedback, gql, MutationType } from '@eventespresso/data'
 import type { ExecutionResult } from 'graphql';
 
 import type { EntityId } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 
 interface BulkDeleteEntitiesProps {
 	entityType: 'DATETIME' | 'TICKET' | 'PRICE';
@@ -28,12 +27,10 @@ const BULK_DELETE_ENTITIES = gql`
 `;
 
 const useBulkDeleteEntities = ({ entityType, typeName }: BulkDeleteEntitiesProps): Callback => {
-	const toaster = useSystemNotifications();
 	const bulkDelete = useMutationWithFeedback({
 		typeName,
 		mutationType: MutationType.Delete,
 		mutation: BULK_DELETE_ENTITIES,
-		toaster,
 	});
 
 	return useCallback<Callback>(

--- a/packages/form-builder/src/data/useElementMutator.ts
+++ b/packages/form-builder/src/data/useElementMutator.ts
@@ -7,7 +7,6 @@ import {
 	OperationVariables,
 	useMutationWithFeedback,
 } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { __ } from '@eventespresso/i18n';
 
 import type {
@@ -39,27 +38,22 @@ const createVariables = (mutationType: MutationType, input: MutationInput): Oper
 };
 
 export const useElementMutator = (id = ''): ElementMutator => {
-	const toaster = useSystemNotifications();
-
 	const createElement = useMutationWithFeedback({
 		typeName: __('element'),
 		mutationType: MutationType.Create,
 		mutation: CREATE_FORM_ELEMENT,
-		toaster,
 	});
 
 	const updateElement = useMutationWithFeedback({
 		typeName: __('element'),
 		mutationType: MutationType.Update,
 		mutation: UPDATE_FORM_ELEMENT,
-		toaster,
 	});
 
 	const deleteElement = useMutationWithFeedback({
 		typeName: __('element'),
 		mutationType: MutationType.Delete,
 		mutation: DELETE_FORM_ELEMENT,
-		toaster,
 	});
 
 	const createEntity = useCallback<ElementMutator['createEntity']>(

--- a/packages/form-builder/src/data/useSectionMutator.ts
+++ b/packages/form-builder/src/data/useSectionMutator.ts
@@ -7,7 +7,6 @@ import {
 	OperationVariables,
 	useMutationWithFeedback,
 } from '@eventespresso/data';
-import { useSystemNotifications } from '@eventespresso/toaster';
 import { __ } from '@eventespresso/i18n';
 
 import type {
@@ -39,27 +38,22 @@ const createVariables = (mutationType: MutationType, input: MutationInput): Oper
 };
 
 export const useSectionMutator = (id = ''): SectionMutator => {
-	const toaster = useSystemNotifications();
-
 	const createSection = useMutationWithFeedback({
 		typeName: __('section'),
 		mutationType: MutationType.Create,
 		mutation: CREATE_FORM_SECTION,
-		toaster,
 	});
 
 	const updateSection = useMutationWithFeedback({
 		typeName: __('section'),
 		mutationType: MutationType.Update,
 		mutation: UPDATE_FORM_SECTION,
-		toaster,
 	});
 
 	const deleteSection = useMutationWithFeedback({
 		typeName: __('section'),
 		mutationType: MutationType.Delete,
 		mutation: DELETE_FORM_SECTION,
-		toaster,
 	});
 
 	const createEntity = useCallback<SectionMutator['createEntity']>(


### PR DESCRIPTION
This PR moves the toaster import into `useMutationWithFeedback` hook to avoid duplicated imports and initializations of the toaster hook.

Closes #999