### PR TITLE
Ensure New Price Modifiers Are Not Disabled

### DIFF
--- a/packages/tpc/src/buttons/AddPriceModifierButtonData.tsx
+++ b/packages/tpc/src/buttons/AddPriceModifierButtonData.tsx
@@ -25,6 +25,7 @@ const AddPriceModifierButtonData: React.FC<Partial<PriceModifierButtonProps>> = 
 			...defaultPriceModifier,
 			id: uuid(),
 			isBasePrice: priceType.isBasePrice,
+			isDefault: false, // override default price modifier
 			isDiscount: priceType.isDiscount,
 			isPercent: priceType.isPercent,
 			isTax: priceType.isTax,


### PR DESCRIPTION
While testing https://github.com/eventespresso/barista/pull/1188 Garth discovered that all inputs for newly added price modifiers were disabled.

This PR:

- overrides new price modifiers `isDefault` property and sets it to false