### PR TITLE
Add concurrency for PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,14 @@ on: [pull_request]
 env:
     PLAYWRIGHT_BROWSERS_PATH: 0 # See https://playwright.dev/docs/ci/#caching-browsers
 
+    # Cancels (by default) all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    # Cancel only if the commit message does not contain "no-cancel"
+    cancel-in-progress: ${{ !contains(github.event.commits[0].message, 'no-cancel') }}
+
 jobs:
     # JOB to check if the files in a path have changed
     what-is-hit:


### PR DESCRIPTION
This PR adds [`concurrency`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) support for PR checks workflow which cancels all previous workflow runs for pull requests that have not completed. This saves quite a bit of resources when pushing multiple commits to a PR branch.

If (for any reason) you don't want to cancel the in-progress workflow runs, just add `no-cancel` to your last commit message.