### PR TITLE
Always Apply Price Modifiers

### DIFF
--- a/packages/tpc/src/utils/applyPriceModifiers.ts
+++ b/packages/tpc/src/utils/applyPriceModifiers.ts
@@ -1,7 +1,7 @@
 import { parsedAmount } from '@eventespresso/utils';
 import { TpcPriceModifier } from '../types';
 
-const applyParallelModifiers = (baseAmount: number, modifiers: Array<TpcPriceModifier>): number => {
+const applyPriceModifiers = (baseAmount: number, modifiers: Array<TpcPriceModifier>): number => {
 	const modifications = modifiers.reduce((prevValue, { amount, isDiscount, isPercent }) => {
 		const priceAmount = parsedAmount(amount) || 0;
 
@@ -20,4 +20,4 @@ const applyParallelModifiers = (baseAmount: number, modifiers: Array<TpcPriceMod
 	return baseAmount + modifications;
 };
 
-export default applyParallelModifiers;
+export default applyPriceModifiers;

--- a/packages/tpc/src/utils/calculateBasePrice.ts
+++ b/packages/tpc/src/utils/calculateBasePrice.ts
@@ -3,7 +3,7 @@ import { reduceRight } from 'ramda';
 import { getPriceModifiers } from '@eventespresso/predicates';
 import { parsedAmount, groupByProp } from '@eventespresso/utils';
 import { DataState } from '../data';
-import undoParallelModifiers from './undoParallelModifiers';
+import undoPriceModifiers from './undoPriceModifiers';
 import { TPC_PRICE_DECIMAL_PLACES } from './constants';
 
 const calculateBasePrice = (ticketTotal: number, prices: DataState['prices']): number => {
@@ -25,7 +25,7 @@ const calculateBasePrice = (ticketTotal: number, prices: DataState['prices']): n
 
 	const newBasePriceAmount = reduceRight(
 		(pricesWithSameOrder, currentTotal) => {
-			return undoParallelModifiers(currentTotal, pricesWithSameOrder);
+			return undoPriceModifiers(currentTotal, pricesWithSameOrder);
 		},
 		ticketTotal,
 		Object.values(orderToPriceMap)

--- a/packages/tpc/src/utils/calculateTicketTotal.ts
+++ b/packages/tpc/src/utils/calculateTicketTotal.ts
@@ -16,11 +16,6 @@ const calculateTicketTotal = (prices: DataState['prices']): number => {
 	const basePrice = getBasePrice(prices);
 	const basePriceAmount = parsedAmount(basePrice.amount);
 
-	// if the king has no value, it's not good for the "story"
-	if (!basePriceAmount) {
-		return 0;
-	}
-
 	// if the battle lasts this far, pawns also matter
 	const priceModifiers = getPriceModifiers(prices);
 

--- a/packages/tpc/src/utils/calculateTicketTotal.ts
+++ b/packages/tpc/src/utils/calculateTicketTotal.ts
@@ -4,7 +4,7 @@ import { getBasePrice, getPriceModifiers } from '@eventespresso/predicates';
 import { parsedAmount, groupByProp } from '@eventespresso/utils';
 
 import { DataState } from '../data';
-import applyParallelModifiers from './applyParallelModifiers';
+import applyPriceModifiers from './applyPriceModifiers';
 
 const calculateTicketTotal = (prices: DataState['prices']): number => {
 	// if there is no wealth or a king, you know what happens
@@ -31,7 +31,7 @@ const calculateTicketTotal = (prices: DataState['prices']): number => {
 	// final nail in the coffin
 	const newTicketTotal = reduce(
 		(currentTotal, pricesWithSameOrder) => {
-			return applyParallelModifiers(currentTotal, pricesWithSameOrder);
+			return applyPriceModifiers(currentTotal, pricesWithSameOrder);
 		},
 		basePriceAmount,
 		Object.values(orderToPriceMap)

--- a/packages/tpc/src/utils/undoPriceModifiers.ts
+++ b/packages/tpc/src/utils/undoPriceModifiers.ts
@@ -1,7 +1,7 @@
 import { parsedAmount } from '@eventespresso/utils';
 import { TpcPriceModifier } from '../types';
 
-const undoParallelModifiers = (subTotal: number, modifiers: Array<TpcPriceModifier>): number => {
+const undoPriceModifiers = (subTotal: number, modifiers: Array<TpcPriceModifier>): number => {
 	const modifications = modifiers.reduce(
 		({ percents, fixedPrices }, { amount, isDiscount, isPercent }) => {
 			const priceAmount = parsedAmount(amount) || 0;
@@ -31,4 +31,4 @@ const undoParallelModifiers = (subTotal: number, modifiers: Array<TpcPriceModifi
 	return newSubTotal / (1 + modifications.percents / 100);
 };
 
-export default undoParallelModifiers;
+export default undoPriceModifiers;


### PR DESCRIPTION
This PR:

- fixes #1187
- renames the two price calculation reducers 


### testing notes

- add/edit event using EDTR
- add/edit ticket price by clicking the price calculator
- set base price to zero
- add price modifier with following values:
    - type: dollar surcharge
    - amount: 1
- [ ] confirm that ticket total is not zero