### PR TITLE
Fix E2E tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,6 @@
 **/coverage/**
 **/build/**
 **/.git/**
-**/public/**
+/public/**
 !.eslintrc.js
 **/**/*.ts

--- a/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
+++ b/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
@@ -1,6 +1,7 @@
 import { saveVideo, PageVideoCapture } from 'playwright-video';
 
 import { addNewTicket, createNewEvent, EDTRGlider, TicketEditor } from '@e2eUtils/admin/events';
+import { Goto } from '@e2eUtils/admin';
 import { assertRegSuccess, EventRegistrar } from '@e2eUtils/public/reg-checkout';
 
 const namespace = 'event.free-event.registration';
@@ -21,6 +22,10 @@ const edtrGlider = new EDTRGlider();
 
 describe(namespace, () => {
 	it('should show thank you message if everything went well', async () => {
+		await Goto.themesPage();
+
+		await page.waitForTimeout(15000);
+
 		await createNewEvent({ title: 'Free event' });
 
 		await ticketEditor.updateQuantityInline(null, 75);

--- a/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
+++ b/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
@@ -1,7 +1,7 @@
 import { saveVideo, PageVideoCapture } from 'playwright-video';
 
 import { addNewTicket, createNewEvent, EDTRGlider, TicketEditor } from '@e2eUtils/admin/events';
-import { EventRegistrar } from '@e2eUtils/public/reg-checkout';
+import { assertRegSuccess, EventRegistrar } from '@e2eUtils/public/reg-checkout';
 
 const namespace = 'event.free-event.registration';
 
@@ -36,8 +36,8 @@ describe(namespace, () => {
 			},
 		});
 
-		const content = await page.$eval('.entry-content', (el) => el.textContent);
-		expect(content).toContain('Your registration has been successfully processed.');
-		expect(content).toContain('View Full Order Confirmation Receipt');
+		const content = await assertRegSuccess();
+
+		expect(content).toContain('Approved');
 	});
 });

--- a/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
+++ b/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
@@ -36,10 +36,8 @@ describe(namespace, () => {
 			},
 		});
 
-		const title = await page.$eval('h1.entry-title', (el) => el.textContent);
-		expect(title).toContain('Thank You');
-
 		const content = await page.$eval('.entry-content', (el) => el.textContent);
-		expect(content).toContain('Congratulations');
+		expect(content).toContain('Your registration has been successfully processed.');
+		expect(content).toContain('View Full Order Confirmation Receipt');
 	});
 });

--- a/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
+++ b/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
@@ -1,12 +1,18 @@
-import { saveVideo } from 'playwright-video';
+import { saveVideo, PageVideoCapture } from 'playwright-video';
 
 import { addNewTicket, createNewEvent, EDTRGlider, TicketEditor } from '@e2eUtils/admin/events';
 import { EventRegistrar } from '@e2eUtils/public/reg-checkout';
 
 const namespace = 'event.free-event.registration';
 
+let capture: PageVideoCapture;
+
 beforeAll(async () => {
-	await saveVideo(page, `artifacts/${namespace}.mp4`);
+	capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
+});
+
+afterAll(async () => {
+	await capture?.stop();
 });
 
 const ticketEditor = new TicketEditor();

--- a/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
+++ b/packages/e2e-tests/specs/public/single-page-checkout/registration-scenarios/index.test.ts
@@ -1,7 +1,6 @@
 import { saveVideo, PageVideoCapture } from 'playwright-video';
 
 import { addNewTicket, createNewEvent, EDTRGlider, TicketEditor } from '@e2eUtils/admin/events';
-import { Goto } from '@e2eUtils/admin';
 import { assertRegSuccess, EventRegistrar } from '@e2eUtils/public/reg-checkout';
 
 const namespace = 'event.free-event.registration';
@@ -22,10 +21,6 @@ const edtrGlider = new EDTRGlider();
 
 describe(namespace, () => {
 	it('should show thank you message if everything went well', async () => {
-		await Goto.themesPage();
-
-		await page.waitForTimeout(15000);
-
 		await createNewEvent({ title: 'Free event' });
 
 		await ticketEditor.updateQuantityInline(null, 75);

--- a/packages/e2e-tests/specs/shared/two-dates-two-tickets.test.ts
+++ b/packages/e2e-tests/specs/shared/two-dates-two-tickets.test.ts
@@ -1,5 +1,5 @@
 import { addNewDate, addNewTicket, createNewEvent, editEntityCard, EDTRGlider } from '@e2eUtils/admin/events';
-import { EventRegistrar } from '@e2eUtils/public/reg-checkout';
+import { assertRegSuccess, EventRegistrar } from '@e2eUtils/public/reg-checkout';
 
 const namespace = 'event.entities.reigstration-2';
 
@@ -35,15 +35,12 @@ describe(namespace, () => {
 				fname: 'Joe',
 				lname: 'Doe',
 				email: 'test@example.com',
-				address: '3868  Burton Avenue',
+				address: '3868 Burton Avenue',
 			},
 		});
 
-		const title = await page.$eval('h1.entry-title', (el) => el.textContent);
-		expect(title).toContain('Thank You');
+		const content = await assertRegSuccess();
 
-		const content = await page.$eval('.entry-content', (el) => el.textContent);
-		expect(content).toContain('Congratulations');
 		expect(content).toContain('Approved');
 	});
 });

--- a/packages/e2e-tests/utils/admin/Goto.ts
+++ b/packages/e2e-tests/utils/admin/Goto.ts
@@ -10,10 +10,18 @@ export class Goto {
 	static async eventsListPage() {
 		await visitAdminPage('admin.php', 'page=espresso_events');
 	}
+
 	/**
 	 * Navigates to "/wp-admin/plugins.php"
 	 */
 	static async pluginsPage() {
 		await visitAdminPage('plugins.php');
+	}
+
+	/**
+	 * Navigates to "/wp-admin/themes.php"
+	 */
+	static async themesPage() {
+		await visitAdminPage('themes.php');
 	}
 }

--- a/packages/e2e-tests/utils/public/reg-checkout/assertRegSuccess.ts
+++ b/packages/e2e-tests/utils/public/reg-checkout/assertRegSuccess.ts
@@ -1,0 +1,12 @@
+/**
+ * Asserts that the registration is successful.
+ */
+export const assertRegSuccess = async (): Promise<string> => {
+	const content = await page.$eval('.entry-content', (el) => el.textContent);
+
+	expect(content).toContain('Your registration has been successfully processed.');
+
+	expect(content).toContain('View Full Order Confirmation Receipt');
+
+	return content;
+};

--- a/packages/e2e-tests/utils/public/reg-checkout/index.ts
+++ b/packages/e2e-tests/utils/public/reg-checkout/index.ts
@@ -1,2 +1,3 @@
+export * from './assertRegSuccess';
 export * from './EventRegistrar';
 export * from './fillAttendeeInformation';


### PR DESCRIPTION
This PR fixes the [failing E2E tests](https://github.com/eventespresso/barista/runs/4163587508?check_suite_focus=true) after #1086 was merged. After debugging, I observed that the theme used in the docker container WP installation via `wp-env` is something very basic which doesn't have a title `<h1>` on registration confirmation page. So, this PR removes that unreliable assertion and uses only the content for assertion.

It also fixes an issue in ES Lint config that ignored the files placed in a directory named `public` anywhere in the codebase.

![screenshot](https://user-images.githubusercontent.com/18226415/141106146-ff206066-7414-4e84-9ac0-4162a737169f.png)
