### PR TITLE
🐛 Fix console error in unit test for useEvent

### DIFF
--- a/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
+++ b/packages/edtr-services/src/apollo/queries/events/test/useEvent.test.ts
@@ -10,7 +10,7 @@ import useInitEventTestCache from './useInitEventTestCache';
 const mockEvent = nodes[0];
 
 describe('useEvent', () => {
-	it('returns undefined when the given event does not exist', async () => {
+	it('checks for non existent event when the cache is empty', async () => {
 		/* Set query options and the wrapper */
 		const {
 			result: { current: request },
@@ -24,8 +24,9 @@ describe('useEvent', () => {
 		const { result } = renderHook(() => useEvent(), {
 			wrapper,
 		});
+		await actWait();
 
-		expect(result.current).toBeUndefined();
+		expect(result.current).toEqual({});
 	});
 
 	it('checks for response data', async () => {


### PR DESCRIPTION
This PR fixes the console error in `useEvent` unit test as a result of recent Apollo upgrade.
`Warning: An update to TestComponent inside a test was not wrapped in act(...).`
The console error can be seen [here](https://github.com/eventespresso/barista/runs/3629516687?check_suite_focus=true).