### PR TITLE
Add video capture

### DIFF
--- a/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
+++ b/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
@@ -1,4 +1,4 @@
-import { saveVideo } from 'playwright-video';
+import { saveVideo, PageVideoCapture } from 'playwright-video';
 
 import {
 	createNewEvent,
@@ -24,8 +24,10 @@ const tamrover = new TAMRover('datetime');
 
 const namespace = 'date-capacity-vs-ticket-qty';
 
+let capture: PageVideoCapture;
+
 beforeAll(async () => {
-	await saveVideo(page, `artifacts/${namespace}.mp4`);
+	capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
 
 	await createNewEvent({ title: namespace });
 
@@ -60,6 +62,10 @@ beforeAll(async () => {
 
 	// Lets now remove all the filters for tickets to make sure we can view all the tickets
 	await ticketsParser.removeAllFilters();
+});
+
+afterAll(async () => {
+	await capture?.stop();
 });
 
 describe(namespace, () => {


### PR DESCRIPTION
A couple of E2E tests failed unexpectedly after the last PR was merged into `master` - [barista/runs/3823672977](https://github.com/eventespresso/barista/runs/3823672977?check_suite_focus=true).
The failure is not consistent because it passed here - [barista/runs/3825564972](https://github.com/eventespresso/barista/runs/3825564972?check_suite_focus=true)

This PR adds the proper video capture to debug what actually happens during the tests. It will be helpful in future if that test fails again.