### PR TITLE
REM | Remove "Assign Dates" Step from Ticket Modal Form

### DIFF
--- a/domains/rem/src/ui/Tickets/multiStep/TicketFormSteps.tsx
+++ b/domains/rem/src/ui/Tickets/multiStep/TicketFormSteps.tsx
@@ -2,7 +2,7 @@ import { __ } from '@eventespresso/i18n';
 
 import { Steps, Step } from '@eventespresso/ui-components';
 import { PrevNext } from '@eventespresso/hooks';
-import { Calculator, Calendar, Ticket } from '@eventespresso/icons';
+import { Calculator, Ticket } from '@eventespresso/icons';
 
 const TicketFormSteps: React.FC<Pick<PrevNext, 'current'>> = ({ current }) => {
 	return (
@@ -13,7 +13,6 @@ const TicketFormSteps: React.FC<Pick<PrevNext, 'current'>> = ({ current }) => {
 				icon={Calculator}
 				title={__('Price Calculator')}
 			/>
-			<Step description={__('relations between tickets and dates')} icon={Calendar} title={__('Assign Dates')} />
 		</Steps>
 	);
 };


### PR DESCRIPTION
This PR removes "Assign Dates" Step from REM Editor's New Ticket Modal Form

Closes #1034 


![image](https://user-images.githubusercontent.com/18226415/135223890-8f41f3b4-ee98-48df-aa7f-9c515f133a1f.png)
