### PR TITLE
don't copy reserved or sold counts when cloning

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/useActions.ts
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/useActions.ts
@@ -31,10 +31,9 @@ const useActions = (datetimeId: EntityId): Actions => {
 
 	const copyDate = useCallback(() => {
 		const newDatetime = R.pick(
-			['capacity', 'description', 'endDate', 'isPrimary', 'name', 'order', 'reserved', 'sold', 'startDate'],
+			['capacity', 'description', 'endDate', 'isPrimary', 'name', 'order', 'startDate'],
 			datetime
 		);
-
 		return createEntity({ ...newDatetime, eventId, tickets });
 	}, [createEntity, datetime, eventId, tickets]);
 


### PR DESCRIPTION
see; https://github.com/eventespresso/event-espresso-core/issues/3592

The work in https://github.com/eventespresso/event-espresso-core/pull/3590 handles updating the sold and reserved counts on datetimes whenever datetime ticket relations change. 

Currently when copying an event datetime, we copy over the sold and reserved counts from the original datetime because those values were NOT updated when the ticket relations were added. But now they are.

This PR simply removes the reserved and sold properties from those that are copied over when a datetime is duplicated.

The work done by Manzoor https://github.com/eventespresso/barista/pull/1092 means that the sold and reserved counts on the copied datetime get updated moments after copying once the server has finished updating the relations. The same updates occur after modifying relations in the ticket assignments manager.