### PR TITLE
Improve Alert Dialog Component

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DateMainMenu.tsx
@@ -1,42 +1,18 @@
 import { useCallback, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import {
-	DropdownMenu,
-	DropdownToggleProps,
-	Copy,
-	Edit,
-	Trash,
-	useConfirmationDialog,
-} from '@eventespresso/ui-components';
-import { EdtrGlobalModals, useDatesListFilterState } from '@eventespresso/edtr-services';
+import { CopyEntity, DropdownMenu, DropdownToggleProps, EditEntity } from '@eventespresso/ui-components';
+import { EdtrGlobalModals } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
 import type { EntityEditModalData } from '@edtrUI/types';
 
+import { DeleteDatetime } from './DeleteDatetime';
 import useActions from './useActions';
 import type { DateMainMenuProps } from './types';
 
 const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
-	const { copyDate, trashDate, isTrashed } = useActions(datetime.id);
+	const { copyDate } = useActions(datetime.id);
 	const { openWithData } = useGlobalModal<EntityEditModalData>(EdtrGlobalModals.EDIT_DATE);
-
-	const isTheOnlyDate = useDatesListFilterState().total === 1;
-
-	const title = isTrashed ? __('Permanently delete Datetime?') : __('Move Datetime to Trash?');
-	const message = isTrashed
-		? __(
-				'Are you sure you want to permanently delete this datetime? This action is permanent and can not be undone.'
-		  )
-		: __(
-				'Are you sure you want to move this datetime to the trash? You can "untrash" this datetime later if you need to.'
-		  );
-	const { confirmationDialog, onOpen } = useConfirmationDialog({
-		message,
-		title,
-		onConfirm: trashDate,
-	});
-
-	const trashDateTitle = isTrashed ? __('delete permanently') : __('trash datetime');
 
 	const toggleProps: DropdownToggleProps = useMemo(
 		() => ({
@@ -51,21 +27,13 @@ const DateMainMenu: React.FC<DateMainMenuProps> = ({ datetime }) => {
 		openWithData({ entityId: datetime.id });
 	}, [datetime.id, openWithData]);
 
-	const cannotBeDeleted = isTrashed && isTheOnlyDate;
-
 	return (
 		<>
 			<DropdownMenu toggleProps={toggleProps}>
-				<Edit onClick={onOpenEditModal} title={__('edit datetime')} />
-				<Copy onClick={copyDate} title={__('copy datetime')} />
-				<Trash
-					data-testid={`ee-trash-date-${datetime.dbId}`}
-					onClick={onOpen}
-					title={trashDateTitle}
-					isDisabled={cannotBeDeleted}
-				/>
+				<EditEntity onClick={onOpenEditModal} title={__('edit datetime')} />
+				<CopyEntity onClick={copyDate} title={__('copy datetime')} />
+				<DeleteDatetime datetime={datetime} />
 			</DropdownMenu>
-			{confirmationDialog}
 		</>
 	);
 };

--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DeleteDatetime.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/actionsMenu/dropdown/DeleteDatetime.tsx
@@ -1,0 +1,47 @@
+import { __ } from '@eventespresso/i18n';
+import { AlertType, TrashEntity, useConfirmationDialog } from '@eventespresso/ui-components';
+import { Trash as TrashIcon } from '@eventespresso/icons';
+import { useDatesListFilterState } from '@eventespresso/edtr-services';
+import useActions from './useActions';
+import type { Datetime } from '@eventespresso/edtr-services';
+
+export interface DeleteDatetimeProps {
+	datetime: Datetime;
+}
+
+export const DeleteDatetime: React.FC<DeleteDatetimeProps> = ({ datetime }) => {
+	const { trashDate, isTrashed } = useActions(datetime.id);
+	const isTheOnlyDate = useDatesListFilterState().total === 1;
+	const trashDateTitle = isTrashed ? __('delete permanently') : __('trash datetime');
+	const cannotBeDeleted = isTrashed && isTheOnlyDate;
+
+	const title = isTrashed ? __('Permanently Delete Datetime?') : __('Move Datetime to Trash?');
+	const message = isTrashed
+		? __(
+				'Are you sure you want to permanently delete this datetime? This action is permanent and can not be undone.'
+		  )
+		: __(
+				'Are you sure you want to move this datetime to the trash? You can "untrash" this datetime later if you need to.'
+		  );
+	const { confirmationDialog, onOpen } = useConfirmationDialog({
+		addIconBG: true,
+		alertType: AlertType.ACCENT,
+		icon: TrashIcon,
+		message,
+		title,
+		onConfirm: trashDate,
+		yesButtonText: __('delete'),
+	});
+
+	return (
+		<>
+			<TrashEntity
+				data-testid={`ee-trash-date-${datetime.dbId}`}
+				onClick={onOpen}
+				title={trashDateTitle}
+				isDisabled={cannotBeDeleted}
+			/>
+			{confirmationDialog}
+		</>
+	);
+};

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/DeleteTicket.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/DeleteTicket.tsx
@@ -2,7 +2,8 @@ import { useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { Ticket, useTicketsListFilterState } from '@eventespresso/edtr-services';
-import { Trash, useConfirmationDialog } from '@eventespresso/ui-components';
+import { Trash as TrashIcon } from '@eventespresso/icons';
+import { AlertType, TrashEntity, useConfirmationDialog } from '@eventespresso/ui-components';
 import { isTrashed as isTicketTrashed, isLocked } from '@eventespresso/predicates';
 import { useLockedTicketAction } from '@eventespresso/tpc';
 
@@ -15,12 +16,12 @@ export interface DeleteTicketProps {
 export const DeleteTicket: React.FC<DeleteTicketProps> = ({ ticket }) => {
 	const isTrashed = isTicketTrashed(ticket);
 
-	const title = isTrashed ? __('Permanently delete Ticket?') : __('Move Ticket to Trash?');
+	const title = isTrashed ? __('Permanently Delete Ticket?') : __('Move Ticket to Trash?');
 
 	const message = isTrashed
 		? __('Are you sure you want to permanently delete this ticket? This action is permanent and can not be undone.')
 		: __(
-				'Are you sure you want to move this ticket to the trash? You can "untrash" this ticket later if you need to.'
+				`Are you sure you want to move this ticket to the trash? You can "untrash" this ticket later if you need to.`
 		  );
 
 	const deleteTicket = useDeleteTicketHandler(ticket.id);
@@ -30,6 +31,9 @@ export const DeleteTicket: React.FC<DeleteTicketProps> = ({ ticket }) => {
 	}, [deleteTicket, isTrashed]);
 
 	const { confirmationDialog, onOpen: confirmDelete } = useConfirmationDialog({
+		addIconBG: true,
+		alertType: AlertType.ACCENT,
+		icon: TrashIcon,
 		message,
 		title,
 		onConfirm: onConfirmDelete,
@@ -47,7 +51,7 @@ export const DeleteTicket: React.FC<DeleteTicketProps> = ({ ticket }) => {
 
 	return (
 		<>
-			<Trash onClick={onDelete} title={deleteTicketTitle} isDisabled={cannotBeDeleted} />
+			<TrashEntity onClick={onDelete} title={deleteTicketTitle} isDisabled={cannotBeDeleted} />
 			{confirmationDialog}
 			{alertContainer}
 		</>

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/actionsMenu/dropdown/TicketMainMenu.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
-import { Copy, Edit, DropdownMenu, DropdownToggleProps } from '@eventespresso/ui-components';
+import { CopyEntity, DropdownMenu, DropdownToggleProps, EditEntity } from '@eventespresso/ui-components';
 import { EdtrGlobalModals, useTicketItem } from '@eventespresso/edtr-services';
 import { useGlobalModal } from '@eventespresso/registry';
 import { useCopyTicket } from '@eventespresso/tpc';
@@ -35,8 +35,8 @@ const TicketMainMenu: React.FC<TicketMainMenuProps> = (props) => {
 
 	return (
 		<DropdownMenu toggleProps={toggleProps}>
-			<Edit onClick={onOpenEditModal} title={__('edit ticket')} />
-			<Copy onClick={copyTicket} title={__('copy ticket')} />
+			<EditEntity onClick={onOpenEditModal} title={__('edit ticket')} />
+			<CopyEntity onClick={copyTicket} title={__('copy ticket')} />
 			<DeleteTicket ticket={ticket} />
 		</DropdownMenu>
 	);

--- a/packages/adapters/src/AlertDialog/AlertDialog.tsx
+++ b/packages/adapters/src/AlertDialog/AlertDialog.tsx
@@ -12,22 +12,31 @@ import type { AlertDialogProps } from './types';
 export const AlertDialog: React.FC<AlertDialogProps> = ({
 	body,
 	cancelButton,
-	contentClassName,
+	dialogClassName,
 	header,
+	icon: Icon,
 	isOpen,
 	leastDestructiveRef,
 	onClose,
 	okButton,
-}) => (
-	<ChakraAlertDialog isOpen={isOpen} leastDestructiveRef={leastDestructiveRef} onClose={onClose}>
-		<AlertDialogOverlay />
-		<AlertDialogContent className={contentClassName}>
-			{header && <AlertDialogHeader className={'ee-alert-dialog__header'}>{header}</AlertDialogHeader>}
-			<AlertDialogBody className={'ee-alert-dialog__body'}>{body}</AlertDialogBody>
-			<AlertDialogFooter className={'ee-alert-dialog__footer'}>
-				{cancelButton}
-				{okButton}
-			</AlertDialogFooter>
-		</AlertDialogContent>
-	</ChakraAlertDialog>
-);
+}) => {
+	const headerIcon = Icon ? <Icon /> : null;
+	return (
+		<ChakraAlertDialog isOpen={isOpen} leastDestructiveRef={leastDestructiveRef} onClose={onClose}>
+			<AlertDialogOverlay />
+			<AlertDialogContent className={dialogClassName}>
+				{header && (
+					<AlertDialogHeader className={'ee-alert-dialog__header'}>
+						{headerIcon}
+						{header}
+					</AlertDialogHeader>
+				)}
+				<AlertDialogBody className={'ee-alert-dialog__body'}>{body}</AlertDialogBody>
+				<AlertDialogFooter className={'ee-alert-dialog__footer'}>
+					{cancelButton}
+					{okButton}
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</ChakraAlertDialog>
+	);
+};

--- a/packages/adapters/src/AlertDialog/types.ts
+++ b/packages/adapters/src/AlertDialog/types.ts
@@ -1,10 +1,22 @@
 import type { AlertDialogProps as AlertDialogAdapterProps, AlertIconProps } from '@chakra-ui/react';
 
+export enum AlertType {
+	ACCENT = 'accent',
+	DEFAULT = 'default',
+	MINIMAL = 'minimal',
+	PRIMARY = 'primary',
+	SECONDARY = 'secondary',
+}
+
 export interface AlertDialogProps extends Omit<AlertDialogAdapterProps, 'children'> {
+	addIconBG?: boolean;
+	alertType?: AlertType;
 	body?: React.ReactNode;
 	cancelButton: React.ReactNode;
-	contentClassName?: string;
+	className?: string;
+	dialogClassName?: string;
 	header: React.ReactNode;
+	icon?: React.ComponentType<any>;
 	okButton: React.ReactNode;
 }
 

--- a/packages/ui-components/src/AlertDialog/AlertDialog.tsx
+++ b/packages/ui-components/src/AlertDialog/AlertDialog.tsx
@@ -1,24 +1,17 @@
-import { AlertDialog as AlertDialogAdapter, AlertDialogProps } from '@eventespresso/adapters';
+import classNames from 'classnames';
+
+import { AlertDialog as AlertDialogAdapter, AlertDialogProps, AlertType } from '@eventespresso/adapters';
 
 import './styles.scss';
 
-export const AlertDialog: React.FC<AlertDialogProps> = ({
-	body,
-	cancelButton,
-	header,
-	isOpen,
-	leastDestructiveRef,
-	okButton,
-	onClose,
-}) => (
-	<AlertDialogAdapter
-		body={body}
-		cancelButton={cancelButton}
-		contentClassName='ee-alert-dialog'
-		header={header}
-		isOpen={isOpen}
-		leastDestructiveRef={leastDestructiveRef}
-		okButton={okButton}
-		onClose={onClose}
-	/>
-);
+export { AlertType };
+
+export const AlertDialog: React.FC<AlertDialogProps> = ({ addIconBG, alertType, className, ...props }) => {
+	const dialogClassName = classNames(
+		className,
+		'ee-alert-dialog',
+		addIconBG && 'ee-alert-dialog--icon-bg',
+		alertType !== AlertType.DEFAULT && [`ee-alert-dialog--${alertType}`]
+	);
+	return <AlertDialogAdapter dialogClassName={dialogClassName} {...props} />;
+};

--- a/packages/ui-components/src/AlertDialog/styles.scss
+++ b/packages/ui-components/src/AlertDialog/styles.scss
@@ -1,21 +1,91 @@
+@import '~@eventespresso/styles/src/mixins/breakpoints';
+
 .ee-alert-dialog[role='alertdialog'] {
+	border-radius: var(--ee-border-radius-default);
 	box-shadow: var(--ee-box-shadow-big);
+	box-sizing: border-box;
+	color: var(--ee-default-text-color);
 	line-height: var(--ee-line-height-modifier);
-	margin-top: 10%;
+	margin-top: 15%;
+	max-width: 100%;
+	overflow: hidden;
+	width: clamp(600px, 25vw, 85%);
+
+	@include max480px {
+		width: calc(100% - 1rem);
+	}
 
 	.ee-alert-dialog {
 		&__header {
-			color: var(--ee-default-text-color-super-low-contrast);
-			font-size: var(--ee-font-size-huge);
-			font-weight: 800;
-			padding: var(--ee-padding-default) var(--ee-padding-default) var(--ee-padding-tiny);
+			align-content: center;
+			align-items: center;
+			display: flex;
+			flex-direction: column;
+			font-size: var(--ee-font-size-bigger);
+			font-weight: 600;
+			line-height: var(--ee-font-size-huge);
+			padding: var(--ee-padding-huge) var(--ee-padding-default) var(--ee-padding-tiny);
 			position: relative;
-			text-transform: unset;
+			text-transform: none;
+
+			svg {
+				font-size: var(--ee-font-size-bigger);
+				box-sizing: border-box;
+				color: var(--ee-color-primary);
+				height: 4rem;
+				width: 4rem;
+				position: relative;
+				top: -1rem;
+			}
+
+			@include max480px {
+				font-size: var(--ee-font-size-bigger);
+
+				svg {
+					height: 3rem;
+					width: 3rem;
+					top: -.75rem;
+				}
+			}
 		}
 
 		&__body {
-			color: var(--ee-default-text-color);
 			font-size: var(--ee-font-size-default);
+			padding: var(--ee-padding-smaller) var(--ee-padding-huge);
+		}
+
+		&__footer {
+			padding: var(--ee-padding-smaller) var(--ee-padding-default) var(--ee-padding-default);
+
+			.ee-btn-base  {
+				margin: var(--ee-margin-nano);
+
+				& + .ee-btn-base {
+					margin-inline-start: var(--ee-margin-default);
+				}
+			}
+		}
+	}
+
+	&.ee-alert-dialog--icon-bg {
+		.ee-alert-dialog__header svg {
+			background: var(--ee-color-primary);
+			border-radius: 50%;
+			color: var(--ee-text-on-primary);
+			padding: 1rem;
+		}
+	}
+
+	&.ee-alert-dialog--accent {
+		.ee-alert-dialog__header svg {
+			color: var(--ee-color-accent);
+		}
+
+		&.ee-alert-dialog--icon-bg {
+			.ee-alert-dialog__header svg {
+				background: var(--ee-color-accent);
+				color: var(--ee-text-on-accent);
+			}
 		}
 	}
 }

--- a/packages/ui-components/src/Button/IconButton/style.scss
+++ b/packages/ui-components/src/Button/IconButton/style.scss
@@ -3,19 +3,9 @@
  * © 2020 Event Espresso
  * ------------------------------------------------------------------------- */
 
-@import '~@eventespresso/styles/src/mixins/breakpoints';
 @import '~@eventespresso/styles/src/mixins/transition';
+@import '../colors';
 
-.btn-focus {
-	border-color: var(--ee-color-primary);
-	box-shadow: var(--ee-button-box-shadow);
-}
-
-.btn-hover {
-	border-color: var(--ee-color-primary-low-contrast);
-	box-shadow: var(--ee-button-box-shadow);
-	color: var(--ee-color-primary-high-contrast);
-}
 
 .ee-btn-base {
 	&.ee-icon-button {
@@ -60,11 +50,15 @@
 		}
 
 		&:focus {
-			@extend .btn-focus;
+			border-color: var(--ee-color-primary);
+			box-shadow: var(--ee-button-box-shadow);
+			color: var(--ee-color-primary-high-contrast);
 		}
 
 		&:hover {
-			@extend .btn-hover;
+			border-color: var(--ee-color-primary-low-contrast);
+			box-shadow: var(--ee-button-box-shadow);
+			color: var(--ee-color-primary-high-contrast);
 		}
 
 		&--active {
@@ -84,6 +78,19 @@
 			&.ee-icon-button {
 				padding: 0;
 			}
+		}
+
+		&.ee-btn--primary {
+			background-color: var(--ee-color-primary);
+			color: var(--ee-text-on-primary);
+		}
+		&.ee-btn--secondary {
+			background-color: var(--ee-color-secondary);
+			color: var(--ee-text-on-secondary);
+		}
+		&.ee-btn--accent {
+			background-color: var(--ee-color-accent);
+			color: var(--ee-text-on-accent);
 		}
 
 		&-color {
@@ -156,5 +163,6 @@
 			padding: var(--ee-padding-small);
 			width: var(--ee-icon-button-size-huge);
 		}
+
 	}
 }

--- a/packages/ui-components/src/Button/_colors.scss
+++ b/packages/ui-components/src/Button/_colors.scss
@@ -2,11 +2,9 @@
 @import '~@eventespresso/styles/src/mixins/buttons';
 
 .ee-btn-base {
-	&.ee-btn {
-		@each $color, $value in $theme-colors {
-			&.ee-btn--#{$color} {
-				@include button-variant($value, $value, $color);
-			}
+	@each $color, $value in $theme-colors {
+		&.ee-btn--#{$color} {
+			@include button-variant($value, $value, $color);
 		}
 	}
 }

--- a/packages/ui-components/src/Confirm/index.ts
+++ b/packages/ui-components/src/Confirm/index.ts
@@ -1,4 +1,3 @@
 export { default as ConfirmClose } from './ConfirmClose';
 export { default as ConfirmDelete } from './ConfirmDelete';
-
 export { default as useConfirmationDialog } from './useConfirmationDialog';

--- a/packages/ui-components/src/Confirm/types.ts
+++ b/packages/ui-components/src/Confirm/types.ts
@@ -1,12 +1,16 @@
 import type { ButtonProps } from '../Button';
+import { AlertType } from '../AlertDialog';
 
 export interface ConfirmProps {
+	addIconBG?: boolean;
+	alertType?: AlertType;
+	icon?: React.ComponentType<any>;
 	message?: string;
-	noButtonText?: string;
+	noButtonText?: string | React.ReactNode;
 	onConfirm?: VoidFunction;
 	onCancel?: VoidFunction;
 	title?: string;
-	yesButtonText?: string;
+	yesButtonText?: string | React.ReactNode;
 }
 
 export interface ConfirmPropsWithButton extends ConfirmProps {

--- a/packages/ui-components/src/Confirm/useConfirmationDialog.tsx
+++ b/packages/ui-components/src/Confirm/useConfirmationDialog.tsx
@@ -2,7 +2,8 @@ import { useCallback, useMemo, useRef } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { useDisclosure } from '@eventespresso/hooks';
-import { AlertDialog, Button, ButtonType } from '../';
+import { AlertDialog, AlertType, Button } from '../';
+import { Check, ExclamationCircle } from '@eventespresso/icons';
 import type { ConfirmProps } from './types';
 
 type UseConfirmationDialog = {
@@ -11,10 +12,15 @@ type UseConfirmationDialog = {
 };
 
 const useConfirmationDialog = ({
+	addIconBG = false,
+	alertType = AlertType.PRIMARY,
+	icon = ExclamationCircle,
 	message,
+	noButtonText,
+	onCancel,
 	onConfirm,
 	title,
-	onCancel,
+	yesButtonText,
 	...props
 }: ConfirmProps): UseConfirmationDialog => {
 	const { isOpen, onOpen, onClose } = useDisclosure();
@@ -29,30 +35,48 @@ const useConfirmationDialog = ({
 		onCancel?.();
 	}, [onCancel, onClose]);
 
-	const noButtonText = props.noButtonText || __('No');
-	const yesButtonText = props.yesButtonText || __('Yes');
-
 	return useMemo(() => {
-		const cancelButton = <Button buttonText={noButtonText} ref={cancelRef} onClick={onCancelHandler} />;
+		const cancelText = noButtonText || __('cancel');
+		const confirmText = yesButtonText || __('confirm');
+
+		const cancelButton = <Button buttonText={cancelText} ref={cancelRef} onClick={onCancelHandler} />;
 
 		const okButton = (
-			<Button buttonText={yesButtonText} buttonType={ButtonType.ACCENT} onClick={onClickHandler} ml={3} />
+			<Button buttonText={confirmText} buttonType={alertType} icon={Check} onClick={onClickHandler} />
 		);
 
 		const confirmationDialog = (
 			<AlertDialog
+				addIconBG={addIconBG}
+				alertType={alertType}
 				body={message}
 				cancelButton={cancelButton}
+				className='ee-confirmation-dialog'
 				header={title}
+				icon={icon}
 				isOpen={isOpen}
 				leastDestructiveRef={cancelRef}
 				okButton={okButton}
 				onClose={onCancelHandler}
+				{...props}
 			/>
 		);
 
 		return { confirmationDialog, onOpen };
-	}, [isOpen, message, noButtonText, onCancelHandler, onClickHandler, onOpen, title, yesButtonText]);
+	}, [
+		addIconBG,
+		alertType,
+		icon,
+		isOpen,
+		message,
+		noButtonText,
+		onCancelHandler,
+		onClickHandler,
+		onOpen,
+		props,
+		title,
+		yesButtonText,
+	]);
 };
 
 export default useConfirmationDialog;

--- a/packages/ui-components/src/EntityActionsMenu/entityMenuItems/CopyEntity.tsx
+++ b/packages/ui-components/src/EntityActionsMenu/entityMenuItems/CopyEntity.tsx
@@ -4,9 +4,9 @@ import { DropdownMenuItem } from '../../DropdownMenu';
 import { Copy as CopyIcon } from '@eventespresso/icons';
 import type { MenuItemProps } from './types';
 
-const Copy: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
+const CopyEntity: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
 	const title = props.title || __('copy');
 	return <DropdownMenuItem {...props} icon={CopyIcon} onClick={onClick} title={title} />;
 };
 
-export default Copy;
+export default CopyEntity;

--- a/packages/ui-components/src/EntityActionsMenu/entityMenuItems/EditEntity.tsx
+++ b/packages/ui-components/src/EntityActionsMenu/entityMenuItems/EditEntity.tsx
@@ -4,9 +4,9 @@ import { DropdownMenuItem } from '../../DropdownMenu';
 import { Edit as EditIcon } from '@eventespresso/icons';
 import type { MenuItemProps } from './types';
 
-const Edit: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
+const EditEntity: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
 	const title = props.title || __('edit');
 	return <DropdownMenuItem {...props} icon={EditIcon} onClick={onClick} title={title} />;
 };
 
-export default Edit;
+export default EditEntity;

--- a/packages/ui-components/src/EntityActionsMenu/entityMenuItems/TrashEntity.tsx
+++ b/packages/ui-components/src/EntityActionsMenu/entityMenuItems/TrashEntity.tsx
@@ -4,10 +4,10 @@ import { Trash as TrashIcon } from '@eventespresso/icons';
 import { DropdownMenuItem } from '../../DropdownMenu';
 import type { MenuItemProps } from './types';
 
-const Trash: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
+const TrashEntity: React.FC<MenuItemProps> = ({ onClick, ...props }) => {
 	const title = props.title || __('trash');
 
 	return <DropdownMenuItem {...props} icon={TrashIcon} onClick={onClick} title={title} />;
 };
 
-export default Trash;
+export default TrashEntity;

--- a/packages/ui-components/src/EntityActionsMenu/entityMenuItems/index.ts
+++ b/packages/ui-components/src/EntityActionsMenu/entityMenuItems/index.ts
@@ -1,4 +1,4 @@
-export { default as Copy } from './Copy';
-export { default as Edit } from './Edit';
-export { default as Trash } from './Trash';
+export { default as CopyEntity } from './CopyEntity';
+export { default as EditEntity } from './EditEntity';
+export { default as TrashEntity } from './TrashEntity';
 export { default as Untrash } from './Untrash';

--- a/packages/ui-components/src/Modal/ModalWithAlert.tsx
+++ b/packages/ui-components/src/Modal/ModalWithAlert.tsx
@@ -18,12 +18,9 @@ export const ModalWithAlert: React.FC<ModalWithAlertProps> = ({
 	showAlertOnClose = true,
 	...props
 }) => {
-	const title = __('Alert!');
-	const message = alertText || __('Are you sure you want to close this?');
-
 	const { confirmationDialog, onOpen: showAlert } = useConfirmationDialog({
-		message,
-		title,
+		message: alertText,
+		title: __('Are you sure you want to close this?'),
 		onConfirm: onClose as VoidFunction,
 	});
 


### PR DESCRIPTION
This PR:

- improves the alert dialog style and adds some additional functionality for controlling the display
- updates the confirmation dialog accordingly
- tweaks button styles
- extracts logic into new `DeleteDatetime` component
- renames some menu item components for greater specificity
- updates ticket menu and menu items accordingly
- simplifies modal alert notice

### examples

delete datetime confirmation

<img width="522" alt="Screenshot 2022-08-12 190727" src="https://user-images.githubusercontent.com/1751030/184464579-8009253b-dbd0-4042-82e4-8aa5098a9017.png">

generic close modal alert

<img width="521" alt="Screenshot 2022-08-12 190932" src="https://user-images.githubusercontent.com/1751030/184464633-9737af5d-47db-4817-a719-a9546ce933b9.png">

