### PR TITLE
🐛 Multiple fixes

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/ModalBody.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/ModalBody.tsx
@@ -29,7 +29,19 @@ const ModalBody: React.FC = () => {
 		(entity) => {
 			const ticketPrices = getTicketPrices(entity.id);
 			const prices = prepTemplatePrices(ticketPrices);
-			addTicket({ ...entity, isNew: true, dbId: 0, prices });
+			addTicket({
+				...entity,
+				isNew: true,
+				dbId: 0,
+				prices,
+				/**
+				 * Ensure that ticket is not trashed,
+				 * as it's possible that a trashed ticket is used as a template
+				 *
+				 * @see https://github.com/eventespresso/barista/issues/1013
+				 */
+				isTrashed: false,
+			});
 		},
 		[addTicket, getTicketPrices, prepTemplatePrices]
 	);

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/bulkEdit/prices/EditPrices.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/bulkEdit/prices/EditPrices.tsx
@@ -17,6 +17,7 @@ const EditPrices: React.FC<EditPricesBaseProps> = ({ onClose, isOpen }) => {
 			onClose={onClose}
 			closeOnOverlayClick={true}
 			title={__('Bulk edit ticket prices')}
+			showAlertOnClose={false}
 		>
 			{!editMode && <EditModeButtons setEditMode={setEditMode} />}
 			{editMode === 'together' && <EditTogether onClose={onClose} />}

--- a/packages/edtr-services/src/apollo/mutations/datetimes/useBulkDeleteDatetimes.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useBulkDeleteDatetimes.ts
@@ -8,9 +8,10 @@ import type { Datetime, DatetimeEdge, DatetimesList } from '../../types';
 import { useDatetimes, useDatetimeQueryOptions, DEFAULT_DATETIME_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
 import { useUpdateDatetimeList } from '../../../hooks';
 import useBulkDeleteEntities from '../useBulkDeleteEntities';
-import { TypeName, cacheNodesFromBulkDelete } from '../';
+import { cacheNodesFromBulkDelete } from '../';
 import useOnDeleteDatetime from './useOnDeleteDatetime';
 import useDeleteRelatedTickets from './useDeleteRelatedTickets';
+import { SINGULAR_ENTITY_NAME } from '../../../constants';
 
 type Callback<R = void> = (entityIds: Array<EntityId>, deletePermanently?: boolean) => R;
 
@@ -22,7 +23,7 @@ const useBulkDeleteDatetimes = (): Callback<Promise<ExecutionResult>> => {
 
 	const { cache } = useApolloClient();
 
-	const bulkDelete = useBulkDeleteEntities({ entityType: 'DATETIME', typeName: TypeName.Datetime });
+	const bulkDelete = useBulkDeleteEntities({ entityType: 'DATETIME', typeName: SINGULAR_ENTITY_NAME.DATETIME });
 
 	const deleteRelatedTickets = useDeleteRelatedTickets();
 

--- a/packages/edtr-services/src/apollo/mutations/tickets/useBulkDeleteTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useBulkDeleteTickets.ts
@@ -9,7 +9,8 @@ import type { Ticket, TicketsList } from '../../types';
 import { useTickets, useTicketQueryOptions, DEFAULT_TICKET_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
 import { useUpdateTicketList } from '../../../hooks';
 import useBulkDeleteEntities from '../useBulkDeleteEntities';
-import { TypeName, cacheNodesFromBulkDelete } from '../';
+import { cacheNodesFromBulkDelete } from '../';
+import { SINGULAR_ENTITY_NAME } from '../../../constants';
 import useOnDeleteTicket from './useOnDeleteTicket';
 
 type Callback<R = void> = (args: {
@@ -26,7 +27,7 @@ const useBulkDeleteTickets = (): Callback<Promise<ExecutionResult | void>> => {
 	const onDeleteTicket = useOnDeleteTicket();
 	const { cache } = useApolloClient();
 
-	const bulkDelete = useBulkDeleteEntities({ entityType: 'TICKET', typeName: TypeName.Ticket });
+	const bulkDelete = useBulkDeleteEntities({ entityType: 'TICKET', typeName: SINGULAR_ENTITY_NAME.TICKET });
 
 	const updateEntityList = useCallback<Callback<VoidFunction>>(
 		({ entityIds, deletePermanently, relatedDatetimeIds }) =>


### PR DESCRIPTION
This PR:

- Fixes i18n for bulk delete toaster feedback
- Disables unnecessary confirmation modal in bulk edit prices
- Fixes trashed tickets being copied into default tickets, thus fixes #1013 