### PR TITLE
Fix branch name for E2E tests cache warmup workflow

### DIFF
--- a/.github/workflows/e2e-cache-warmup.yml
+++ b/.github/workflows/e2e-cache-warmup.yml
@@ -27,7 +27,7 @@ jobs:
                   private-key: ${{ secrets.GH_ACTIONS_SSH_PRIVATE_KEY }}
 
             - name: Run E2E Tests
-              uses: eventespresso/actions/packages/e2e-tests@CHORE/create-e2e-tests-package
+              uses: eventespresso/actions/packages/e2e-tests@main
               with:
                   cafe_repo_branch: DEV
                   barista_repo_branch: master


### PR DESCRIPTION
### this pull request:

Fixes E2E cache warmup workflow failing due to wrong branch name. Example of error [here](https://github.com/eventespresso/cafe/actions/runs/6061186877/workflow):

> Unable to resolve action `eventespresso/actions@CHORE/create-e2e-tests-package`, unable to find version `CHORE/create-e2e-tests-package`

Test note: due to how GitHub workflows work, this change won't apply until it is merged into main branch (hard limitation of GitHub).