### PR TITLE
Ensure New Default Tickets ALWAYS Have a Base Price

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/data/useSubmitForm.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/defaultTickets/data/useSubmitForm.ts
@@ -8,7 +8,7 @@ import type { DataState } from './types';
 type UseSubmitForm = (dataState: DataState) => () => Promise<void>;
 
 const useSubmitForm: UseSubmitForm = ({ deletedTickets, tickets }) => {
-	const mutateTicket = useMutateTicket();
+	const mutateTicket = useMutateTicket(true);
 	const { deleteEntity: deleteTicket } = useTicketMutator();
 
 	return useCallback(async () => {

--- a/packages/tpc/src/hooks/test/useDefaultBasePrice.test.ts
+++ b/packages/tpc/src/hooks/test/useDefaultBasePrice.test.ts
@@ -34,4 +34,19 @@ describe('useDefaultBasePrice', () => {
 
 		expect(result.current.isBasePrice).toBeUndefined();
 	});
+
+	it('Sets the isDefault flag to true when createNewDefault is true', async () => {
+		const { result } = renderHook(
+			() => {
+				return useDefaultBasePrice(true);
+			},
+			{
+				wrapper: TestWrapper,
+			}
+		);
+		await actWait();
+
+		expect(result.current.isBasePrice).toBe(true);
+		expect(result.current.isDefault).toBe(true);
+	});
 });

--- a/packages/tpc/src/hooks/useDefaultBasePrice.ts
+++ b/packages/tpc/src/hooks/useDefaultBasePrice.ts
@@ -8,13 +8,16 @@ import { updatePriceModifier } from '../utils';
 import { usePriceModifier } from '../hooks';
 import { TpcPriceModifier } from '../types';
 
-const useDefaultBasePrice = (): TpcPriceModifier => {
+const useDefaultBasePrice = (createNewDefault = false): TpcPriceModifier => {
 	const allPriceTypes = usePriceTypes();
 
 	const [basePriceType] = useMemo(() => {
 		return allPriceTypes.filter(isBasePrice);
 	}, [allPriceTypes]);
 
+	if (createNewDefault) {
+		defaultPrice.isDefault = true;
+	}
 	const defaultPriceModifier = usePriceModifier(defaultPrice);
 	const basePrice = useMemo(
 		() => updatePriceModifier(defaultPriceModifier, basePriceType),

--- a/packages/tpc/src/hooks/useMutatePrices.ts
+++ b/packages/tpc/src/hooks/useMutatePrices.ts
@@ -42,7 +42,10 @@ const useMutatePrices = (createNewDefault = false): Callback => {
 				// need to ensure there is ALWAYS a base price
 				const newPriceFields = copyPriceFields(defaultBasePrice, isPriceInputField);
 				const newPrice = await createPrice(newPriceFields);
-				relatedPriceIds = [newPrice?.data?.createEspressoPrice?.espressoPrice?.id];
+				const newPriceId = newPrice?.data?.createEspressoPrice?.espressoPrice?.id;
+				if (newPriceId) {
+					relatedPriceIds = [newPriceId];
+				}
 			}
 
 			if (deletedPriceIds?.length) {

--- a/packages/tpc/src/hooks/useMutateTicket.ts
+++ b/packages/tpc/src/hooks/useMutateTicket.ts
@@ -22,9 +22,9 @@ interface TicketData extends Partial<Entity>, Omit<UpdateTicketInput, 'prices' |
 
 type Callback = (ticket: TicketData) => Promise<EntityId>;
 
-const useMutateTicket = (): Callback => {
+const useMutateTicket = (createNewDefault = false): Callback => {
 	const { createEntity: createTicket, updateEntity: updateTicket } = useTicketMutator();
-	const mutatePrices = useMutatePrices();
+	const mutatePrices = useMutatePrices(createNewDefault);
 	const tickets = useTickets();
 
 	// Async to make sure that prices are handled before updating the ticket.


### PR DESCRIPTION
plz see: https://github.com/eventespresso/cafe/issues/745

If you create a new default ticket but skip setting ticket prices, then the ticket will appear to have a price of zero. When you attempt to use that ticket on the frontend however, the system default ticket base price will get assigned, even if that base price has been edited and is no longer zero.

This PR ensures that this will not happen by creating a new default base price for any new default tickets that skip the ticket price step during default ticket creation.