### PR TITLE
Protect Ticket Assignments Manager Table Positioning

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/ticketAssignmentsManager/components/table/styles.scss
+++ b/domains/core/admin/eventEditor/src/ui/ticketAssignmentsManager/components/table/styles.scss
@@ -8,6 +8,7 @@
 .ee-ticket-assignments-manager.ee-ticket-assignments-manager.ee-rspnsv-table__outer_wrapper {
 	.ee-rspnsv-table {
 		background: var(--ee-background-color);
+		position: unset;
 
 		&__inner-wrapper {
 			background: var(--ee-background-color);
@@ -40,7 +41,7 @@
 						font-size: var(--ee-font-size-small);
 						font-weight: bold;
 						line-height: var(--ee-line-height-modifier);
-    					margin-inline: 1px;
+						margin-inline: 1px;
 						padding: var(--ee-padding-micro);
 						text-transform: uppercase;
 						width: calc(100% - 2px);


### PR DESCRIPTION
plz see: https://eventespresso.com/topic/ticket-assignment-manager-css-bug/#post-341637

The user in the above thread reported that the Ticket Assignments Manager (TAM) table row headings were unreadable due to the table cell positioning. 
My guess is that another plugin is applying `position: relative;` to all table elements which is messing up our rendering (which i failed to protect against).

This PR fixes this issue by unsetting any positioning applied to the TAM table.