### PR TITLE
Ticket Price Calculator: Enforce Price Order

### DIFF
--- a/domains/eventSmart/admin/edtrSlots/src/constants.ts
+++ b/domains/eventSmart/admin/edtrSlots/src/constants.ts
@@ -1,4 +1,4 @@
 /* The namespace to use for actions/filters */
 export const NAMESPACE = 'es';
 
-export const ADVANCED_EDITOR_CAP = 'ee_advanced_event_editor';
+export const ADVANCED_EDITOR_CAP = 'use_advanced_event_editor';

--- a/packages/tpc/src/data/useDataReducer.ts
+++ b/packages/tpc/src/data/useDataReducer.ts
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
 import { any, append, findIndex, has, insert, last, update } from 'ramda';
 
-import { DataStateReducer, StateInitializer, DataState } from './types';
 import { entityHasGuid, isTax, sortByPriceOrderIdAsc } from '@eventespresso/predicates';
+
+import { DataStateReducer, StateInitializer, DataState } from './types';
 import { TpcPriceModifier } from '../types';
+import { enforceBasePriceOrder } from '../utils';
 
 export const initialState: DataState = {
 	ticket: null,
@@ -124,7 +126,7 @@ const useDataReducer = (initializer: StateInitializer): DataStateReducer => {
 
 					if (isOrderChanged) {
 						// sort them by order
-						updatedPrices = sortByPriceOrderIdAsc(updatedPrices);
+						updatedPrices = enforceBasePriceOrder(sortByPriceOrderIdAsc(updatedPrices));
 					}
 
 					isTaxable = any(isTax, updatedPrices);

--- a/packages/tpc/src/hooks/useAddDefaultTaxes.ts
+++ b/packages/tpc/src/hooks/useAddDefaultTaxes.ts
@@ -6,6 +6,7 @@ import { getDefaultTaxes, sortByPriceOrderIdAsc, getGuids } from '@eventespresso
 import usePricesPollInterval from './usePricesPollInterval';
 import { useDataState } from '../data';
 import usePriceToTpcModifier from './usePriceToTpcModifier';
+import { enforceBasePriceOrder } from '../utils';
 
 const useAddDefaultTaxes = (): VoidFunction => {
 	const allPrices = usePrices();
@@ -29,7 +30,7 @@ const useAddDefaultTaxes = (): VoidFunction => {
 		const newPrices = [...prices, ...newTpcDefaultTaxPriceModifiers];
 
 		//sort'em
-		const sortedPrices = sortByPriceOrderIdAsc(newPrices);
+		const sortedPrices = enforceBasePriceOrder(sortByPriceOrderIdAsc(newPrices));
 
 		setPrices(sortedPrices);
 	}, [convertPriceToTpcModifier, defaultTaxPrices, prices, setPrices, setPricesPollInterval]);

--- a/packages/tpc/src/hooks/usePrepTemplatePrices.ts
+++ b/packages/tpc/src/hooks/usePrepTemplatePrices.ts
@@ -7,6 +7,7 @@ import { uuid } from '@eventespresso/utils';
 import { TpcPriceModifier } from '../types';
 import usePriceToTpcModifier from './usePriceToTpcModifier';
 import useDefaultBasePrice from './useDefaultBasePrice';
+import { enforceBasePriceOrder } from '../utils';
 
 type PrepTemplatePrices = (templatePrices: Array<Price>, addBasePrice?: boolean) => Array<TpcPriceModifier>;
 
@@ -47,7 +48,7 @@ const usePrepTemplatePrices = (): PrepTemplatePrices => {
 			});
 
 			//sort'em
-			const sortedPrices = sortByPriceOrderIdAsc(prices);
+			const sortedPrices = enforceBasePriceOrder(sortByPriceOrderIdAsc(prices));
 
 			if (!addBasePrice) {
 				// if we're not going to add a base price,

--- a/packages/tpc/src/utils/utilities.ts
+++ b/packages/tpc/src/utils/utilities.ts
@@ -1,14 +1,20 @@
-import { prop } from 'ramda';
+import * as R from 'ramda';
 
 import type { Price, PriceType } from '@eventespresso/edtr-services';
 import type { EntityId } from '@eventespresso/data';
-import { findEntityByGuid, sortByPriceOrderIdAsc } from '@eventespresso/predicates';
+import {
+	findEntityByGuid,
+	sortByPriceOrderIdAsc,
+	getBasePrice,
+	getPriceModifiers,
+	isBasePrice,
+} from '@eventespresso/predicates';
 
 import type { TpcPriceModifier } from '../types';
 import type { PriceToTpcModifier } from '../hooks/usePriceToTpcModifier';
 
 // returns GUID for price modifier's related price type
-export const getPriceModifierPriceTypeGuid = (price: TpcPriceModifier): EntityId => prop('priceType', price);
+export const getPriceModifierPriceTypeGuid = (price: TpcPriceModifier): EntityId => R.prop('priceType', price);
 
 // returns price type for supplied price modifier if found in array of price types
 export const getPriceType =
@@ -36,8 +42,23 @@ export const preparePricesForTpc = (
 	convertPriceToTpcModifier: PriceToTpcModifier
 ): Array<TpcPriceModifier> => {
 	//sort'em
-	const sortedPrices = sortByPriceOrderIdAsc(prices);
+	const sortedPrices = enforceBasePriceOrder(sortByPriceOrderIdAsc(prices));
 
 	// convert to TPC price objects by adding "priceType"
 	return sortedPrices.map(convertPriceToTpcModifier);
+};
+
+export const enforceBasePriceOrder = <T extends Price>(prices: Array<T>) => {
+	const basePrice = getBasePrice(prices);
+
+	// if the list doesn't have a base price
+	// or base price is at 0 index
+	if (!basePrice || isBasePrice(R.head(prices))) {
+		// no need to change anything
+		return prices;
+	}
+	const priceModifiers = getPriceModifiers(prices);
+
+	// place base price at the beginning
+	return [basePrice, ...priceModifiers];
 };


### PR DESCRIPTION
This PR enforces the order of prices to ensure base price is at the beginning of the list.
It also fixes a bug in ES domain that marked all tickets as disabled/locked.

Fixes #1045 

![image](https://user-images.githubusercontent.com/18226415/137108495-2a66fe58-2092-4944-8cda-bd8116f4b5fa.png)
