### PR TITLE
Set `data-selected` on Selected Option

### DIFF
--- a/packages/adapters/src/Select/Select.tsx
+++ b/packages/adapters/src/Select/Select.tsx
@@ -14,21 +14,31 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
 		const childNodes =
 			children ||
-			options.map(({ label, options: optionGroups, value, ...optionProps }, index) => {
+			options.map(({ label, options: optionGroups, value, ...optionProps }, index: number) => {
 				if (optionGroups?.length && label) {
 					return (
 						<optgroup label={label as string} key={`${label}${index}`} {...optionProps}>
-							{optionGroups.map(({ label: optLabel, value, ...optProps }, i) => (
-								<option {...optProps} value={value} key={`${value}${i}`}>
-									{optLabel}
-								</option>
-							))}
+							{optionGroups.map(({ label: optLabel, value, ...optProps }, i: number) => {
+								const oProps = { ...optProps };
+								if (props.value === value) {
+									oProps['data-selected'] = true;
+								}
+								return (
+									<option {...oProps} value={value} key={`${value}${i}`}>
+										{optLabel}
+									</option>
+								);
+							})}
 						</optgroup>
 					);
 				}
 
+				const oProps = { ...optionProps };
+				if (props.value === value) {
+					oProps['data-selected'] = true;
+				}
 				return (
-					<option {...optionProps} value={value} key={`${value}${index}`}>
+					<option {...oProps} value={value} key={`${value}${index}`}>
 						{label}
 					</option>
 				);


### PR DESCRIPTION
This PR:

- fixes #1232
- adds `data-selected='true'` to current selected option

Looks like the [Chakra UI Select component](https://chakra-ui.com/docs/components/select) doesn't display the selected option, even if you do something like: 
```js
<option {...oProps} value={value} key={`${value}${index}`} selected='true'>
```

best compromise i could find was setting `data-selected='true'` which produces the following:
![image](https://github.com/eventespresso/barista/assets/1751030/b67940dd-2133-4b7c-8216-deb574f89c27)
