### PR TITLE
Fix Chakra Colour Mode

### DIFF
--- a/packages/adapters/src/theme/ThemeProvider.tsx
+++ b/packages/adapters/src/theme/ThemeProvider.tsx
@@ -1,15 +1,20 @@
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme, LightMode } from '@chakra-ui/react';
 
 import { isRTL } from '@eventespresso/i18n';
 
-const theme = extendTheme({ styles: null, direction: isRTL() ? 'rtl' : 'ltr' });
+const theme = extendTheme({
+	direction: isRTL() ? 'rtl' : 'ltr',
+	initialColorMode: 'light',
+	styles: null,
+	useSystemColorMode: false,
+});
 
 const environment = { window, document };
 
 const ThemeProvider: React.FC = ({ children }) => {
 	return (
 		<ChakraProvider theme={theme} resetCSS environment={environment}>
-			{children}
+			<LightMode>{children}</LightMode>
 		</ChakraProvider>
 	);
 };


### PR DESCRIPTION
After the most recent Chakra UI update, some of the components were taking on the dark mode color theme if your system was set to use a dark theme.

![chakra-dark-mode](https://user-images.githubusercontent.com/1751030/140991576-241d6f08-48c5-4d0d-b515-dd6788fe19c9.png)


This PR: 

- adds color mode props to our custom theme config
- completely overrides everything by wrapping our entire app with a `LightMode` component. This will be removed in the future after we refactor things to accommodate dark mode themes.

