### PR TITLE
Fix RTE Button Active State Styles

### DIFF
--- a/packages/rich-text-editor/src/components/RichTextEditor/style.scss
+++ b/packages/rich-text-editor/src/components/RichTextEditor/style.scss
@@ -26,7 +26,7 @@
 		border: none;
 		border-radius: 0;
 		margin: 0;
-		padding:  var(--ee-padding-tiny) 0 var(--ee-padding-small);
+		padding: var(--ee-padding-tiny) 0 var(--ee-padding-small);
 		display: flex;
 		flex-wrap: wrap;
 
@@ -88,6 +88,13 @@
 			color: var(--ee-default-text-color-high-contrast);
 			font-weight: 100;
 		}
+		.public-DraftStyleDefault-block:first-child {
+			margin-block-start: 0;
+		}
+		pre .public-DraftStyleDefault-block,
+		pre .public-DraftStyleDefault-block:first-child {
+			margin: var(--ee-margin-pico);
+		}
 	}
 
 	.public-DraftEditor-content,
@@ -101,7 +108,7 @@
 	}
 
 	&-root {
-		.ee-tabs  {
+		.ee-tabs {
 			.ee-tabs__tab {
 				&-list {
 					// margin-inline-end: 1rem;

--- a/packages/rich-text-editor/src/rte-old/components/RichTextEditor/style.scss
+++ b/packages/rich-text-editor/src/rte-old/components/RichTextEditor/style.scss
@@ -2,7 +2,7 @@
 @import '~@eventespresso/styles/src/mixins/transition';
 
 @mixin ee-rte-option {
-	background: var(--ee-button-background-rte);
+	background: var(--ee-button-background);
 	border: var(--ee-border-width) solid var(--ee-border-color);
 	border-color: transparent;
 	border-radius: var(--ee-border-radius-small);
@@ -61,11 +61,23 @@
 			padding: var(--ee-padding-smaller);
 		}
 
-		.rdw-option-wrapper {
-			@include ee-rte-option;
+		.rdw-option {
+			&-wrapper {
+				@include ee-rte-option;
 
-			&.rdw-option-disabled {
-				cursor: not-allowed;
+				&.rdw-option-disabled {
+					cursor: not-allowed;
+				}
+			}
+
+			&-active {
+				background: var(--ee-color-primary);
+				color: var(--ee-text-on-primary);
+
+				img {
+					filter: invert(1);
+					opacity: 1;
+				}
 			}
 		}
 
@@ -135,20 +147,6 @@
 			// override WP image styles
 			border: 0 !important;
 			opacity: 0.65;
-		}
-	}
-
-	&__controls {
-		&-bold,
-		&-italic,
-		&-underline,
-		&-ordered,
-		&-unordered {
-			@include ee-rte-option;
-		}
-
-		&-block-type {
-			@include ee-rte-block-dropdown;
 		}
 	}
 


### PR DESCRIPTION
This PR:

- fixes #1240 
- also fixes some margin issues in the basic RTE

![image](https://github.com/eventespresso/barista/assets/1751030/efe955d5-6719-448f-8ac0-7c48f9b2d7b3)

### testing



- follow these steps for setting up testing for Barista PRs:
  https://github.com/eventespresso/barista/wiki/Getting-Started:-Quality-Assurance-Testing

- the branch for this PR is
   ```
   FIX/RTE-button-styles
   ```

- now go to the Event Espresso Events admin page and add/edit an event

- follow the steps from your original post to recreate the reported issue 

- [ ] confirm that the RTE (Rich Text Editor) toolbar buttons accurately reflect the editor state when styles are applied to text