### PR TITLE
E2E test for custom display order

### DIFF
--- a/packages/e2e-tests/specs/admin/events/templates/useCustomDisplayOrder.test.ts
+++ b/packages/e2e-tests/specs/admin/events/templates/useCustomDisplayOrder.test.ts
@@ -1,0 +1,39 @@
+import { saveVideo, PageVideoCapture } from 'playwright-video';
+import { Goto, TemplatesManager } from '@e2eUtils/admin';
+
+const templatesManager = new TemplatesManager();
+
+const namespace = 'templates-use-custom-display-order';
+let capture: PageVideoCapture;
+
+beforeAll(async () => {
+	capture = await saveVideo(page, `artifacts/${namespace}.mp4`);
+	// Remove all event from link actions (View all events, Draft, Trash)
+	await Goto.eventsListPage();
+	//  go to templates tab
+	await templatesManager.gotoTemplates();
+});
+
+afterAll(async () => {
+	await capture?.stop();
+});
+
+describe('Display status banner test', () => {
+	it('Set use custom display order to No', async () => {
+		// set custom display order to "No"
+		await templatesManager.setCustomDisplayOrder({ value: '0' });
+		// get event single sortable attribute classname value
+		const getClassName = await templatesManager.getEventSingleSortableAttribute('class');
+		// assert attribute classname value
+		expect(getClassName).toBe('ui-sortable ui-sortable-disabled');
+	});
+
+	it('Set use custom display order to Yes', async () => {
+		// set custom display order to "Yes"
+		await templatesManager.setCustomDisplayOrder({ value: '1' });
+		// get event single sortable attribute classname value
+		const getClassName = await templatesManager.getEventSingleSortableAttribute('class');
+		// assert attribute classname value
+		expect(getClassName).toBe('ui-sortable');
+	});
+});

--- a/packages/e2e-tests/utils/admin/events/templates/TemplatesManager.ts
+++ b/packages/e2e-tests/utils/admin/events/templates/TemplatesManager.ts
@@ -34,4 +34,19 @@ export class TemplatesManager {
 		// save changes from templates tab
 		await Promise.all([page.waitForNavigation(), page.click('#template_settings_save')]);
 	};
+
+	/**
+	 * set use custom display order
+	 */
+	setCustomDisplayOrder = async ({ value }: { value: string }): Promise<void> => {
+		// set display status banner
+		await page.selectOption('select#EED_Events_Single_use_sortable_display_order', { value });
+	};
+
+	/**
+	 * get event single sortable attribute
+	 */
+	getEventSingleSortableAttribute = async (attribute: string): Promise<string> => {
+		return await (await page.$('ul#event-single-sortable-js')).getAttribute(attribute);
+	};
 }


### PR DESCRIPTION
For this ticket:

- Use Custom Display Order? - setting this to "Yes" should enable the Display Order list (see next item) by adding a ui-sortable-disabled class to the event-single-sortable-js DOM element