### PR TITLE
Set time to fixed point in E2E environment

### DIFF
--- a/e2e-tests/ddev/.ddev/commands/web/freeze-time
+++ b/e2e-tests/ddev/.ddev/commands/web/freeze-time
@@ -12,7 +12,7 @@ if grep -q ClockMock $file; then
 fi
 
 if [[ "$1" == '' ]]; then
-  echo 'Error: missing timestamp value (taken as a literal string)!'
+  echo 'Error: missing timestamp value (taken as a literal string or number)!'
   echo '  for example, ddev freeze-time 1986-06-05'
   echo '  for more details, see PHP docs on new DateTime() constructor'
   exit 1

--- a/e2e-tests/ddev/.ddev/commands/web/freeze-time
+++ b/e2e-tests/ddev/.ddev/commands/web/freeze-time
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+## Description: Freeze WordPress time so that it is always the same
+## Usage: freeze-time
+## Example: ddev freeze-time
+
+file='wp-config.php'
+
+if grep -q ClockMock $file; then
+  echo 'Error: you have already fixed time in wp-config.php!'
+  exit 1
+fi
+
+if [[ "$1" == '' ]]; then
+  echo 'Error: missing timestamp value (taken as a literal string)!'
+  echo '  for example, ddev freeze-time 1986-06-05'
+  echo '  for more details, see PHP docs on new DateTime() constructor'
+  exit 1
+fi
+
+if [[ ! -f $file ]]
+then
+  echo "WordPress config not found in current directory!"
+  exit 1
+fi
+
+composer require slope-it/clock-mock
+
+# https://stackoverflow.com/a/23930212/4343719
+read -r -d '' php << EOM
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+use SlopeIt\ClockMock\ClockMock;
+ClockMock::freeze(new DateTime('$1'));
+
+EOM
+
+sed -i -e 's/<?php//g' $file
+
+config=$(cat $file)
+
+echo "$php" > $file
+
+echo "$config" >> $file

--- a/e2e-tests/ddev/.ddev/commands/web/freeze-time
+++ b/e2e-tests/ddev/.ddev/commands/web/freeze-time
@@ -11,7 +11,7 @@ if grep -q ClockMock $file; then
   exit 1
 fi
 
-if [[ "$1" == '' ]]; then
+if [[ -z "$1" ]]; then
   echo 'Error: missing timestamp value (taken as a literal string or number)!'
   echo '  for example, ddev freeze-time 1986-06-05'
   echo '  for more details, see PHP docs on new DateTime() constructor'

--- a/e2e-tests/ddev/.ddev/config.yaml
+++ b/e2e-tests/ddev/.ddev/config.yaml
@@ -12,6 +12,7 @@ database:
 use_dns_when_possible: true
 composer_version: '2'
 web_environment: []
+webimage_extra_packages: [php8.1-uopz]
 nodejs_version: '18'
 hooks:
     post-start:

--- a/e2e-tests/ddev/.ddev/config.yaml
+++ b/e2e-tests/ddev/.ddev/config.yaml
@@ -15,9 +15,9 @@ web_environment: []
 nodejs_version: '18'
 hooks:
     post-start:
-        - exec: 'wp core download'
-        - exec: 'wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db'
-        - exec: 'wp core install --url="$DDEV_PRIMARY_URL" --title="$DDEV_PROJECT" --admin_user=admin --admin_email=admin@fake.test --admin_password=password'
-        - exec: 'wp plugin activate event-espresso-core barista'
-        - exec: 'wp rewrite structure "/%postname%/"'
-        - exec: 'wp rewrite flush --hard' # in case we ever use apache
+        - exec: wp core download
+        - exec: wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db
+        - exec: wp core install --url="$DDEV_PRIMARY_URL" --title="$DDEV_PROJECT" --admin_user=admin --admin_email=admin@fake.test --admin_password=password
+        - exec: wp plugin activate event-espresso-core barista
+        - exec: wp rewrite structure "/%postname%/"
+        - exec: wp rewrite flush --hard # in case we ever use apache

--- a/e2e-tests/ddev/.ddev/config.yaml
+++ b/e2e-tests/ddev/.ddev/config.yaml
@@ -18,6 +18,7 @@ hooks:
     post-start:
         - exec: wp core download
         - exec: wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db
+        - exec-host: ddev freeze-time 2023-08-05
         - exec: wp core install --url="$DDEV_PRIMARY_URL" --title="$DDEV_PROJECT" --admin_user=admin --admin_email=admin@fake.test --admin_password=password
         - exec: wp plugin activate event-espresso-core barista
         - exec: wp rewrite structure "/%postname%/"

--- a/e2e-tests/ddev/.ddev/config.yaml
+++ b/e2e-tests/ddev/.ddev/config.yaml
@@ -18,7 +18,7 @@ hooks:
     post-start:
         - exec: wp core download
         - exec: wp config create --dbname=db --dbuser=db --dbpass=db --dbhost=db
-        - exec-host: ddev freeze-time 2023-08-05
+        - exec: /mnt/ddev_config/commands/web/freeze-time "$FREEZE_TIME"
         - exec: wp core install --url="$DDEV_PRIMARY_URL" --title="$DDEV_PROJECT" --admin_user=admin --admin_email=admin@fake.test --admin_password=password
         - exec: wp plugin activate event-espresso-core barista
         - exec: wp rewrite structure "/%postname%/"

--- a/e2e-tests/ddev/.ddev/docker-compose.override.yaml
+++ b/e2e-tests/ddev/.ddev/docker-compose.override.yaml
@@ -7,3 +7,7 @@ services:
         target: /var/www/html/wp-content/mu-plugins/freeze-time.php
         type: bind
         consistency: cached
+      - source: mu-plugins/freeze-time.js
+        target: /var/www/html/wp-content/mu-plugins/freeze-time.js
+        type: bind
+        consistency: cached

--- a/e2e-tests/ddev/.ddev/docker-compose.override.yaml
+++ b/e2e-tests/ddev/.ddev/docker-compose.override.yaml
@@ -1,0 +1,9 @@
+services:
+  web:
+    volumes:
+    # for must-use plugins, we cannot override subdirectory
+    #  b/c cafe repository has its own must-use plugins
+      - source: mu-plugins/freeze-time.php
+        target: /var/www/html/wp-content/mu-plugins/freeze-time.php
+        type: bind
+        consistency: cached

--- a/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.js
+++ b/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.js
@@ -1,0 +1,13 @@
+const fakeNow = new Date('%s').valueOf();
+Date = class extends Date {
+	constructor(...args) {
+		if (args.length === 0) {
+			super(fakeNow);
+		} else {
+			super(...args);
+		}
+	}
+};
+const __DateNowOffset = fakeNow - Date.now();
+const __DateNow = Date.now;
+Date.now = () => __DateNow() + __DateNowOffset;

--- a/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
+++ b/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
@@ -8,7 +8,7 @@
 function freeze_time(): void
 {
   $template = file_get_contents(__DIR__ . '/freeze-time.js');
-  $script = sprintf($template, 'August 05 2023 00:00:00');
+  $script = sprintf($template, $_ENV['FREEZE_TIME']);
 
   echo '<script>';
   echo $script . PHP_EOL;

--- a/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
+++ b/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Plugin Name: Freeze Time (JavaScript)
+ * Description: Part of E2E environment, fixes time for browsers to a deterministic point in time to make relative time predictable, see issue #1247 under Barista repo. For server-side time fixing, see wp-config.php. MU plugin is *not* suitable for overriding server-side time as we need to override time *before* WordPress initiation sequence starts.
+ */
+
+function freeze_time(): void
+{
+  echo '<script>';
+  echo <<<'JS'
+const fakeNow = new Date('August 05 2023 00:00:00').valueOf();
+Date = class extends Date {
+  constructor(...args) {
+    if (args.length === 0) {
+      super(fakeNow);
+    } else {
+      super(...args);
+    }
+  }
+};
+const __DateNowOffset = fakeNow - Date.now();
+const __DateNow = Date.now;
+Date.now = () => __DateNow() + __DateNowOffset;
+
+JS;
+  echo '</script>' . PHP_EOL;
+}
+
+// ensure highest level of override, before *anything* else gets a chance to start, run, etc.
+$priority = PHP_INT_MIN;
+
+// keep in mind that for normal plugins, this is NOT how you do it
+// but in the context of E2E it is important to fix time to a
+// specific point so that relative time like last month is always
+// the same
+add_action('admin_enqueue_scripts', 'freeze_time', $priority);
+add_action('wp_head', 'freeze_time', $priority);

--- a/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
+++ b/e2e-tests/ddev/.ddev/mu-plugins/freeze-time.php
@@ -7,23 +7,11 @@
 
 function freeze_time(): void
 {
-  echo '<script>';
-  echo <<<'JS'
-const fakeNow = new Date('August 05 2023 00:00:00').valueOf();
-Date = class extends Date {
-  constructor(...args) {
-    if (args.length === 0) {
-      super(fakeNow);
-    } else {
-      super(...args);
-    }
-  }
-};
-const __DateNowOffset = fakeNow - Date.now();
-const __DateNow = Date.now;
-Date.now = () => __DateNow() + __DateNowOffset;
+  $template = file_get_contents(__DIR__ . '/freeze-time.js');
+  $script = sprintf($template, 'August 05 2023 00:00:00');
 
-JS;
+  echo '<script>';
+  echo $script . PHP_EOL;
   echo '</script>' . PHP_EOL;
 }
 

--- a/e2e-tests/ddev/.ddev/php/uopz-override.ini
+++ b/e2e-tests/ddev/.ddev/php/uopz-override.ini
@@ -1,0 +1,1 @@
+uopz.exit=1

--- a/e2e-tests/ddev/.gitignore
+++ b/e2e-tests/ddev/.gitignore
@@ -1,3 +1,4 @@
 .*
 !.gitignore
 !.*.example
+!.ddev/

--- a/e2e-tests/ddev/MakeConfig.ts
+++ b/e2e-tests/ddev/MakeConfig.ts
@@ -67,7 +67,12 @@ class MakeConfig {
 			const configPath = resolve(source, o.file);
 			const configYaml = this.loadYamlConfig(configPath);
 			const mergeFn = (l: any, r: any): any => {
-				if (typeof l === 'object') return R.concat(l, r);
+				if (Array.isArray(l)) {
+					return R.concat(l, r);
+				}
+				if (R.is(Object, l)) {
+					return R.mergeAll([l, r]);
+				}
 				return r;
 			};
 			const newConfig = R.mergeDeepWith(mergeFn, configYaml, o.override);

--- a/e2e-tests/ddev/MakeConfig.ts
+++ b/e2e-tests/ddev/MakeConfig.ts
@@ -58,6 +58,7 @@ class MakeConfig {
 				name: manifest.project,
 				router_http_port: opts.httpPort,
 				router_https_port: opts.httpsPort,
+				web_environment: [`FREEZE_TIME=${this.getFreezeTime()}`],
 			},
 		};
 
@@ -80,6 +81,21 @@ class MakeConfig {
 			const newYaml = yaml.stringify(newConfig);
 			writeFileSync(newPath, newYaml);
 		}
+	}
+
+	/**
+	 * Always return 15th of the current month to avoid dealing with unexpected issues like today become yesterday when running E2E test on the last day of the months on the last hour
+	 */
+	private getFreezeTime(): string {
+		const today = new Date();
+		// we want *local* time to 15th 00:00:00 hence we are using UTC
+		// https://stackoverflow.com/a/32648115/4343719
+		// if timezone will become an issue, it can be addressed by
+		//   - adjusting PlayWright config (client-side)
+		//   - adjusting Docker container timezone (server-side)
+		today.setUTCDate(15);
+		today.setUTCHours(0, 0, 0, 0);
+		return today.toISOString(); // ISO 8601 format
 	}
 
 	public parseCliArgs(): void {

--- a/e2e-tests/ddev/MakeConfig.ts
+++ b/e2e-tests/ddev/MakeConfig.ts
@@ -100,8 +100,11 @@ class MakeConfig {
 			.addOption(new Option('-h, --http-port <port>', 'HTTP port for Traefik router'))
 			.addOption(new Option('-s, --https-port <port>', 'HTTPS port for Traefik router'))
 			.action(async (project, cafe, barista, opts) => {
-				if (!cafe || !barista) {
-					throw new Error('Unexpected runtime condition!');
+				if (!cafe) {
+					throw new Error('Missing environment variable: CAFE');
+				}
+				if (!barista) {
+					throw new Error('Missing environment variable: BARISTA');
 				}
 				const options: Options = {};
 				if (opts.httpPort) {

--- a/e2e-tests/ddev/MakeConfig.ts
+++ b/e2e-tests/ddev/MakeConfig.ts
@@ -84,14 +84,10 @@ class MakeConfig {
 			.argument('<project>', 'DDEV project name')
 			.argument('<cafe>', 'path to cafe repository')
 			.argument('<barista>', 'path to barista repository')
-			.addOption(new Option('-p, --path <path>', 'Path where config will be saved to').default(undefined))
 			.addOption(new Option('-h, --http-port <port>', 'HTTP port for Traefik router'))
 			.addOption(new Option('-s, --https-port <port>', 'HTTPS port for Traefik router'))
 			.action(async (project, cafe, barista, opts) => {
 				const options: Options = {};
-				if (opts.path) {
-					options['path'] = opts.path;
-				}
 				if (opts.httpPort) {
 					options['httpPort'] = parseInt(opts.httpPort);
 				}

--- a/e2e-tests/fixtures/DateFactory.ts
+++ b/e2e-tests/fixtures/DateFactory.ts
@@ -8,7 +8,22 @@ class DateFactory {
 
 	constructor() {
 		// if you decide to change base, keep in mind that there is code that is rendered by PHP (see WpEnv for implementation details)
-		this.base = 'December 15 2042 13:37:00';
+		this.base = this.getBase();
+	}
+
+	/**
+	 * Always return 15th of the current month to avoid dealing with unexpected issues like today become yesterday when running E2E test on the last day of the months on the last hour
+	 */
+	private getBase(): string {
+		const today = new Date();
+		// we want *local* time to 15th 00:00:00 hence we are using UTC
+		// https://stackoverflow.com/a/32648115/4343719
+		// if timezone will become an issue, it can be addressed by
+		//   - adjusting PlayWright config (client-side)
+		//   - adjusting Docker container timezone (server-side)
+		today.setUTCDate(15);
+		today.setUTCHours(0, 0, 0, 0);
+		return today.toISOString(); // ISO 8601 format
 	}
 
 	public minutes(minutes: number): DateFactory {


### PR DESCRIPTION
In order to avoid flakiness with E2E tests due to relative time like `today`, `next week`, `last month`, I have fixed the time to _always_ be 15th of the _current_ month. This way:

- SSL will always be valid as the date won't be something crazy way in the future
- being 15th of the month, we don't need to consider if month has 30 or 31 days
- time being fixed to a precise day makes it easy to create entities like `datetime` that have happened `last month`

---

This fixes #1247