### PR TITLE
Fix E2E tests for REM and Date capacity vs ticket quantity

### DIFF
--- a/packages/e2e-tests/specs/add-ons/rem/index.test.ts
+++ b/packages/e2e-tests/specs/add-ons/rem/index.test.ts
@@ -48,8 +48,6 @@ describe('REM', () => {
 
 		await clickButton('Next');
 
-		await page.click('#ee-add-new-datetime');
-
 		await page.focus('.ee-render-fields >> text=Name');
 
 		await page.type('.ee-render-fields >> text=Name', 'New date');

--- a/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
+++ b/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
@@ -69,7 +69,7 @@ afterAll(async () => {
 });
 
 const scrollToAddNewTicketBtn = async () =>
-	(await page.$('[type=button] >> text=Add New Ticket')).scrollIntoViewIfNeeded;
+	await (await page.$('[type=button] >> text=Add New Ticket')).scrollIntoViewIfNeeded();
 
 describe(namespace, () => {
 	it('tests the default date capacity and ticket quantity', async () => {

--- a/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
+++ b/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
@@ -68,7 +68,8 @@ afterAll(async () => {
 	await capture?.stop();
 });
 
-const focusAddNewTicketBtn = async () => await page.focus('[type=button] >> text=Add New Ticket');
+const scrollToAddNewTicketBtn = async () =>
+	(await page.$('[type=button] >> text=Add New Ticket')).scrollIntoViewIfNeeded;
 
 describe(namespace, () => {
 	it('tests the default date capacity and ticket quantity', async () => {
@@ -82,7 +83,7 @@ describe(namespace, () => {
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
 		expect(newTicketQuantity).toBe('∞');
 		// Default ticket quantity is 100 by default
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('100');
 	});
 
@@ -96,7 +97,7 @@ describe(namespace, () => {
 
 		let oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
 		// This should not have changed, because it's already less than old date capacity
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('100');
 
 		// Set the old date capacity to 90
@@ -104,12 +105,12 @@ describe(namespace, () => {
 
 		oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
 		// This should now be set to 90
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('90');
 
 		// New ticket quantity should remain unchanged
 		let newTicketQuantity = await getTicketQuantityByName(newTicketName);
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('∞');
 
 		const newDate = await dateEditor.getItemBy('name', newDateName);
@@ -121,7 +122,7 @@ describe(namespace, () => {
 
 		// This should now be set to 300
 		newTicketQuantity = await getTicketQuantityByName(newTicketName);
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('300');
 
 		oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
@@ -134,7 +135,7 @@ describe(namespace, () => {
 		await dateEditor.editDateBy('name', newDateName, { capacity: '200' });
 
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('200');
 	});
 
@@ -144,7 +145,7 @@ describe(namespace, () => {
 		await addNewDate({ name: 'One more new date', capacity: '60' });
 
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('60');
 
 		const oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
@@ -165,7 +166,7 @@ describe(namespace, () => {
 
 		// Now the old ticket quantity should have changed from 90 to 60
 		const oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
-		await focusAddNewTicketBtn(); // for debugging
+		await scrollToAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('60');
 	});
 });

--- a/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
+++ b/packages/e2e-tests/specs/shared/date-capacity-vs-ticket-qty.test.ts
@@ -68,6 +68,8 @@ afterAll(async () => {
 	await capture?.stop();
 });
 
+const focusAddNewTicketBtn = async () => await page.focus('[type=button] >> text=Add New Ticket');
+
 describe(namespace, () => {
 	it('tests the default date capacity and ticket quantity', async () => {
 		const oldDateCapacity = await getDateCapacityByName(oldDateName);
@@ -80,6 +82,7 @@ describe(namespace, () => {
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
 		expect(newTicketQuantity).toBe('∞');
 		// Default ticket quantity is 100 by default
+		await focusAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('100');
 	});
 
@@ -93,6 +96,7 @@ describe(namespace, () => {
 
 		let oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
 		// This should not have changed, because it's already less than old date capacity
+		await focusAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('100');
 
 		// Set the old date capacity to 90
@@ -100,10 +104,12 @@ describe(namespace, () => {
 
 		oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
 		// This should now be set to 90
+		await focusAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('90');
 
 		// New ticket quantity should remain unchanged
 		let newTicketQuantity = await getTicketQuantityByName(newTicketName);
+		await focusAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('∞');
 
 		const newDate = await dateEditor.getItemBy('name', newDateName);
@@ -115,6 +121,7 @@ describe(namespace, () => {
 
 		// This should now be set to 300
 		newTicketQuantity = await getTicketQuantityByName(newTicketName);
+		await focusAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('300');
 
 		oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
@@ -127,6 +134,7 @@ describe(namespace, () => {
 		await dateEditor.editDateBy('name', newDateName, { capacity: '200' });
 
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
+		await focusAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('200');
 	});
 
@@ -136,6 +144,7 @@ describe(namespace, () => {
 		await addNewDate({ name: 'One more new date', capacity: '60' });
 
 		const newTicketQuantity = await getTicketQuantityByName(newTicketName);
+		await focusAddNewTicketBtn(); // for debugging
 		expect(newTicketQuantity).toBe('60');
 
 		const oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
@@ -156,6 +165,7 @@ describe(namespace, () => {
 
 		// Now the old ticket quantity should have changed from 90 to 60
 		const oldTicketQuantity = await getTicketQuantityByName(oldTicketName);
+		await focusAddNewTicketBtn(); // for debugging
 		expect(oldTicketQuantity).toBe('60');
 	});
 });


### PR DESCRIPTION
This PR
- Fixes the continuously [failing E2E tests](https://github.com/eventespresso/barista/runs/3885733006?check_suite_focus=true) for Date capacity vs Ticket quantity.
- Fixes the REM [E2E tests failing](https://github.com/eventespresso/barista/runs/3897920616?check_suite_focus=true) after the removal of Add New date button in date details step in #1048 