### PR TITLE
Narrow down type of the property __typename in the interface Entity

### DIFF
--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -9,7 +9,7 @@ export interface Cacheable {
 export interface Entity extends Cacheable {
 	id: EntityId;
 	dbId: EntityDbId;
-	// unless otherwise state, the entity/type comes from EE core i.e.
+	// unless otherwise stated, the entity/type comes from EE core i.e.
 	// plugins/event-espresso-core/core/domain/services/graphql/types/*.php
 	__typename?:
 		| 'EspressoAttendee'

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -9,7 +9,22 @@ export interface Cacheable {
 export interface Entity extends Cacheable {
 	id: EntityId;
 	dbId: EntityDbId;
-	__typename?: string;
+	// unless otherwise state, the entity/type comes from EE core i.e.
+	// plugins/event-espresso-core/core/domain/services/graphql/types/*.php
+	__typename?:
+		| 'EspressoAttendee'
+		| 'EspressoCountry'
+		| 'EspressoDatetime'
+		| 'EspressoEvent'
+		| 'EspressoFormElement'
+		| 'EspressoFormSection'
+		| 'EspressoPrice'
+		| 'EspressoPriceType'
+		| 'EspressoRootQuery'
+		| 'EspressoState'
+		| 'EspressoTicket'
+		| 'EspressoVenue'
+		| 'EspressoRecurrence'; // Recuring Events Manager (REM)
 }
 
 export interface Trashable {


### PR DESCRIPTION
I think we could benefit from a more narrow type for `__typename` property since we can infer those values from Cafe repository since those values are not dynamically generated but come from concretely defined classes