### PR TITLE
🐛 E2E | Fix bug in date predicates and the flags

### DIFF
--- a/packages/predicates/src/common/isExpired/index.ts
+++ b/packages/predicates/src/common/isExpired/index.ts
@@ -12,5 +12,5 @@ import { NOW as now } from '@eventespresso/constants';
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
 export const isExpired = (entity: Ticket | Datetime, ignoreFlag = false): boolean => {
-	return (!ignoreFlag && isBooleanTrue(entity.isExpired)) || diff('minutes', parseISO(entity.endDate), now) < 0;
+	return (!ignoreFlag && isBooleanTrue(entity.isExpired)) || diff('seconds', parseISO(entity.endDate), now) < 0;
 };

--- a/packages/predicates/src/tickets/isOnSale/index.ts
+++ b/packages/predicates/src/tickets/isOnSale/index.ts
@@ -14,7 +14,7 @@ import type { Ticket } from '@eventespresso/edtr-services';
 const isOnSale = (ticket: Ticket, ignoreFlag = false): boolean => {
 	return (
 		(!ignoreFlag && isBooleanTrue(ticket.isOnSale)) ||
-		(diff('minutes', parseISO(ticket.startDate), now) < 0 && diff('minutes', parseISO(ticket.endDate), now) > 0)
+		(diff('seconds', parseISO(ticket.startDate), now) < 0 && diff('seconds', parseISO(ticket.endDate), now) > 0)
 	);
 };
 

--- a/packages/predicates/src/tickets/isPending/index.ts
+++ b/packages/predicates/src/tickets/isPending/index.ts
@@ -13,7 +13,7 @@ import type { Ticket } from '@eventespresso/edtr-services';
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
 const isPending = (ticket: Ticket, ignoreFlag = false): boolean => {
-	return (!ignoreFlag && isBooleanTrue(ticket.isPending)) || diff('minutes', parseISO(ticket.startDate), now) > 0;
+	return (!ignoreFlag && isBooleanTrue(ticket.isPending)) || diff('seconds', parseISO(ticket.startDate), now) > 0;
 };
 
 export default isPending;


### PR DESCRIPTION
This PR updates `isOnSale`, `isPending` and `isExpired` predicates to calculate the difference in `seconds` instead of `minutes`.

Fixes #1031 