### PR TITLE
Add withPermission HOC and Fix New EDTR Caps

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/DatesListButtons.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/DatesListButtons.tsx
@@ -6,7 +6,7 @@ import { Ticket } from '@eventespresso/icons';
 import { Button, ButtonRow } from '@eventespresso/ui-components';
 import { EdtrGlobalModals, useDatetimes, useTickets } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
-import { withFeature } from '@eventespresso/services';
+import { withPermission } from '@eventespresso/services';
 
 import { BaseProps } from '../../ticketAssignmentsManager';
 import { NewDateButton } from './newDateOptions';
@@ -39,4 +39,4 @@ const DatesListButtons: React.FC = () => {
 	);
 };
 
-export default withFeature('use_advanced_event_editor')(DatesListButtons);
+export default withPermission('ee_advanced_event_editor')(DatesListButtons);

--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
@@ -5,7 +5,7 @@ import { __ } from '@eventespresso/i18n';
 import { BulkActions } from '@eventespresso/ee-components';
 import { Collapsible } from '@eventespresso/ui-components';
 import { useDisclosure, useMemoStringify } from '@eventespresso/hooks';
-import { withFeature } from '@eventespresso/services';
+import { withPermission } from '@eventespresso/services';
 import { useDatesListFilterState, hooks } from '@eventespresso/edtr-services';
 import { DatetimeStatus } from '@eventespresso/predicates';
 import { useBulkEdit } from '@eventespresso/services';
@@ -77,4 +77,4 @@ const Actions: React.FC = () => {
 	);
 };
 
-export default withFeature('ee_event_editor_bulk_edit')(Actions);
+export default withPermission('ee_event_editor_bulk_edit')(Actions);

--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/Checkbox.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { ActionCheckbox } from '@eventespresso/ee-components';
 import { useVisibleDatetimeIds } from '@eventespresso/edtr-services';
-import { withFeature } from '@eventespresso/services';
+import { withPermission } from '@eventespresso/services';
 import type { ActionCheckboxProps } from '@eventespresso/ee-components';
 
 const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
@@ -9,4 +9,4 @@ const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
 	return <ActionCheckbox {...props} visibleEntityIds={visibleDatetimeIds} />;
 };
 
-export default withFeature('ee_event_editor_bulk_edit')(Checkbox);
+export default withPermission('ee_event_editor_bulk_edit')(Checkbox);

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/bulkEdit/actions/Actions.tsx
@@ -7,7 +7,7 @@ import { useDisclosure, useMemoStringify } from '@eventespresso/hooks';
 import { useTickets, useTicketsListFilterState } from '@eventespresso/edtr-services';
 import { SOLD_TICKET_ERROR_MESSAGE } from '@eventespresso/tpc';
 import { entitiesWithGuIdInArray, TicketsStatus } from '@eventespresso/predicates';
-import { withFeature, useBulkEdit } from '@eventespresso/services';
+import { withPermission, useBulkEdit } from '@eventespresso/services';
 import type { BulkActionsProps } from '@eventespresso/ui-components';
 
 import Checkbox from '../../tableView/Checkbox';
@@ -83,4 +83,4 @@ const Actions: React.FC = () => {
 	);
 };
 
-export default withFeature('ee_event_editor_bulk_edit')(Actions);
+export default withPermission('ee_event_editor_bulk_edit')(Actions);

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/Checkbox.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { ActionCheckbox } from '@eventespresso/ee-components';
 import { useVisibleTicketIds } from '@eventespresso/edtr-services';
-import { withFeature } from '@eventespresso/services';
+import { withPermission } from '@eventespresso/services';
 import type { ActionCheckboxProps } from '@eventespresso/ee-components';
 
 const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
@@ -9,4 +9,4 @@ const Checkbox: React.FC<ActionCheckboxProps> = (props) => {
 	return <ActionCheckbox {...props} visibleEntityIds={visibleTicketIds} />;
 };
 
-export default withFeature('ee_event_editor_bulk_edit')(Checkbox);
+export default withPermission('ee_event_editor_bulk_edit')(Checkbox);

--- a/ee-barista.php
+++ b/ee-barista.php
@@ -38,7 +38,6 @@ add_action(
             function ($capabilities) {
                 return array_merge($capabilities, [
                     'use_advanced_event_editor'  => true,
-                    'ee_event_editor_bulk_edit'    => true,
                     'use_default_ticket_manager' => true,
                     'use_event_description_rte'  => true,
                     'use_experimental_rte'       => true,

--- a/packages/ee-components/src/EntityList/EntityList.tsx
+++ b/packages/ee-components/src/EntityList/EntityList.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@eventespresso/i18n';
-import { useFeature, useStatus } from '@eventespresso/services';
+import { useCurrentUserCan, useStatus } from '@eventespresso/services';
 import { Slot } from '@eventespresso/slot-fill';
 import { CollapsibleLegend, EmptyState, Pagination, EntityList as EntityListUI } from '@eventespresso/ui-components';
 import type { EntityListFilterStateManager } from '@eventespresso/services';
@@ -23,7 +23,8 @@ const EntityList = <ELFS extends EntityListFilterStateManager<any>>({
 	const { isError, isLoading } = useStatus();
 	const error = isError(entityType);
 	const loading = isLoading(entityType);
-	const showBulkActions = useFeature('ee_event_editor_bulk_edit');
+	const currentUserCan = useCurrentUserCan();
+	const showBulkActions = currentUserCan('ee_event_editor_bulk_edit');
 
 	let entityList: React.ReactNode;
 

--- a/packages/services/src/permissions/index.ts
+++ b/packages/services/src/permissions/index.ts
@@ -2,5 +2,6 @@ export { default as useCurrentUserCan } from './useCurrentUserCan';
 export { default as useSitePermissions } from './useSitePermissions';
 export { default as useUserCapabilities } from './useUserCapabilities';
 export { default as usePermissions } from './usePermissions';
+export * from './withPermission';
 
 export * from './types';

--- a/packages/services/src/permissions/withPermission.tsx
+++ b/packages/services/src/permissions/withPermission.tsx
@@ -1,0 +1,15 @@
+import type { AnyObject } from '@eventespresso/utils';
+import usePermissions from './usePermissions';
+import { Capability } from './types';
+
+export const withPermission =
+	(capability: Capability) =>
+	<P extends AnyObject>(Component: React.FC<P>) => {
+		const WrappedComponent: React.FC<P> = (props) => {
+			const permissions = usePermissions();
+			const hasPermission = permissions?.includes(capability);
+			return hasPermission ? <Component {...props} /> : null;
+		};
+
+		return WrappedComponent;
+	};


### PR DESCRIPTION
In #1138 I used the `withFeature()` HOC to hide the `DatesListButtons` component
and in #1137 i renamed the `use_bulk_edit` feature flag to `ee_event_editor_bulk_edit` to match the new cap created for that feature.

HOWEVER...

The server side PHP feature flag logic that I wrote can work directly with caps, and I mistakenly thought that the client side JS feature flags could do the same, but they can not. 

This PR fixes things so that caps can be used the same way our feature flags work, by doing the following:

- added a new `withPermission` curried HOC for coupling the display of a feature to the existence of a user cap
- updates components that use bulk edits or "advanced event editor" features to use the new HOC instead of the `withFeature` HOC
- removes the `ee_event_editor_bulk_edit` from the list of feature flags since they can't work with caps