### PR TITLE
Ticket Details Edit Form Section Requires `ee_advanced_event_editor` Capability

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -9,10 +9,11 @@ import { useMemoStringify } from '@eventespresso/hooks';
 import { setDefaultTime } from '@eventespresso/dates';
 import { EntityId } from '@eventespresso/data';
 import { __ } from '@eventespresso/i18n';
-import type { EspressoFormProps } from '@eventespresso/form';
+import type { EspressoFormProps, FormSectionProps } from '@eventespresso/form';
 import type { Ticket, TicketFormConfig } from '@eventespresso/edtr-services';
 import { EndDateFieldWrapper } from '@eventespresso/ee-components';
 import { preparePricesForTpc, usePriceToTpcModifier } from '@eventespresso/tpc';
+import { usePermissions } from '@eventespresso/services';
 
 import { validate } from './formValidation';
 
@@ -40,6 +41,8 @@ const adjacentFormItemProps = {
 
 export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFormConfig => {
 	const ticket = useTicketItem({ id });
+	const permissions = usePermissions();
+	const userHasAdvancedEditor = permissions?.includes('ee_advanced_event_editor');
 
 	const toUtcISO = useSiteDateToUtcISO();
 	const toSiteDate = useUtcISOToSiteDate();
@@ -126,103 +129,108 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 						},
 					],
 				},
-				{
-					name: 'details',
-					icon: ControlOutlined,
-					title: __('Details'),
-					fields: [
-						{
-							name: 'quantity',
-							label: __('Quantity For Sale'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000000,
-							min: -1,
-							info:
-								__('The maximum number of this ticket available for sale.') +
-								'\n' +
-								__('Set to 0 to stop sales, or leave blank for no limit.'),
-							width: 'small',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'uses',
-							label: __('Number of Uses'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000,
-							min: 0,
-							info:
-								__(
-									'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
-								) +
-								'\n' +
-								__(
-									'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
-								),
-							width: 'small',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'min',
-							label: __('Minimum Quantity'),
-							fieldType: 'number',
-							max: 1000000,
-							min: 0,
-							info:
-								__(
-									'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-								) +
-								'\n' +
-								__('Leave blank for no minimum.'),
-							width: 'small',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'max',
-							label: __('Maximum Quantity'),
-							fieldType: 'number',
-							parseAsInfinity: true,
-							max: 1000000,
-							min: -1,
-							info:
-								__(
-									'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
-								) +
-								'\n' +
-								__('Leave blank for no maximum.'),
-							width: 'small',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'isRequired',
-							label: __('Required Ticket'),
-							fieldType: 'switch',
-							info: __(
-								'If enabled, the ticket must be selected and will appear first in frontend ticket lists.'
-							),
-							width: 'small',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'isTrashed',
-							label: __('Trash'),
-							fieldType: 'switch',
-							formControlProps: adjacentFormItemProps,
-						},
-						{
-							name: 'visibility',
-							label: __('Visibility'),
-							fieldType: 'select',
-							info: __('Where the ticket can be viewed throughout the UI.'),
-							options: VISIBILITY_OPTIONS,
-						},
-					],
-				},
 			],
 			ticket
 		);
 	}, [ticket]);
+
+	const detailsSection: FormSectionProps = useMemo(() => {
+		return {
+			name: 'details',
+			icon: ControlOutlined,
+			title: __('Details'),
+			fields: [
+				{
+					name: 'quantity',
+					label: __('Quantity For Sale'),
+					fieldType: 'number',
+					parseAsInfinity: true,
+					max: 1000000,
+					min: -1,
+					info:
+						__('The maximum number of this ticket available for sale.') +
+						'\n' +
+						__('Set to 0 to stop sales, or leave blank for no limit.'),
+					width: 'small',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'uses',
+					label: __('Number of Uses'),
+					fieldType: 'number',
+					parseAsInfinity: true,
+					max: 1000,
+					min: 0,
+					info:
+						__(
+							'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.'
+						) +
+						'\n' +
+						__(
+							'Example: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
+						),
+					width: 'small',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'min',
+					label: __('Minimum Quantity'),
+					fieldType: 'number',
+					max: 1000000,
+					min: 0,
+					info:
+						__(
+							'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+						) +
+						'\n' +
+						__('Leave blank for no minimum.'),
+					width: 'small',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'max',
+					label: __('Maximum Quantity'),
+					fieldType: 'number',
+					parseAsInfinity: true,
+					max: 1000000,
+					min: -1,
+					info:
+						__(
+							'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.'
+						) +
+						'\n' +
+						__('Leave blank for no maximum.'),
+					width: 'small',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'isRequired',
+					label: __('Required Ticket'),
+					fieldType: 'switch',
+					info: __('If enabled, the ticket must be selected and will appear first in frontend ticket lists.'),
+					width: 'small',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'isTrashed',
+					label: __('Trash'),
+					fieldType: 'switch',
+					formControlProps: adjacentFormItemProps,
+				},
+				{
+					name: 'visibility',
+					label: __('Visibility'),
+					fieldType: 'select',
+					info: __('Where the ticket can be viewed throughout the UI.'),
+					options: VISIBILITY_OPTIONS,
+				},
+			],
+		};
+	}, []);
+
+	if (userHasAdvancedEditor) {
+		sections.push(detailsSection);
+	}
 
 	return useMemo(
 		() => ({

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketForm/useTicketFormConfig.ts
@@ -4,7 +4,7 @@ import * as R from 'ramda';
 import { CalendarOutlined, ControlOutlined, ProfileOutlined } from '@eventespresso/icons';
 import { useUtcISOToSiteDate, useSiteDateToUtcISO, getEEDomData } from '@eventespresso/services';
 import { startAndEndDateFixer, useTicketItem, hooks, useTicketPrices } from '@eventespresso/edtr-services';
-import { PLUS_ONE_MONTH } from '@eventespresso/constants';
+import { PLUS_ONE_MONTH, USE_ADVANCED_EDITOR } from '@eventespresso/constants';
 import { useMemoStringify } from '@eventespresso/hooks';
 import { setDefaultTime } from '@eventespresso/dates';
 import { EntityId } from '@eventespresso/data';
@@ -13,7 +13,7 @@ import type { EspressoFormProps, FormSectionProps } from '@eventespresso/form';
 import type { Ticket, TicketFormConfig } from '@eventespresso/edtr-services';
 import { EndDateFieldWrapper } from '@eventespresso/ee-components';
 import { preparePricesForTpc, usePriceToTpcModifier } from '@eventespresso/tpc';
-import { usePermissions } from '@eventespresso/services';
+import { useCurrentUserCan } from '@eventespresso/services';
 
 import { validate } from './formValidation';
 
@@ -41,8 +41,7 @@ const adjacentFormItemProps = {
 
 export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFormConfig => {
 	const ticket = useTicketItem({ id });
-	const permissions = usePermissions();
-	const userHasAdvancedEditor = permissions?.includes('ee_advanced_event_editor');
+	const currentUserCan = useCurrentUserCan();
 
 	const toUtcISO = useSiteDateToUtcISO();
 	const toSiteDate = useUtcISOToSiteDate();
@@ -228,7 +227,7 @@ export const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): T
 		};
 	}, []);
 
-	if (userHasAdvancedEditor) {
+	if (currentUserCan(USE_ADVANCED_EDITOR)) {
 		sections.push(detailsSection);
 	}
 

--- a/packages/ui-components/src/NumberInput/style.scss
+++ b/packages/ui-components/src/NumberInput/style.scss
@@ -42,6 +42,9 @@
 	}
 
 	.ee-number-field-stepper {
+		height: calc(var(--ee-button-height) + 2px);
+		right: -3px;
+		top: 6px;
 		z-index: 0;
 
 		> div {


### PR DESCRIPTION
plz see: https://github.com/eventespresso/eventsmart.com-website/issues/909#issuecomment-1065551774

This PR:

- conditionally adds the Ticket Details form section to the edit ticket form based on whether the current user has the `ee_advanced_event_editor` ccap
- fixes the number stepper button layout styles