### PR TITLE
Improve Entity Sorting

### DIFF
--- a/packages/edtr-services/src/apollo/mutations/datetimes/useReorderDatetimes.ts
+++ b/packages/edtr-services/src/apollo/mutations/datetimes/useReorderDatetimes.ts
@@ -24,7 +24,7 @@ const useReorderDatetimes = (filteredEntityIds: Array<EntityId>): ReorderDatetim
 
 	const datetimes = useMemo(() => filteredEntityIds.map(getDatetime), [filteredEntityIds, getDatetime]);
 
-	const { allReorderedEntities, done, sortEntities } = useReorderEntities<Datetime>({
+	const { allReorderedEntities, updateSortOrder, sortEntities } = useReorderEntities<Datetime>({
 		entityType: 'DATETIME',
 		filteredEntities: datetimes,
 	});
@@ -33,13 +33,13 @@ const useReorderDatetimes = (filteredEntityIds: Array<EntityId>): ReorderDatetim
 	const queryOptions = useDatetimeQueryOptions();
 	const updateDatetimeList = useUpdateDatetimeList();
 
-	const updateEntityList = useCallback(() => {
+	const updateEntityList = useCallback(async () => {
 		const espressoDatetimes: DatetimeEdge = {
 			nodes: allUpdatedEntities,
 			__typename: 'EspressoRootQueryDatetimesConnection',
 		};
 
-		done();
+		await updateSortOrder();
 
 		updateDatetimeList({
 			...queryOptions,
@@ -47,7 +47,7 @@ const useReorderDatetimes = (filteredEntityIds: Array<EntityId>): ReorderDatetim
 				espressoDatetimes,
 			},
 		});
-	}, [allUpdatedEntities, done, queryOptions, updateDatetimeList]);
+	}, [allUpdatedEntities, updateSortOrder, queryOptions, updateDatetimeList]);
 
 	const sortResponder = useCallback<SortResponder>(
 		({ destination, source }) => {

--- a/packages/edtr-services/src/apollo/mutations/tickets/useReorderTickets.ts
+++ b/packages/edtr-services/src/apollo/mutations/tickets/useReorderTickets.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { __ } from '@eventespresso/i18n';
 import { ticketDroppableId } from '@eventespresso/constants';
 import type { EntityId } from '@eventespresso/data';
 import type { EntityTableProps } from '@eventespresso/ee-components';
@@ -21,7 +22,7 @@ const useReorderTickets = (filteredEntityIds: Array<EntityId>): ReorderTickets =
 	const getTicket = useLazyTicket();
 	const filteredTickets = useMemo(() => filteredEntityIds.map(getTicket), [filteredEntityIds, getTicket]);
 
-	const { allReorderedEntities, done, sortEntities } = useReorderEntities<Ticket>({
+	const { allReorderedEntities, updateSortOrder, sortEntities } = useReorderEntities<Ticket>({
 		entityType: 'TICKET',
 		filteredEntities: filteredTickets,
 	});
@@ -30,21 +31,22 @@ const useReorderTickets = (filteredEntityIds: Array<EntityId>): ReorderTickets =
 
 	const queryOptions = useTicketQueryOptions();
 	const updateTicketList = useUpdateTicketList();
-	const updateEntityList = useCallback(() => {
+	const updateEntityList = useCallback(async () => {
 		const espressoTickets: TicketEdge = {
 			nodes: allUpdatedEntities,
 			__typename: 'EspressoRootQueryTicketsConnection',
 		};
 
-		done();
+		await updateSortOrder();
 
 		updateTicketList({
 			...queryOptions,
 			data: {
 				espressoTickets,
 			},
-		});
-	}, [allUpdatedEntities, done, queryOptions, updateTicketList]);
+        });
+
+	}, [allUpdatedEntities, updateSortOrder, queryOptions, updateTicketList]);
 
 	const sortResponder = useCallback<SortResponder>(
 		({ destination, source }) => {


### PR DESCRIPTION
this PR:

- gets rid of unnecessary debounce that simply delayed the updating of the sort order... by FIVE seconds
- instead returns a promise from the sort order mutation
- waits for sort order update mutation before updating entity lists instead of relying on debounce
- displays success notification AFTER resorting and update has completed 