### PR TITLE
Change Datepicker Time Interval to 15 Minutes & Fix Timezone Formats

### DIFF
--- a/packages/dates/src/components/DatePicker.tsx
+++ b/packages/dates/src/components/DatePicker.tsx
@@ -3,6 +3,8 @@ import { forwardRef, memo, useMemo } from 'react';
 import ReactDatePicker from 'react-datepicker';
 import * as locales from 'date-fns/locale';
 
+import { DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT } from '../constants';
+import { stripTimezoneFormat } from '../../../predicates';
 import { DatePickerProps } from '../types';
 
 import 'react-datepicker/dist/react-datepicker.css';
@@ -11,6 +13,10 @@ import './styles.scss';
 type InputProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 export const DatePicker: React.FC<DatePickerProps> = ({ inputValue, locale, onChange, value, ...props }) => {
+	let dateFormat = Array.isArray(props?.dateFormat) ? props?.dateFormat[0] : props?.dateFormat;
+	dateFormat = stripTimezoneFormat(dateFormat ?? DEFAULT_DATE_FORMAT);
+	const timeFormat = stripTimezoneFormat(props?.timeFormat ?? DEFAULT_TIME_FORMAT);
+
 	// get locale object from date-fns
 	// we need to change "en_US" to "enUS"
 	const datefnsLocale = useMemo(() => locales?.[locale?.replace(/-_/, '')] ?? locales.enUS, [locale]);
@@ -35,13 +41,16 @@ export const DatePicker: React.FC<DatePickerProps> = ({ inputValue, locale, onCh
 
 	return (
 		<ReactDatePicker
+			{...props}
 			calendarClassName='ee-datepicker'
+			customInput={<CustomInput />}
+			dateFormat={dateFormat}
+			locale={datefnsLocale}
 			onChange={onChange}
 			selected={value}
+			timeFormat={timeFormat}
+			timeIntervals={15}
 			value={inputValue}
-			locale={datefnsLocale}
-			customInput={<CustomInput />}
-			{...props}
 		/>
 	);
 };

--- a/packages/dates/src/components/DateTimePicker.tsx
+++ b/packages/dates/src/components/DateTimePicker.tsx
@@ -1,16 +1,22 @@
 import { __ } from '@eventespresso/i18n';
 
 import { DatePicker } from './DatePicker';
-import { DEFAULT_DATETIME_FORMAT } from '../constants';
+import { DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT } from '../constants';
+import { stripTimezoneFormat } from '../../../predicates';
 import type { DatePickerProps } from '../types';
 
 export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
+	let dateFormat = Array.isArray(props?.dateFormat) ? props?.dateFormat[0] : props?.dateFormat;
+	dateFormat = stripTimezoneFormat(dateFormat ?? DEFAULT_DATE_FORMAT);
+	const timeFormat = stripTimezoneFormat(props?.timeFormat ?? DEFAULT_TIME_FORMAT);
 	return (
 		<DatePicker
 			calendarClassName='ee-datetime-picker'
-			dateFormat={DEFAULT_DATETIME_FORMAT}
+			dateFormat={dateFormat}
 			showTimeSelect
 			timeCaption={__('time')}
+			timeFormat={timeFormat}
+			timeIntervals={15}
 			{...props}
 		/>
 	);

--- a/packages/dates/src/components/TimePicker.tsx
+++ b/packages/dates/src/components/TimePicker.tsx
@@ -1,17 +1,21 @@
 import { __ } from '@eventespresso/i18n';
-import { DEFAULT_TIME_FORMAT } from '@eventespresso/constants';
 
 import { DatePicker } from './DatePicker';
+
+import { DEFAULT_TIME_FORMAT } from '../constants';
+import { stripTimezoneFormat } from '../../../predicates';
 import type { DatePickerProps } from '../types';
 
 export const TimePicker: React.FC<DatePickerProps> = (props) => {
+	const timeFormat = stripTimezoneFormat(props?.timeFormat ?? DEFAULT_TIME_FORMAT);
 	return (
 		<DatePicker
 			calendarClassName='ee-timepicker'
-			dateFormat={props.timeFormat || DEFAULT_TIME_FORMAT}
+			dateFormat={timeFormat}
 			showTimeSelect
 			showTimeSelectOnly
 			timeCaption={__('time')}
+			timeFormat={timeFormat}
 			timeIntervals={15}
 			{...props}
 		/>

--- a/packages/dates/src/components/styles.scss
+++ b/packages/dates/src/components/styles.scss
@@ -2,8 +2,8 @@
 @import '~@eventespresso/styles/src/mixins/transition';
 
 .react-datepicker {
-	$container-width:  calc(var(--ee-icon-button-size-big) * 7 + 2px);
-	$datetime-container-width:  calc(var(--ee-icon-button-size-big) * 9.25 + 2px);
+	$container-width: calc(var(--ee-icon-button-size-big) * 7 + 2px);
+	$datetime-container-width: calc(var(--ee-icon-button-size-big) * 9.25 + 2px);
 	$header-height: calc(var(--ee-icon-button-size-big) * 2);
 	$month-height: calc(var(--ee-icon-button-size-big) * 6 + 5px);
 	$month-container-height: calc(var(--ee-icon-button-size-big) * 8 + 5px);
@@ -24,11 +24,11 @@
 		font-size: var(--ee-font-size-small);
 	}
 
-	&.ee-datepicker,
 	&.ee-month-picker {
 		width: $container-width;
 	}
 
+	&.ee-datepicker,
 	&.ee-datetime-picker {
 		width: $datetime-container-width;
 	}
@@ -343,52 +343,64 @@
 							// use graduated coloring for time blocks
 							// so that nighttime blocks are darker than daytime blocks
 							&:hover {
-								background-color: var(--ee-color-blue-low-contrast);
-								color: var(--ee-text-on-blue);
+								&:nth-child(n + 32) {
+									background-color: var(--ee-color-blue-low-contrast);
+									color: var(--ee-text-on-blue);
+								}
 
-								&:nth-child(-n+16),
-								&:nth-child(n+33) {
+								&:nth-child(-n + 32),
+								&:nth-child(n + 65) {
 									background-color: var(--ee-color-blue);
+									color: var(--ee-text-on-blue);
 								}
 
-								&:nth-child(-n+12),
-								&:nth-child(n+37) {
+								&:nth-child(-n + 24),
+								&:nth-child(n + 73) {
 									background-color: var(--ee-color-blue-high-contrast);
+									color: var(--ee-text-on-blue-high-contrast);
 								}
 
-								&:nth-child(-n+8),
-								&:nth-child(n+41) {
+								&:nth-child(-n + 16),
+								&:nth-child(n + 81) {
 									background-color: var(--ee-color-blue-super-high-contrast);
+									color: var(--ee-text-on-blue-super-high-contrast);
 								}
 
-								&:nth-child(-n+4),
-								&:nth-child(n+45) {
+								&:nth-child(-n + 8),
+								&:nth-child(n + 89) {
 									background-color: var(--ee-color-dark-blue-high-contrast);
+									color: var(--ee-text-on-dark-blue-high-contrast);
 								}
 							}
 
 							&:focus {
-								border-color: var(--ee-color-blue-low-contrast);
+								&:nth-child(n + 32) {
+									border-color: var(--ee-color-blue-low-contrast);
+								}
 
-								&:nth-child(-n+16),
-								&:nth-child(n+33) {
+								&:nth-child(-n + 32),
+								&:nth-child(n + 65) {
 									border-color: var(--ee-color-blue);
 								}
 
-								&:nth-child(-n+12),
-								&:nth-child(n+37) {
+								&:nth-child(-n + 24),
+								&:nth-child(n + 73) {
 									border-color: var(--ee-color-blue-high-contrast);
 								}
 
-								&:nth-child(-n+8),
-								&:nth-child(n+41) {
+								&:nth-child(-n + 16),
+								&:nth-child(n + 81) {
 									border-color: var(--ee-color-blue-super-high-contrast);
 								}
 
-								&:nth-child(-n+4),
-								&:nth-child(n+45) {
+								&:nth-child(-n + 8),
+								&:nth-child(n + 89) {
 									border-color: var(--ee-color-dark-blue-high-contrast);
 								}
+							}
+
+							&:focus-visible {
+								outline: none;
 							}
 
 							&--disabled {
@@ -424,53 +436,58 @@
 							// use graduated coloring for time blocks
 							// so that nighttime blocks are darker than daytime blocks
 							&:hover {
-								&:nth-child(n+32) {
+								&:nth-child(n + 32) {
 									background-color: var(--ee-color-blue-low-contrast);
+									color: var(--ee-text-on-blue);
 								}
 
-								&:nth-child(-n+32),
-								&:nth-child(n+65) {
+								&:nth-child(-n + 32),
+								&:nth-child(n + 65) {
 									background-color: var(--ee-color-blue);
+									color: var(--ee-text-on-blue);
 								}
 
-								&:nth-child(-n+24),
-								&:nth-child(n+73) {
+								&:nth-child(-n + 24),
+								&:nth-child(n + 73) {
 									background-color: var(--ee-color-blue-high-contrast);
+									color: var(--ee-text-on-blue-high-contrast);
 								}
 
-								&:nth-child(-n+16),
-								&:nth-child(n+81) {
+								&:nth-child(-n + 16),
+								&:nth-child(n + 81) {
 									background-color: var(--ee-color-blue-super-high-contrast);
+									color: var(--ee-text-on-blue-super-high-contrast);
 								}
 
-								&:nth-child(-n+8),
-								&:nth-child(n+89) {
+								&:nth-child(-n + 8),
+								&:nth-child(n + 89) {
 									background-color: var(--ee-color-dark-blue-high-contrast);
+									color: var(--ee-text-on-dark-blue-high-contrast);
 								}
 							}
 
 							&:focus {
-								&:nth-child(n+32) {
+								&:nth-child(n + 32) {
 									border-color: var(--ee-color-blue-low-contrast);
 								}
 
-								&:nth-child(-n+32),
-								&:nth-child(n+65) {
+								&:nth-child(-n + 32),
+								&:nth-child(n + 65) {
 									border-color: var(--ee-color-blue);
 								}
 
-								&:nth-child(-n+24),
-								&:nth-child(n+73) {
+								&:nth-child(-n + 24),
+								&:nth-child(n + 73) {
 									border-color: var(--ee-color-blue-high-contrast);
 								}
 
-								&:nth-child(-n+16),
-								&:nth-child(n+81) {
+								&:nth-child(-n + 16),
+								&:nth-child(n + 81) {
 									border-color: var(--ee-color-blue-super-high-contrast);
 								}
 
-								&:nth-child(-n+8),
-								&:nth-child(n+89) {
+								&:nth-child(-n + 8),
+								&:nth-child(n + 89) {
 									border-color: var(--ee-color-dark-blue-high-contrast);
 								}
 							}
@@ -490,7 +507,6 @@
 			}
 		}
 	}
-
 
 	&__triangle::after {
 		.react-datepicker-popper[data-placement^='bottom'] & {
@@ -548,7 +564,7 @@
 			height: unset;
 			width: unset;
 		}
-		&__month-text  {
+		&__month-text {
 			align-items: center;
 			border-radius: 0 !important;
 			color: var(--ee-default-text-color);
@@ -564,10 +580,10 @@
 				background-color: var(--ee-color-grey-14);
 			}
 
-			&--keyboard-selected  {
-					background-color: var(--ee-color-primary-low-contrast);
-					color: var(--ee-text-on-primary);
-					font-weight: 700;
+			&--keyboard-selected {
+				background-color: var(--ee-color-primary-low-contrast);
+				color: var(--ee-text-on-primary);
+				font-weight: 700;
 
 				&:hover {
 					background-color: var(--ee-date-picker-date-in-range-bg-color-hover);

--- a/packages/dates/src/constants.ts
+++ b/packages/dates/src/constants.ts
@@ -1,6 +1,8 @@
 import { __ } from '@eventespresso/i18n';
 
+export const DEFAULT_DATE_FORMAT = 'MMM d, yyyy'; // Aug 19, 2020
 export const DEFAULT_DATETIME_FORMAT = 'MMM d, yyyy h:mm aa'; // Aug 19, 2020 3:11 PM
+export const DEFAULT_TIME_FORMAT = 'h:mm aa'; // 3:11 PM
 
 export const endDateAfterStartDateErrorMessage = __('End Date & Time must be set later than the Start Date & Time');
 

--- a/packages/predicates/src/datetimes/index.ts
+++ b/packages/predicates/src/datetimes/index.ts
@@ -1,21 +1,20 @@
 export { default as capacityAtOrAbove } from './capacityAtOrAbove';
+export { default as isActive } from './isActive';
+export { default as isDateSoldOut } from './isSoldOut';
+export { default as isInMonth } from './isInMonth';
+export { default as isInYear } from './isInYear';
 export { default as isRecentlyExpired } from './isRecentlyExpired';
+export { default as isSoldOut } from './isSoldOut';
+export { default as isUpcoming } from './isUpcoming';
+export { default as sortDates } from './sorters';
 export { default as validFiniteCapacityLimit } from './validFiniteCapacityLimit';
 export { default as validSold } from './validSold';
 export { default as validStatus } from './validStatus';
 
-export { default as isActive } from './isActive';
-export { default as isInMonth } from './isInMonth';
-export { default as isInYear } from './isInYear';
-export { default as isDateSoldOut } from './isSoldOut';
-export { default as isUpcoming } from './isUpcoming';
-export { default as isSoldOut } from './isSoldOut';
-
-export { default as sortDates } from './sorters';
-
 export * from './constants';
-export * from './types';
-export * from './filters';
 export * from './datetimeFields';
+export * from './filters';
 export * from './selectionPredicates';
+export * from './stripTimezoneFormat';
+export * from './types';
 export * from './updatePredicates';

--- a/packages/predicates/src/datetimes/stripTimezoneFormat.ts
+++ b/packages/predicates/src/datetimes/stripTimezoneFormat.ts
@@ -1,0 +1,1 @@
+export const stripTimezoneFormat = (format: string) => format.replace(/x/g, '').trim();


### PR DESCRIPTION
This PR:

- fixes https://github.com/eventespresso/cafe/issues/622
- also fixes new issue discovered while fixing https://github.com/eventespresso/cafe/pull/611
- changes the timepicker and datetimepicker time intervals to 15 minutes from 30
- strips the timezone / GMT offset from the datetime formats 