### PR TITLE
E2E test for default registration status.

### DIFF
--- a/packages/e2e-tests/specs/admin/events/default-settings/defaultRegistrationStatus.test.ts
+++ b/packages/e2e-tests/specs/admin/events/default-settings/defaultRegistrationStatus.test.ts
@@ -1,0 +1,46 @@
+import { saveVideo, PageVideoCapture } from 'playwright-video';
+import { Goto, DefaultSettingsManager } from '@e2eUtils/admin';
+import { defaultRegStatusOptions } from '../../../shared/data';
+
+const defaultSettingsManager = new DefaultSettingsManager();
+
+const namespace = 'default-settings-registration-status';
+let capture: PageVideoCapture;
+
+beforeAll(async () => {
+	capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
+	await Goto.eventsListPage();
+	// go to default settings tab
+	await defaultSettingsManager.gotoDefaultSettings();
+});
+
+afterAll(async () => {
+	await capture?.stop();
+});
+
+describe('Default registration status test', () => {
+	it('Check selected default registration status', async () => {
+		// Get selected default status and return weither option value or innertext of the option
+		const getSelectedDefaultStatus = await defaultSettingsManager.getSelectedDefaultStatus({ value: true });
+		// assert the current selected registration status
+		expect(getSelectedDefaultStatus).toBe(defaultRegStatusOptions[getSelectedDefaultStatus].value);
+	});
+
+	it('Select approved default registration status', async () => {
+		// Process to select default registration status base on option value
+		const afterSelectStatus = await defaultSettingsManager.processToSelectRegStatus(
+			defaultRegStatusOptions.RAP.value
+		);
+		// assert before and after selecting new registration status
+		expect(afterSelectStatus).toBe(defaultRegStatusOptions.RAP.value);
+	});
+
+	it('Select not approved default registration status', async () => {
+		// Process to select default registration status base on option value
+		const afterSelectStatus = await defaultSettingsManager.processToSelectRegStatus(
+			defaultRegStatusOptions.RNA.value
+		);
+		// assert before and after selecting new registration status
+		expect(afterSelectStatus).toBe(defaultRegStatusOptions.RNA.value);
+	});
+});

--- a/packages/e2e-tests/specs/shared/data.ts
+++ b/packages/e2e-tests/specs/shared/data.ts
@@ -83,3 +83,10 @@ export const eventData = {
 export const categoryData = {
 	sample: { title: 'Sample category', description: 'Sample category description' },
 };
+
+// data use create sample category
+export const defaultRegStatusOptions = {
+	RAP: { value: 'RAP', text: 'Approved' },
+	RNA: { value: 'RNA', text: 'Not Approved' },
+	RPP: { value: 'RPP', text: 'Pending Payment' },
+};

--- a/packages/e2e-tests/utils/admin/events/default-settings/DefaultSettingsManager.ts
+++ b/packages/e2e-tests/utils/admin/events/default-settings/DefaultSettingsManager.ts
@@ -1,0 +1,65 @@
+import { Goto } from '@e2eUtils/admin';
+import { WPListTable } from '../../WPListTable';
+
+export class DefaultSettingsManager extends WPListTable {
+	/**
+	 * go to default settings tab
+	 */
+	gotoDefaultSettings = async (): Promise<void> => {
+		const linkCategories = await page.$(`.nav-tab-wrapper a:has-text("Default Settings")`);
+		const hrefCategories = await linkCategories.getAttribute('href');
+		await Promise.all([page.waitForNavigation(), page.goto(hrefCategories)]);
+	};
+
+	/**
+	 * Trigger save at update settings section
+	 */
+	updateSettingsSave = async (): Promise<void> => {
+		// select delete category from bulk action
+		await Promise.all([page.waitForNavigation(), page.click('input#default_event_settings_save')]);
+	};
+
+	/**
+	 * Get selected default status and return weither option value or innertext of the option
+	 */
+	getSelectedDefaultStatus = async ({ value = false, text = false }): Promise<string> => {
+		// select the option for registration default status
+		const wrapper = await page.$(
+			'select#update_default_event_settings-default-reg-status option[selected="selected"]'
+		);
+
+		// if value is equal to true return the value of selected option
+		if (value) {
+			return await wrapper.getAttribute('value');
+		}
+		// if text is equal to true return the innertext of selected option
+		if (text) {
+			return await wrapper.innerText();
+		}
+	};
+
+	/**
+	 * Select default registration status base on option value
+	 */
+	selectDefaultRegStatus = async (optionValue: string): Promise<void> => {
+		// select delete category from bulk action
+		await page.selectOption('select#update_default_event_settings-default-reg-status', {
+			value: optionValue,
+		});
+		await this.updateSettingsSave();
+	};
+
+	/**
+	 * Process to select default registration status base on option value
+	 */
+	processToSelectRegStatus = async (optionValue: string): Promise<string> => {
+		// Select default registration status base on option value
+		await this.selectDefaultRegStatus(optionValue);
+		// go to main event admin page
+		await Goto.eventsListPage();
+		// go to default settings tab
+		await this.gotoDefaultSettings();
+		// Get selected default status and return weither option value or innertext of the option
+		return await this.getSelectedDefaultStatus({ value: true });
+	};
+}

--- a/packages/e2e-tests/utils/admin/events/default-settings/index.ts
+++ b/packages/e2e-tests/utils/admin/events/default-settings/index.ts
@@ -1,0 +1,1 @@
+export * from './DefaultSettingsManager';

--- a/packages/e2e-tests/utils/admin/events/index.ts
+++ b/packages/e2e-tests/utils/admin/events/index.ts
@@ -1,3 +1,4 @@
+export * from './categories';
+export * from './default-settings';
 export * from './editor';
 export * from './list';
-export * from './categories';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37426301/146402088-0dcb6191-104b-4d45-9f9a-d4d85367ce87.png)

For this ticket:

- Create E2E test for default registration status at default settings admin.