### PR TITLE
Add path to manual e2e tests

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -22,7 +22,7 @@ jobs:
             # This step outputs a JSON object of e2e test paths - {"path": []}, which is passed to the e2e matrix
             - id: list
               run: echo "::set-output name=files::{\"path\":$(ls -d packages/e2e-tests/specs/* | jq -R -s -c 'split("\n")[:-1]')}"
-
+            # this step computes the matrix from the path given in inputs
             - id: input
               run: echo "::set-output name=path::{\"path\":[\"${{ github.event.inputs.path }}\"]}"
     e2e:

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -1,4 +1,4 @@
-name: E2E tests on master
+name: E2E tests
 
 on:
     push:
@@ -16,18 +16,21 @@ jobs:
     list-e2e-specs:
         runs-on: ubuntu-latest
         outputs:
-            specs: ${{ steps.list.outputs.files }}
+            specs: ${{ (github.event.inputs.path && steps.input.outputs.path) || steps.list.outputs.files }}
         steps:
             - uses: actions/checkout@v2
             # This step outputs a JSON object of e2e test paths - {"path": []}, which is passed to the e2e matrix
             - id: list
               run: echo "::set-output name=files::{\"path\":$(ls -d packages/e2e-tests/specs/* | jq -R -s -c 'split("\n")[:-1]')}"
+
+            - id: input
+              run: echo "::set-output name=path::{\"path\":[\"${{ github.event.inputs.path }}\"]}"
     e2e:
         name: E2E Tests
         needs: [list-e2e-specs]
         runs-on: ubuntu-latest
         strategy:
-            matrix: ${{ (github.event.inputs.path && [github.event.inputs.type]) || fromJSON(needs.list-e2e-specs.outputs.specs) }}
+            matrix: ${{ fromJSON(needs.list-e2e-specs.outputs.specs) }}
             fail-fast: false
         steps:
             - name: Checkout and yarn

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -5,6 +5,11 @@ on:
         branches: [master]
     # Allow to run E2E on demand
     workflow_dispatch:
+        inputs:
+            path:
+                description: 'Run E2E tests in path, e.g. `packages/e2e-tests/specs/admin`'
+                required: false
+                default: ''
 env:
     PLAYWRIGHT_BROWSERS_PATH: 0 # See https://playwright.dev/docs/ci/#caching-browsers
 jobs:
@@ -22,7 +27,7 @@ jobs:
         needs: [list-e2e-specs]
         runs-on: ubuntu-latest
         strategy:
-            matrix: ${{ fromJSON(needs.list-e2e-specs.outputs.specs) }}
+            matrix: ${{ (github.event.inputs.path && [github.event.inputs.type]) || fromJSON(needs.list-e2e-specs.outputs.specs) }}
             fail-fast: false
         steps:
             - name: Checkout and yarn


### PR DESCRIPTION
This PR adds a path filter to manual E2E tests workflow.

![image](https://user-images.githubusercontent.com/18226415/134864546-86a78a87-da6f-42c1-af09-ee5f85641a32.png)
