### PR TITLE
✨ Form Builder | mapsTo UI and EDTR Reg Form validation

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import * as R from 'ramda';
+
+import { FormBuilderProps } from '@eventespresso/form-builder';
+import { Banner } from '@eventespresso/ui-components';
+import { sprintf, __ } from '@eventespresso/i18n';
+import { isNotSharedOrDefault, getGuids } from '@eventespresso/predicates';
+
+const hasAttendeeFirstName = R.any(R.allPass([R.propEq('type', 'TEXT'), R.propEq('mapsTo', 'Attendee.fname')]));
+const hasAttendeeEmailName = R.any(R.allPass([R.propEq('type', 'EMAIL'), R.propEq('mapsTo', 'Attendee.email')]));
+
+export const ErrorMessage: FormBuilderProps['topBanner'] = ({ elements, sections }) => {
+	let message = '';
+
+	const info = useMemo(() => {
+		// Lets filter not consider default or shared sections
+		const formSectionIds = getGuids(Object.values(sections).filter(isNotSharedOrDefault));
+
+		const formElements = Object.values(elements).filter(
+			// filters out the elements that belong to shared or default section
+			R.propSatisfies(R.flip(R.includes)(formSectionIds), 'belongsTo')
+		);
+		return {
+			hasFirstName: hasAttendeeFirstName(formElements),
+			hasEmail: hasAttendeeEmailName(formElements),
+		};
+	}, [elements, sections]);
+
+	if (!info.hasFirstName) {
+		message = sprintf(
+			/* translators: field name */
+			__('Registration form must have a field of type "%1$s" which maps to "%2$s"'),
+			__('Text Input'),
+			__('Attendee First Name')
+		);
+	} else if (!info.hasEmail) {
+		message = sprintf(
+			/* translators: field name */
+			__('Registration form must have a field of type "%1$s" which maps to "%2$s"'),
+			__('Email Address'),
+			__('Attendee Email Address')
+		);
+	}
+
+	if (!message) {
+		return null;
+	}
+
+	return <Banner description={message} status='error' title={__('Please add the required fields')} />;
+};

--- a/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
@@ -5,15 +5,15 @@ import { FormBuilderProps } from '@eventespresso/form-builder';
 import { Banner } from '@eventespresso/ui-components';
 import { sprintf, __ } from '@eventespresso/i18n';
 import { isNotSharedOrDefault, getGuids } from '@eventespresso/predicates';
-
-const hasAttendeeFirstName = R.any(R.allPass([R.propEq('type', 'TEXT'), R.propEq('mapsTo', 'Attendee.fname')]));
-const hasAttendeeEmailName = R.any(R.allPass([R.propEq('type', 'EMAIL'), R.propEq('mapsTo', 'Attendee.email')]));
+import { hasAnElementAsAttendeeEmail, hasAnElementAsAttendeeFName } from './utils';
 
 export const ErrorMessage: FormBuilderProps['topBanner'] = ({ elements, sections }) => {
 	let message = '';
 
 	const info = useMemo(() => {
 		// Lets filter not consider default or shared sections
+		// because it is possible that there is valid data in default or shared sections/elements
+		// but not added to the event
 		const formSectionIds = getGuids(Object.values(sections).filter(isNotSharedOrDefault));
 
 		const formElements = Object.values(elements).filter(
@@ -21,8 +21,8 @@ export const ErrorMessage: FormBuilderProps['topBanner'] = ({ elements, sections
 			R.propSatisfies(R.flip(R.includes)(formSectionIds), 'belongsTo')
 		);
 		return {
-			hasFirstName: hasAttendeeFirstName(formElements),
-			hasEmail: hasAttendeeEmailName(formElements),
+			hasFirstName: hasAnElementAsAttendeeFName(formElements),
+			hasEmail: hasAnElementAsAttendeeEmail(formElements),
 		};
 	}, [elements, sections]);
 

--- a/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/ErrorMessage.tsx
@@ -11,7 +11,7 @@ export const ErrorMessage: FormBuilderProps['topBanner'] = ({ elements, sections
 	let message = '';
 
 	const info = useMemo(() => {
-		// Lets filter not consider default or shared sections
+		// Lets not consider default or shared sections
 		// because it is possible that there is valid data in default or shared sections/elements
 		// but not added to the event
 		const formSectionIds = getGuids(Object.values(sections).filter(isNotSharedOrDefault));

--- a/domains/core/admin/eventEditor/src/ui/registrationForm/RegistrationForm.tsx
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/RegistrationForm.tsx
@@ -4,6 +4,9 @@ import { Heading } from '@eventespresso/ui-components';
 import { FormBuilder } from '@eventespresso/form-builder';
 import { getEdtrDomData } from '@eventespresso/edtr-services';
 
+import { APPLIES_TO_OPTIONS, MAPS_TO_OPTIONS } from './constants';
+import { ErrorMessage } from './ErrorMessage';
+
 const header = (
 	<Heading as='h3' className='ee-edtr-section-heading'>
 		{__('Registration Form')}
@@ -12,12 +15,16 @@ const header = (
 
 export const RegistrationForm: React.FC = () => {
 	const { elements, sections, topLevelSectionId } = getEdtrDomData('formBuilder');
+
 	return (
 		<FormBuilder
+			appliesToOptions={APPLIES_TO_OPTIONS}
 			containerClassName='ee-edtr-section'
 			header={header}
 			initialElements={elements}
 			initialSections={sections}
+			mapsToOptions={MAPS_TO_OPTIONS}
+			topBanner={ErrorMessage}
 			topLevelSectionId={topLevelSectionId}
 			onChange={console.log}
 		/>

--- a/domains/core/admin/eventEditor/src/ui/registrationForm/constants.ts
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/constants.ts
@@ -1,0 +1,46 @@
+import { __ } from '@eventespresso/i18n';
+import type { OptionsType } from '@eventespresso/adapters';
+
+export type AppliesTo = 'ALL' | 'PRIMARY' | 'PURCHASER' | 'REGISTRANTS';
+
+export const APPLIES_TO_OPTIONS: OptionsType<AppliesTo> = [
+	{
+		value: 'ALL',
+		label: __('all'),
+	},
+	{
+		value: 'PRIMARY',
+		label: __('primary registrant'),
+	},
+	{
+		value: 'PURCHASER',
+		label: __('purchaser'),
+	},
+	{
+		value: 'REGISTRANTS',
+		label: __('registrants'),
+	},
+];
+
+export const MAPS_TO_OPTIONS: OptionsType = [
+	{
+		value: '',
+		label: '...',
+	},
+	{
+		value: 'Attendee.fname',
+		label: __('Attendee First Name'),
+	},
+	{
+		value: 'Attendee.lname',
+		label: __('Attendee Last Name'),
+	},
+	{
+		value: 'Attendee.email',
+		label: __('Attendee Email Address'),
+	},
+	{
+		value: 'Attendee.address',
+		label: __('Attendee Address'),
+	},
+];

--- a/domains/core/admin/eventEditor/src/ui/registrationForm/utils.ts
+++ b/domains/core/admin/eventEditor/src/ui/registrationForm/utils.ts
@@ -1,0 +1,19 @@
+import * as R from 'ramda';
+
+const hasTypeAsText = R.propEq('type', 'TEXT');
+const hasMapsToAsFName = R.propEq('mapsTo', 'Attendee.fname');
+const hasTypeAsTextAndMapsToAsFName = R.allPass([hasTypeAsText, hasMapsToAsFName]);
+/**
+ * Given a list of elements, it returns a boolean indicating whether there is
+ * an element which maps to 'Attendee.fname'
+ */
+export const hasAnElementAsAttendeeFName = R.any(hasTypeAsTextAndMapsToAsFName);
+
+const hasTypeAsEmail = R.propEq('type', 'EMAIL');
+const hasMapsToAsEmail = R.propEq('mapsTo', 'Attendee.email');
+const hasTypeAsEmailAndMapsToAsEmail = R.allPass([hasTypeAsEmail, hasMapsToAsEmail]);
+/**
+ * Given a list of elements, it returns a boolean indicating whether there is
+ * an element which maps to 'Attendee.email'
+ */
+export const hasAnElementAsAttendeeEmail = R.any(hasTypeAsEmailAndMapsToAsEmail);

--- a/packages/adapters/src/Select/types.ts
+++ b/packages/adapters/src/Select/types.ts
@@ -2,14 +2,14 @@ import type { SelectProps as ChakraSelectProps } from '@chakra-ui/react';
 
 import type { CommonInputProps } from '../types';
 
-export interface OptionProps {
+export interface OptionProps<T extends React.ReactText = React.ReactText> {
 	label?: React.ReactNode;
 	options?: Array<Omit<OptionProps, 'options'>>; // for optgroup
-	value?: React.ReactText;
+	value?: T;
 	[key: string]: any;
 }
 
-export type OptionsType = Array<OptionProps>;
+export type OptionsType<T extends React.ReactText = React.ReactText> = Array<OptionProps<T>>;
 
 export interface SelectProps extends ChakraSelectProps, CommonInputProps<HTMLSelectElement> {
 	options?: OptionsType;

--- a/packages/form-builder/src/FormBuilder.tsx
+++ b/packages/form-builder/src/FormBuilder.tsx
@@ -14,8 +14,14 @@ import type { FormBuilderProps } from './types';
 
 import './styles.scss';
 
-const FormBuilder: React.FC<FormBuilderProps> = ({ bodyClassName, containerClassName, contentClassName, header }) => {
-	const { getSections } = useFormState();
+const FormBuilder: React.FC<FormBuilderProps> = ({
+	bodyClassName,
+	containerClassName,
+	contentClassName,
+	header,
+	topBanner: TopBanner,
+}) => {
+	const { getSections, getData } = useFormState();
 
 	// handle save form
 	useSaveForm();
@@ -36,6 +42,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ bodyClassName, containerClass
 
 	return (
 		<Container classes={classes} header={header}>
+			{TopBanner && <TopBanner {...getData()} />}
 			<DragDropContext onDragEnd={handleDnD}>
 				<Droppable droppableId={SECTIONS_DROPPABLE_ID} type='section'>
 					{({ innerRef, droppableProps, placeholder }, { isDraggingOver }) => {

--- a/packages/form-builder/src/FormElement/Tabs/Settings.tsx
+++ b/packages/form-builder/src/FormElement/Tabs/Settings.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@eventespresso/i18n';
-import { SwitchWithLabel, TextInputWithLabel, withLabel } from '@eventespresso/ui-components';
+import { SwitchWithLabel, TextInputWithLabel, withLabel, SelectWithLabel } from '@eventespresso/ui-components';
 import { SimpleTextEditor } from '@eventespresso/rich-text-editor';
 
 import type { FormElementProps } from '../../types';
@@ -8,17 +8,20 @@ import { isFieldWithOptions } from '../../utils';
 import { useUpdateElement } from '../useUpdateElement';
 import { InputType } from './InputType';
 import { isFieldOfType } from '../../utils';
+import { useFormState } from '../../state';
 
 const RTEWithLabel = withLabel(SimpleTextEditor);
 
 export const Settings: React.FC<FormElementProps> = ({ element }) => {
 	const onChangeValue = useUpdateElement(element);
 
+	const { mapsToOptions } = useFormState();
+
 	return (
 		<>
 			{
 				// HTML doesn't need a public label
-				isFieldOfType(['HTML'], element) && (
+				!isFieldOfType(['HTML'], element) && (
 					<TextInputWithLabel
 						label={__('public label')}
 						onChangeValue={onChangeValue('label.publicLabel')}
@@ -62,6 +65,14 @@ export const Settings: React.FC<FormElementProps> = ({ element }) => {
 					/>
 					<InputType element={element} />
 				</>
+			)}
+			{mapsToOptions && (
+				<SelectWithLabel
+					label={__('maps to')}
+					onChangeValue={onChangeValue('mapsTo')}
+					value={element.mapsTo}
+					options={mapsToOptions}
+				/>
 			)}
 		</>
 	);

--- a/packages/form-builder/src/FormSection/AddFormElementPopover.tsx
+++ b/packages/form-builder/src/FormSection/AddFormElementPopover.tsx
@@ -49,10 +49,10 @@ export const AddFormElementPopover: React.FC<SidebarProps> = ({ formSection }) =
 			// make sure that new status is not 'SHARED' and `belongsTo` is not set
 			// just to let the reducer to add `belongsTo` as the `topLevelSection`
 			section = { ...R.omit(['belongsTo'], section), status: 'ACTIVE' };
-			copySection({ id: selectedSection, section });
+			copySection({ id: selectedSection, section, afterId: formSection.id });
 		}
 		onClose();
-	}, [copySection, onClose, selectedSection, sharedSections]);
+	}, [copySection, formSection.id, onClose, selectedSection, sharedSections]);
 
 	const onChangeElement = useCallback<SelectProps['onChangeValue']>((value) => {
 		setSelectedElement(value as ElementType);

--- a/packages/form-builder/src/FormSection/FormSectionToolbar.tsx
+++ b/packages/form-builder/src/FormSection/FormSectionToolbar.tsx
@@ -16,7 +16,7 @@ export const FormSectionToolbar = memo<FormSectionToolbarProps>(({ formSection, 
 	const { id } = formSection;
 	const active = isElementOpen({ id });
 
-	const onCopy = useCallback(() => copySection({ id, section: {} }), [id, copySection]);
+	const onCopy = useCallback(() => copySection({ id, section: {}, afterId: '' }), [id, copySection]);
 	const onDelete = useCallback(() => deleteSection({ id }), [id, deleteSection]);
 	const onToggle = useCallback(() => toggleOpenElement({ openElement: id }), [id, toggleOpenElement]);
 

--- a/packages/form-builder/src/FormSection/SaveSection.tsx
+++ b/packages/form-builder/src/FormSection/SaveSection.tsx
@@ -15,7 +15,11 @@ export const SaveSection: React.FC<FormSectionProps> = ({ formSection }) => {
 	const [value, setValue] = useState('SHARED');
 	const onSave = useCallback(() => {
 		// Lets create a copy of the section with status set to the selected value
-		copySection({ id: formSection.id, section: { status: value as FormStatus, belongsTo: '', order: 0 } });
+		copySection({
+			id: formSection.id,
+			section: { status: value as FormStatus, belongsTo: '', order: 0 },
+			afterId: '',
+		});
 	}, [copySection, formSection.id, value]);
 
 	const renderTrigger = useCallback<PopoverFormProps['renderTrigger']>(

--- a/packages/form-builder/src/FormSection/Tabs/Settings.tsx
+++ b/packages/form-builder/src/FormSection/Tabs/Settings.tsx
@@ -2,30 +2,14 @@ import { __ } from '@eventespresso/i18n';
 import { TextInputWithLabel, SwitchWithLabel, SelectWithLabel } from '@eventespresso/ui-components';
 
 import { useUpdateSection } from '../useUpdateSection';
+import { useFormState } from '../../state';
 
 import type { FormSectionProps } from '../../types';
 
-const APPLIES_TO_OPTIONS = [
-	{
-		value: 'ALL',
-		label: __('all'),
-	},
-	{
-		value: 'PRIMARY',
-		label: __('primary registrant'),
-	},
-	{
-		value: 'PURCHASER',
-		label: __('purchaser'),
-	},
-	{
-		value: 'REGISTRANTS',
-		label: __('registrants'),
-	},
-];
-
 export const Settings: React.FC<FormSectionProps> = ({ formSection }) => {
 	const onChangeValue = useUpdateSection(formSection);
+
+	const { appliesToOptions } = useFormState();
 
 	return (
 		<>
@@ -44,12 +28,14 @@ export const Settings: React.FC<FormSectionProps> = ({ formSection }) => {
 				onChangeValue={onChangeValue('label.showLabel')}
 				isChecked={formSection.label?.showLabel}
 			/>
-			<SelectWithLabel
-				label={__('applies to')}
-				onChangeValue={onChangeValue('appliesTo')}
-				value={formSection.appliesTo}
-				options={APPLIES_TO_OPTIONS}
-			/>
+			{appliesToOptions && (
+				<SelectWithLabel
+					label={__('applies to')}
+					onChangeValue={onChangeValue('appliesTo')}
+					value={formSection.appliesTo}
+					options={appliesToOptions}
+				/>
+			)}
 		</>
 	);
 };

--- a/packages/form-builder/src/context/FormStateProvider.tsx
+++ b/packages/form-builder/src/context/FormStateProvider.tsx
@@ -1,5 +1,7 @@
 import { createContext } from 'react';
 
+import type { OptionsType } from '@eventespresso/adapters';
+
 import { FormState, FormStateManager, useFormStateManager } from '../state';
 import { FormSectionRaw, FormElementRaw } from '../types';
 
@@ -8,8 +10,10 @@ const FormStateContext = createContext<FormStateManager>(null);
 const { Provider, Consumer: FormStateConsumer } = FormStateContext;
 
 export interface FormStateProviderProps {
-	initialSections?: Array<FormSectionRaw>;
+	appliesToOptions?: OptionsType;
 	initialElements?: Array<FormElementRaw>;
+	initialSections?: Array<FormSectionRaw>;
+	mapsToOptions?: OptionsType;
 	topLevelSectionId?: string;
 	onChange?: (data: FormState) => void;
 }

--- a/packages/form-builder/src/state/types.ts
+++ b/packages/form-builder/src/state/types.ts
@@ -47,11 +47,13 @@ export type FormStateManagerHook = (props?: FormStateProviderProps) => FormState
 
 type ArgsData = Required<DataAction>;
 
-export interface FormStateManager extends FormState {
+export interface FormStateManager
+	extends FormState,
+		Pick<FormStateProviderProps, 'appliesToOptions' | 'mapsToOptions'> {
 	addElement: (args: Pick<ArgsData, 'element'>) => void;
 	addSection: (args: Pick<ArgsData, 'section' | 'afterId'>) => void;
-	copyElement: (args: Pick<ArgsData, 'id'>) => void;
-	copySection: (args: Pick<ArgsData, 'section' | 'id'>) => void;
+	copyElement: (args: Pick<ArgsData, 'id' | 'afterId'>) => void;
+	copySection: (args: Pick<ArgsData, 'section' | 'id' | 'afterId'>) => void;
 	deleteElement: (args: Pick<ArgsData, 'id'>) => void;
 	deleteSection: (args: Pick<ArgsData, 'id'>) => void;
 	getData: () => FormState;

--- a/packages/form-builder/src/state/types.ts
+++ b/packages/form-builder/src/state/types.ts
@@ -52,7 +52,7 @@ export interface FormStateManager
 		Pick<FormStateProviderProps, 'appliesToOptions' | 'mapsToOptions'> {
 	addElement: (args: Pick<ArgsData, 'element'>) => void;
 	addSection: (args: Pick<ArgsData, 'section' | 'afterId'>) => void;
-	copyElement: (args: Pick<ArgsData, 'id' | 'afterId'>) => void;
+	copyElement: (args: Pick<ArgsData, 'id'>) => void;
 	copySection: (args: Pick<ArgsData, 'section' | 'id' | 'afterId'>) => void;
 	deleteElement: (args: Pick<ArgsData, 'id'>) => void;
 	deleteSection: (args: Pick<ArgsData, 'id'>) => void;

--- a/packages/form-builder/src/state/useFormStateManager.ts
+++ b/packages/form-builder/src/state/useFormStateManager.ts
@@ -9,7 +9,7 @@ import { useInitialState } from './useInitialState';
 
 type FSM = FormStateManager;
 
-export const useFormStateManager: FormStateManagerHook = ({ onChange, ...props }) => {
+export const useFormStateManager: FormStateManagerHook = ({ onChange, appliesToOptions, mapsToOptions, ...props }) => {
 	const initializer = useInitialState(props);
 	const reducer = useFormStateReducer(initializer);
 	const [state, dispatch] = useReducer(reducer, initialState, initializer);
@@ -49,11 +49,12 @@ export const useFormStateManager: FormStateManagerHook = ({ onChange, ...props }
 		});
 	}, []);
 
-	const copySection = useCallback<FSM['copySection']>(({ id, section }) => {
+	const copySection = useCallback<FSM['copySection']>(({ id, section, afterId }) => {
 		dispatch({
 			type: 'COPY_SECTION',
 			id,
 			section,
+			afterId,
 		});
 	}, []);
 
@@ -102,10 +103,11 @@ export const useFormStateManager: FormStateManagerHook = ({ onChange, ...props }
 		});
 	}, []);
 
-	const copyElement = useCallback<FSM['copyElement']>(({ id }) => {
+	const copyElement = useCallback<FSM['copyElement']>(({ id, afterId }) => {
 		dispatch({
 			type: 'COPY_ELEMENT',
 			id,
+			afterId,
 		});
 	}, []);
 
@@ -171,6 +173,7 @@ export const useFormStateManager: FormStateManagerHook = ({ onChange, ...props }
 			...state,
 			addElement,
 			addSection,
+			appliesToOptions,
 			copyElement,
 			copySection,
 			deleteElement,
@@ -181,6 +184,7 @@ export const useFormStateManager: FormStateManagerHook = ({ onChange, ...props }
 			getSharedSections,
 			isElementOpen,
 			isTopLevelSection,
+			mapsToOptions,
 			markElementAsDeleted,
 			markElementAsSaved,
 			markSectionAsDeleted,

--- a/packages/form-builder/src/state/useFormStateManager.ts
+++ b/packages/form-builder/src/state/useFormStateManager.ts
@@ -103,11 +103,10 @@ export const useFormStateManager: FormStateManagerHook = ({ onChange, appliesToO
 		});
 	}, []);
 
-	const copyElement = useCallback<FSM['copyElement']>(({ id, afterId }) => {
+	const copyElement = useCallback<FSM['copyElement']>(({ id }) => {
 		dispatch({
 			type: 'COPY_ELEMENT',
 			id,
-			afterId,
 		});
 	}, []);
 

--- a/packages/form-builder/src/state/useFormStateReducer.ts
+++ b/packages/form-builder/src/state/useFormStateReducer.ts
@@ -49,7 +49,7 @@ export const useFormStateReducer = (initializer: StateInitializer): FormStateRed
 				case 'COPY_SECTION': {
 					// Copied section will be composed of the existing section
 					const newSection = prepareNewSection({ ...state.sections[id], ...section });
-					predicates = [addSectionToState(newSection, id), copySectionElements(id, newSection.id)];
+					predicates = [addSectionToState(newSection, afterId || id), copySectionElements(id, newSection.id)];
 					break;
 				}
 
@@ -107,7 +107,7 @@ export const useFormStateReducer = (initializer: StateInitializer): FormStateRed
 				case 'COPY_ELEMENT': {
 					// Copied element will be composed of the existing element
 					const newElement = prepareNewElement(state.elements[id]);
-					predicates = [addElementToState(newElement, id)];
+					predicates = [addElementToState(newElement, afterId || id)];
 					break;
 				}
 

--- a/packages/form-builder/src/types.ts
+++ b/packages/form-builder/src/types.ts
@@ -1,5 +1,7 @@
 import type { DraggableProvidedDragHandleProps, OptionsType } from '@eventespresso/adapters';
 
+import { FormState } from './state';
+
 export type ElementType =
 	| 'BUTTON'
 	| 'CHECKBOX_MULTI'
@@ -102,10 +104,9 @@ export interface FormElement extends LocalOnlyFields {
 }
 
 export type FormStatus = 'ACTIVE' | 'ARCHIVED' | 'DEFAULT' | 'SHARED' | 'TRASHED';
-export type FormSectionAppliesTo = 'ALL' | 'PRIMARY' | 'PURCHASER' | 'REGISTRANTS';
 
 export interface FormSection extends LocalOnlyFields, Required<FormStatusFlags> {
-	appliesTo?: FormSectionAppliesTo;
+	appliesTo?: string;
 	attributes?: FormAttributes;
 	belongsTo?: string;
 	id: string;
@@ -129,6 +130,7 @@ export interface FormBuilderProps {
 	contentClassName?: string;
 	header?: React.ReactNode;
 	sidebarClassName?: string;
+	topBanner?: React.ComponentType<FormState>;
 }
 
 interface CommonProps {


### PR DESCRIPTION
This PR:
- Adds UI for `mapsTo` field for Form Builder elements
- It also moves the `appliesTo` options to the domain to decouple FB from domain logic, [more here](https://github.com/eventespresso/barista/issues/996#issuecomment-920631594).
- Wires up the new FB API with EDTR
- Adds validation banner under Registration Form header inside EDTR.
- Fixes a few minor issues in FB

Shoots 2 birds with single shot, closes #996, #1004 

![demo](https://user-images.githubusercontent.com/18226415/133646440-a2bf28ee-2b59-4bab-ae65-58d74da3d95e.gif)


