### PR TITLE
Add stub for cafe repository function espresso_version()

### DIFF
--- a/stubs/cafe.php
+++ b/stubs/cafe.php
@@ -1,0 +1,14 @@
+<?php
+
+// here I will include stubs related to Cafe repository for IDE auto-completion
+
+/**
+ * espresso_version
+ * Returns the plugin version
+ *
+ * @return string
+ */
+function espresso_version(): string
+{
+  return '';
+}


### PR DESCRIPTION
Without this stub, IDE will complain that function `espresso_version()` does not exist. This is due to function being defined in Cafe repository. The function itself works fine as it is defined and loaded _after_ core plugin is loaded.

![image](https://github.com/eventespresso/barista/assets/3331946/a3970f9a-386e-4f42-a4c7-82c038b6cd95)
