### PR TITLE
Add New Feature Flags Admin UI

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/bulkEdit/actions/Actions.tsx
@@ -2,10 +2,9 @@ import { useState, useCallback } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { BulkActions } from '@eventespresso/ee-components';
-import { Collapsible } from '@eventespresso/ui-components';
 import { DatetimeStatus } from '@eventespresso/predicates';
 import { USE_ADVANCED_EDITOR } from '@eventespresso/constants';
-import { useBulkEdit } from '@eventespresso/services';
+import { useBulkEdit, useFeature } from '@eventespresso/services';
 import { useDatesListFilterState, hooks } from '@eventespresso/edtr-services';
 import { useDisclosure, useMemoStringify } from '@eventespresso/hooks';
 import { withCurrentUserCan } from '@eventespresso/services';
@@ -22,10 +21,11 @@ const actions: Array<Action> = ['edit-details', 'delete', ''];
 const Actions: React.FC = () => {
 	const [action, setAction] = useState<Action>('');
 	const bulkEdit = useBulkEdit();
+	const canUseBulkEdit = useFeature('ee_event_editor_bulk_edit');
 
 	const { isOpen, onOpen, onClose } = useDisclosure();
 
-	const { status, showBulkActions } = useDatesListFilterState();
+	const { status } = useDatesListFilterState();
 
 	const areTrashedDates = status === DatetimeStatus.trashedOnly;
 
@@ -59,21 +59,21 @@ const Actions: React.FC = () => {
 	);
 
 	return (
-		<Collapsible show={showBulkActions}>
-			<BulkActions
-				Checkbox={Checkbox}
-				defaultAction=''
-				id={'ee-bulk-edit-dates-actions'}
-				onApply={onApply}
-				options={options}
-			/>
-			{isOpen && (
+		canUseBulkEdit && (
+			<>
+				<BulkActions
+					Checkbox={Checkbox}
+					defaultAction=''
+					id={'ee-bulk-edit-dates-actions'}
+					onApply={onApply}
+					options={options}
+				/>
 				<>
-					{action === 'edit-details' && <EditDetails isOpen={true} onClose={onClose} />}
+					{action === 'edit-details' && <EditDetails isOpen={isOpen} onClose={onClose} />}
 					{action === 'delete' && <Delete areTrashedDates={areTrashedDates} onClose={onClose} />}
 				</>
-			)}
-		</Collapsible>
+			</>
+		)
 	);
 };
 

--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/useBodyRowGenerator.tsx
@@ -6,7 +6,7 @@ import * as R from 'ramda';
 import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components';
 import { filterCellByStartOrEndDate, useDatetimes, useLazyDatetime } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
-import { useTimeZoneTime } from '@eventespresso/services';
+import { useFeature, useTimeZoneTime } from '@eventespresso/services';
 import { getDatetimeBackgroundColorClassName, datetimeStatus } from '@eventespresso/helpers';
 import { findEntityByGuid } from '@eventespresso/predicates';
 import type { EntityId } from '@eventespresso/data';
@@ -28,13 +28,14 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 	const datetimes = useDatetimes();
 	const getDatetime = useCallback((id: EntityId) => findEntityByGuid(datetimes)(id), [datetimes]);
 	const getLazyDatetime = useLazyDatetime();
+	const canUseBulkEdit = useFeature('ee_event_editor_bulk_edit');
 	const { formatForSite: format } = useTimeZoneTime();
 
 	return useCallback<DatesTableBodyRowGen>(
 		({ entityId, filterState }) => {
 			const datetime = getDatetime(entityId) || getLazyDatetime(entityId);
 
-			const { displayStartOrEndDate, showBulkActions } = filterState;
+			const { displayStartOrEndDate } = filterState;
 
 			const bgClassName = getDatetimeBackgroundColorClassName(datetime);
 			const id = datetime.dbId || 0;
@@ -48,7 +49,7 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 				value: datetime.name,
 			};
 
-			const bulkActionCheckboxCell: CellData = showBulkActions && {
+			const bulkActionCheckboxCell: CellData = canUseBulkEdit && {
 				key: 'cell',
 				size: 'micro',
 				textAlign: 'center',
@@ -147,7 +148,7 @@ const useBodyRowGenerator = (): DatesTableBodyRowGen => {
 				type: 'row',
 			};
 		},
-		[format, getDatetime, getLazyDatetime]
+		[canUseBulkEdit, format, getDatetime, getLazyDatetime]
 	);
 };
 

--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/useHeaderRowGenerator.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/tableView/useHeaderRowGenerator.tsx
@@ -6,12 +6,14 @@ import { filterCellByStartOrEndDate } from '@eventespresso/edtr-services';
 import type { CellData } from '@eventespresso/ui-components';
 import type { HeaderRowGeneratorFn } from '@eventespresso/ee-components';
 import type { DatetimesFilterStateManager } from '@eventespresso/edtr-services';
+import { useFeature } from '@eventespresso/services';
 
 import Checkbox from './Checkbox';
 
 type DatesTableHeaderRowGen = HeaderRowGeneratorFn<DatetimesFilterStateManager>;
 
 const useHeaderRowGenerator = (): DatesTableHeaderRowGen => {
+	const canUseBulkEdit = useFeature('ee_event_editor_bulk_edit');
 	const stripeCell: CellData = useMemo(
 		() => ({
 			className: 'ee-entity-list-status-stripe',
@@ -128,9 +130,9 @@ const useHeaderRowGenerator = (): DatesTableHeaderRowGen => {
 
 	return useCallback<DatesTableHeaderRowGen>(
 		(filterState) => {
-			const { displayStartOrEndDate, showBulkActions } = filterState;
+			const { displayStartOrEndDate } = filterState;
 
-			const checkboxCell: CellData = showBulkActions && {
+			const checkboxCell: CellData = canUseBulkEdit && {
 				key: 'checkbox',
 				size: 'micro',
 				textAlign: 'center',
@@ -169,7 +171,18 @@ const useHeaderRowGenerator = (): DatesTableHeaderRowGen => {
 				type: 'row',
 			};
 		},
-		[actionsCell, capacityCell, endCell, idCell, nameCell, registrationsCell, soldCell, startCell, stripeCell]
+		[
+			actionsCell,
+			canUseBulkEdit,
+			capacityCell,
+			endCell,
+			idCell,
+			nameCell,
+			registrationsCell,
+			soldCell,
+			startCell,
+			stripeCell,
+		]
 	);
 };
 

--- a/domains/core/admin/eventEditor/src/ui/datetimes/registryInit.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/registryInit.tsx
@@ -94,7 +94,7 @@ const datesListFilterBar: DatesListFilterBarCallback = ({ listId, registry }) =>
 
 	registerFilterBarItem('sortBy', () => {
 		return (
-			<FilterBarFilter>
+			<FilterBarFilter width='big'>
 				<SortByControl />
 			</FilterBarFilter>
 		);

--- a/domains/core/admin/eventEditor/src/ui/tickets/registryInit.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/registryInit.tsx
@@ -83,7 +83,7 @@ const ticketsListFilterBar: TicketsListFilterBarCallback = ({ listId, registry }
 
 	registerFilterBarItem('isChained', () => {
 		return (
-			<FilterBarFilter className='ee-filter-bar__chain ee-filter-bar__filter--micro'>
+			<FilterBarFilter className='ee-filter-bar__chain' width='micro'>
 				<IsChainedButton />
 			</FilterBarFilter>
 		);
@@ -107,7 +107,7 @@ const ticketsListFilterBar: TicketsListFilterBarCallback = ({ listId, registry }
 
 	registerFilterBarItem('sortBy', () => {
 		return (
-			<FilterBarFilter>
+			<FilterBarFilter width='big'>
 				<SortByControl />
 			</FilterBarFilter>
 		);

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/options.ts
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/filterBar/controls/options.ts
@@ -49,7 +49,7 @@ export const sortByOptions = {
 
 export const labels = {
 	displayStartOrEndDate: __('display'),
-	isChained: __('link'),
+	isChained: __('linked'),
 	sales: __('sales'),
 	search: __('search'),
 	sortBy: __('sort by'),

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
@@ -7,7 +7,7 @@ import { addZebraStripesOnMobile, CellData } from '@eventespresso/ui-components'
 import { CurrencyDisplay } from '@eventespresso/ee-components';
 import { filterCellByStartOrEndDate, useTickets, useLazyTicket } from '@eventespresso/edtr-services';
 import { ENTITY_LIST_DATE_TIME_FORMAT } from '@eventespresso/constants';
-import { useTimeZoneTime } from '@eventespresso/services';
+import { useFeature, useTimeZoneTime } from '@eventespresso/services';
 import { getTicketBackgroundColorClassName, ticketStatus } from '@eventespresso/helpers';
 import { findEntityByGuid } from '@eventespresso/predicates';
 import type { EntityId } from '@eventespresso/data';
@@ -26,12 +26,13 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 	const tickets = useTickets();
 	const getTicket = useCallback((id: EntityId) => findEntityByGuid(tickets)(id), [tickets]);
 	const getLazyTicket = useLazyTicket();
+	const canUseBulkEdit = useFeature('ee_event_editor_bulk_edit');
 	const { formatForSite: format } = useTimeZoneTime();
 
 	return useCallback<TicketsTableBodyRowGen>(
 		({ entityId, filterState }) => {
 			const ticket = getTicket(entityId) || getLazyTicket(entityId);
-			const { displayStartOrEndDate, showBulkActions } = filterState;
+			const { displayStartOrEndDate } = filterState;
 
 			const bgClassName = getTicketBackgroundColorClassName(ticket);
 			const id = ticket.dbId || 0;
@@ -45,7 +46,7 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 				value: ticket.name,
 			};
 
-			const bulkActionCheckboxCell: CellData = showBulkActions && {
+			const bulkActionCheckboxCell: CellData = canUseBulkEdit && {
 				key: 'cell',
 				size: 'micro',
 				textAlign: 'center',
@@ -155,7 +156,7 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 				type: 'row',
 			};
 		},
-		[format, getLazyTicket, getTicket]
+		[canUseBulkEdit, format, getLazyTicket, getTicket]
 	);
 };
 

--- a/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/useHeaderRowGenerator.tsx
+++ b/domains/core/admin/eventEditor/src/ui/tickets/ticketsList/tableView/useHeaderRowGenerator.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { __ } from '@eventespresso/i18n';
 import { filterCellByStartOrEndDate } from '@eventespresso/edtr-services';
+import { useFeature } from '@eventespresso/services';
 
 import type { CellData } from '@eventespresso/ui-components';
 import type { HeaderRowGeneratorFn } from '@eventespresso/ee-components';
@@ -12,6 +13,7 @@ import Checkbox from './Checkbox';
 type TicketsTableHeaderRowGen = HeaderRowGeneratorFn<TicketsFilterStateManager>;
 
 const useHeaderRowGenerator = (): TicketsTableHeaderRowGen => {
+	const canUseBulkEdit = useFeature('ee_event_editor_bulk_edit');
 	const stripeCell: CellData = useMemo(
 		() => ({
 			className: 'ee-entity-list-status-stripe',
@@ -127,9 +129,9 @@ const useHeaderRowGenerator = (): TicketsTableHeaderRowGen => {
 
 	return useCallback<TicketsTableHeaderRowGen>(
 		(filterState) => {
-			const { displayStartOrEndDate, showBulkActions } = filterState;
+			const { displayStartOrEndDate } = filterState;
 
-			const checkboxCell: CellData = showBulkActions && {
+			const checkboxCell: CellData = canUseBulkEdit && {
 				key: 'checkbox',
 				size: 'micro',
 				textAlign: 'center',
@@ -172,6 +174,7 @@ const useHeaderRowGenerator = (): TicketsTableHeaderRowGen => {
 		[
 			idCell,
 			actionsCell,
+			canUseBulkEdit,
 			endCell,
 			nameCell,
 			priceCell,

--- a/ee-barista.php
+++ b/ee-barista.php
@@ -22,7 +22,6 @@
  * GitHub Plugin URI: https://github.com/eventespresso/packages
  */
 
-use EventEspresso\core\domain\services\capabilities\FeatureFlagsConfig;
 
 defined('ABSPATH') || die();
 
@@ -33,8 +32,8 @@ define('EE_BARISTA_URL', trailingslashit(plugins_url('', __FILE__)));
 add_action(
     'AHEE__EE_System__load_espresso_addons',
     function () {
-        require_once __DIR__ . '/lib/Barista.php';
-        $barista = new Barista();
+		EE_Psr4AutoloaderInit::psr4_loader()->addNamespace('EventEspresso\Barista', __DIR__. '/lib');
+        $barista = new EventEspresso\Barista\Barista();
         $barista->initialize();
     }
 );

--- a/lib/Barista.php
+++ b/lib/Barista.php
@@ -1,328 +1,329 @@
 <?php
 
+namespace EventEspresso\Barista;
+
+use WP_Scripts;
+use WP_Styles;
+
 class Barista
 {
+	private array $entry_points = [];
 
-    /**
-     * @var array
-     */
-    private $entry_points;
+	private array $manifest = [];
 
-    /**
-     * @var array
-     */
-    private $manifest;
+	private array $styles = [];
 
-    /**
-     * @var array
-     */
-    private $styles = [];
-
-    /**
-     * @var array
-     */
-    private $edtr_domains = ['eventSmart'];
+	private array $edtr_domains = ['eventSmart'];
 
 
-    public function initialize()
-    {
-        add_action('wp_default_scripts', [$this, 'registerScripts']);
-        add_action('wp_default_styles', [$this, 'registerPackagesStyles']);
-        add_action('admin_enqueue_scripts', [$this, 'addAssets']);
-        add_action('admin_enqueue_scripts', [$this, 'enqueueScripts']);
-    }
+	public function initialize()
+	{
+		add_action('wp_default_scripts', [$this, 'registerScripts']);
+		add_action('wp_default_styles', [$this, 'registerPackagesStyles']);
+		add_action('admin_enqueue_scripts', [$this, 'addAssets']);
+		add_action('admin_enqueue_scripts', [$this, 'enqueueScripts']);
+		add_filter(
+			'FHEE__Maintenance_Admin_Page__page_setup__page_config',
+			[FeatureFlagsAdminPage::class, 'loadFeatureFlagsAdminPageConfig']
+		);
+		add_filter(
+			'FHEE__Maintenance_Admin_Page__page_setup__page_routes',
+			[FeatureFlagsAdminPage::class, 'loadFeatureFlagsAdminPageRoutes']
+		);
+	}
 
 
-    /**
-     * Retrieves a URL to a file in the ee_barista plugin.
-     *
-     * @param string $path Relative path of the desired file.
-     *
-     * @return string       Fully qualified URL pointing to the desired file.
-     *
-     * @since 0.0.1
-     */
-    public function url(string $path): string
-    {
-        return EE_BARISTA_URL . $path;
-    }
+	/**
+	 * Retrieves a URL to a file in the ee_barista plugin.
+	 *
+	 * @param string $path Relative path of the desired file.
+	 *
+	 * @return string       Fully qualified URL pointing to the desired file.
+	 *
+	 * @since 0.0.1
+	 */
+	public function url(string $path): string
+	{
+		return EE_BARISTA_URL . $path;
+	}
 
 
-    /**
-     * @return array
-     */
-    protected function getEntryPoints(): array
-    {
-        if (! $this->entry_points) {
-            $this->entry_points = array_keys($this->getManifest('entrypoints'));
-        }
-        return $this->entry_points;
-    }
+	/**
+	 * @return array
+	 */
+	protected function getEntryPoints(): array
+	{
+		if (! $this->entry_points) {
+			$this->entry_points = array_keys($this->getManifest('entrypoints'));
+		}
+		return $this->entry_points;
+	}
 
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
-    protected function getManifest($key = 'files')
-    {
-        if (! $this->manifest) {
-            $manifest_path = EE_BARISTA_DIR . 'build/asset-manifest.json';
+	/**
+	 * @param string $key
+	 * @return mixed
+	 */
+	protected function getManifest(string $key = 'files')
+	{
+		if (! $this->manifest) {
+			$manifest_path = EE_BARISTA_DIR . 'build/asset-manifest.json';
 
-            if (! file_exists($manifest_path)) {
-                wp_die('No manifest file found. Try yarn dev');
-            }
+			if (! file_exists($manifest_path)) {
+				wp_die('No manifest file found. Try yarn dev');
+			}
 
-            // TODO May be use WP File system? ¯\_(ツ)_/¯
-            $manifest_json  = file_get_contents($manifest_path);
-            $this->manifest = json_decode($manifest_json, true);
-        }
+			// TODO May be use WP File system? ¯\_(ツ)_/¯
+			$manifest_json  = file_get_contents($manifest_path);
+			$this->manifest = json_decode($manifest_json, true);
+		}
 
-        if (empty($this->manifest[ $key ])) {
-            wp_die(sprintf('No entry for %1$s found in manifest file.', $key));
-        }
+		if (empty($this->manifest[ $key ])) {
+			wp_die(sprintf('No entry for %1$s found in manifest file.', $key));
+		}
 
-        return $this->manifest[ $key ];
-    }
-
-
-    /**
-     * Registers a script according to `wp_register_script`. Honors this request by
-     * reassigning internal dependency properties of any script handle already
-     * registered by that name. It does not deregister the original script, to
-     * avoid losing inline scripts which may have been attached.
-     *
-     * @param WP_Scripts       $scripts   WP_Scripts instance.
-     * @param string           $handle    Name of the script. Should be unique.
-     * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root
-     *                                    directory.
-     * @param array            $deps      Optional. An array of registered script handles this script depends on.
-     *                                    Default empty array.
-     * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is
-     *                                    added to the URL as a query string for cache busting purposes. If version is
-     *                                    set to false, a version number is automatically added equal to current
-     *                                    installed WordPress version. If set to null, no version is added.
-     * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the
-     *                                    <head>. Default 'false'.
-     * @since 0.0.1
-     */
-    protected function overrideScript(
-        WP_Scripts $scripts,
-        string $handle,
-        string $src,
-        array $deps = [],
-        $ver = false,
-        $in_footer = false
-    ) {
-        $script = $scripts->query($handle);
-        if ($script) {
-            /*
-             * In many ways, this is a reimplementation of `wp_register_script` but
-             * bypassing consideration of whether a script by the given handle had
-             * already been registered.
-             */
-
-            // See: `_WP_Dependency::__construct` .
-            $script->src  = $src;
-            $script->deps = $deps;
-            $script->ver  = $ver;
-            $script->args = $in_footer;
-        } else {
-            $scripts->add($handle, $src, $deps, $ver, $in_footer);
-        }
-
-        $script = $scripts->query($handle);
-        if ($script) {
-            /*
-            * The script's `group` designation is an indication of whether it is
-            * to be printed in the header or footer. The behavior here defers to
-            * the arguments as passed. Specifically, group data is not assigned
-            * for a script unless it is designated to be printed in the footer.
-            */
-            // See: `wp_register_script` .
-            unset($script->extra['group']);
-            if ($in_footer) {
-                $script->add_data('group', 1);
-            }
-        }
-    }
+		return $this->manifest[ $key ];
+	}
 
 
-    /**
-     * Registers a style according to `wp_register_style`. Honors this request by
-     * de-registering any style by the same handler before registration.
-     *
-     * @param WP_Styles        $styles WP_Styles instance.
-     * @param string           $handle Name of the stylesheet. Should be unique.
-     * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress
-     *                                 root directory.
-     * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on.
-     *                                 Default empty array.
-     * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is
-     *                                 added to the URL as a query string for cache busting purposes. If version is set
-     *                                 to false, a version number is automatically added equal to current installed
-     *                                 WordPress version. If set to null, no version is added.
-     * @param string           $media  Optional. The media for which this stylesheet has been defined.
-     *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media
-     *                                 queries like
-     *                                 '(orientation: portrait)' and '(max-width: 640px)'.
-     * @since 0.0.1
-     *
-     */
-    protected function overrideStyle(
-        WP_Styles $styles,
-        string $handle,
-        string $src,
-        array $deps = [],
-        $ver = false,
-        $media = 'all'
-    ) {
-        $style = $styles->query($handle);
-        if ($style) {
-            $styles->remove($handle);
-        }
-        // save the handle to use for loading styles for dev env
-        $this->styles[ $handle ] = true;
+	/**
+	 * Registers a script according to `wp_register_script`. Honors this request by
+	 * reassigning internal dependency properties of any script handle already
+	 * registered by that name. It does not deregister the original script, to
+	 * avoid losing inline scripts which may have been attached.
+	 *
+	 * @param WP_Scripts       $scripts   WP_Scripts instance.
+	 * @param string           $handle    Name of the script. Should be unique.
+	 * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root
+	 *                                    directory.
+	 * @param array            $deps      Optional. An array of registered script handles this script depends on.
+	 *                                    Default empty array.
+	 * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is
+	 *                                    added to the URL as a query string for cache busting purposes. If version is
+	 *                                    set to false, a version number is automatically added equal to current
+	 *                                    installed WordPress version. If set to null, no version is added.
+	 * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the
+	 *                                    <head>. Default 'false'.
+	 * @since 0.0.1
+	 */
+	protected function overrideScript(
+		WP_Scripts $scripts,
+		string $handle,
+		string $src,
+		array $deps = [],
+		$ver = false,
+		bool $in_footer = false
+	) {
+		$script = $scripts->query($handle);
+		if ($script) {
+			/*
+			 * In many ways, this is a reimplementation of `wp_register_script` but
+			 * bypassing consideration of whether a script by the given handle had
+			 * already been registered.
+			 */
 
-        $styles->add($handle, $src, $deps, $ver, $media);
-    }
+			// See: `_WP_Dependency::__construct` .
+			$script->src  = $src;
+			$script->deps = $deps;
+			$script->ver  = $ver;
+			$script->args = $in_footer;
+		} else {
+			$scripts->add($handle, $src, $deps, $ver, $in_footer);
+		}
 
-    /**
-     * Whether a domain depends upon eventEditor domain.
-     *
-     * @param string $entry_point
-     * @return void
-     */
-    private function dependsUponEdtr($entry_point)
-    {
-        return in_array($entry_point, $this->edtr_domains, true);
-    }
-
-
-    /**
-     * Registers all the WordPress packages scripts that are in the standardized
-     * `build/` location.
-     *
-     * @param WP_Scripts $scripts WP_Scripts instance.
-     * @since 0.0.1
-     */
-    public function registerScripts(WP_Scripts $scripts)
-    {
-        $asset_files  = $this->getManifest();
-        $entry_points = $this->getEntryPoints();
-
-        foreach ($entry_points as $entry_point) {
-            $handle = 'eventespresso-' . $entry_point;
-
-            // Get the path from root directory as expected by `$this->url`.
-            $package_path = 'build' . $asset_files[ $entry_point . '.js' ];
-
-            $dependencies = [];
-
-            if (! empty($asset_files[ $entry_point . '.php' ])) {
-                $asset_file   = EE_BARISTA_DIR . 'build' . $asset_files[ $entry_point . '.php' ];
-                $asset        = file_exists($asset_file) ? require($asset_file) : null;
-                $dependencies = isset($asset['dependencies']) ? $asset['dependencies'] : $dependencies;
-            }
-
-            // remove cyclical dependencies, if any
-            if (($key = array_search($handle, $dependencies, true)) !== false) {
-                unset($dependencies[ $key ]);
-            }
-            if ($this->dependsUponEdtr($entry_point)) {
-                $dependencies[] = 'eventespresso-eventEditor';
-            }
-
-            $version = isset($asset['version']) ? $asset['version'] : '';
-            $version = $version === '' && file_exists(EE_BARISTA_DIR . $package_path)
-            ? filemtime(EE_BARISTA_DIR . $package_path)
-            : espresso_version();
-
-            $this->overrideScript(
-                $scripts,
-                $handle,
-                $this->url($package_path),
-                $dependencies,
-                $version,
-                true
-            );
-        }
-    }
+		$script = $scripts->query($handle);
+		if ($script) {
+			/*
+			* The script's `group` designation is an indication of whether it is
+			* to be printed in the header or footer. The behavior here defers to
+			* the arguments as passed. Specifically, group data is not assigned
+			* for a script unless it is designated to be printed in the footer.
+			*/
+			// See: `wp_register_script` .
+			unset($script->extra['group']);
+			if ($in_footer) {
+				$script->add_data('group', 1);
+			}
+		}
+	}
 
 
-    /**
-     * Registers all the packages and domain styles that are in the build folder.
-     *
-     * @param WP_Styles $styles WP_Styles instance.
-     * @since 0.0.1
-     */
-    public function registerPackagesStyles(WP_Styles $styles)
-    {
-        $asset_files  = $this->getManifest();
-        $entry_points = $this->getEntryPoints();
+	/**
+	 * Registers a style according to `wp_register_style`. Honors this request by
+	 * de-registering any style by the same handler before registration.
+	 *
+	 * @param WP_Styles        $styles WP_Styles instance.
+	 * @param string           $handle Name of the stylesheet. Should be unique.
+	 * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress
+	 *                                 root directory.
+	 * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on.
+	 *                                 Default empty array.
+	 * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is
+	 *                                 added to the URL as a query string for cache busting purposes. If version is set
+	 *                                 to false, a version number is automatically added equal to current installed
+	 *                                 WordPress version. If set to null, no version is added.
+	 * @param string           $media  Optional. The media for which this stylesheet has been defined.
+	 *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media
+	 *                                 queries like
+	 *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+	 * @since 0.0.1
+	 *
+	 */
+	protected function overrideStyle(
+		WP_Styles $styles,
+		string $handle,
+		string $src,
+		array $deps = [],
+		$ver = false,
+		string $media = 'all'
+	) {
+		$style = $styles->query($handle);
+		if ($style) {
+			$styles->remove($handle);
+		}
+		// save the handle to use for loading styles for dev env
+		$this->styles[ $handle ] = true;
 
-        foreach ($entry_points as $entry_point) {
-            $handle = 'eventespresso-' . $entry_point;
-
-            $dependencies = []; // May be we need it some day ¯\_(ツ)_/¯
-
-            if (! empty($asset_files[ $entry_point . '.css' ])) {
-                $css_relative_path = 'build' . $asset_files[ $entry_point . '.css' ];
-                $css_absolute_path = EE_BARISTA_DIR . $css_relative_path;
-
-                if (file_exists($css_absolute_path)) {
-                    $version = filemtime($css_absolute_path);
-                    $this->overrideStyle(
-                        $styles,
-                        $handle,
-                        $this->url($css_relative_path),
-                        $dependencies,
-                        $version
-                    );
-                }
-            }
-        }
-    }
-
-
-    /**
-     * Enqueues assets that are loaded by exernal plugins/services.
-     */
-    public function enqueueScripts($hook)
-    {
-        global $post;
-
-        $is_edtr_page = $post && $post->post_type === 'espresso_events';
-        $is_edtr_page = $is_edtr_page && ($hook == 'post-new.php' || $hook == 'post.php');
-
-        if (!$is_edtr_page) {
-            return;
-        }
-
-        $scripts = ['esEdtrSlots'];
-
-        foreach ($scripts as $handle) {
-            $handle = 'eventespresso-' . $handle;
-            if (wp_script_is($handle, 'registered')) {
-                wp_enqueue_script($handle);
-            }
-        }
-    }
+		$styles->add($handle, $src, $deps, $ver, $media);
+	}
 
 
-    public function addAssets()
-    {
-        // Enqueue the empty style with all the barista styles as deps.
-        wp_enqueue_style(
-            'ee-barista',
-            plugins_url('styles.css', __FILE__),
-            array_keys($this->styles)
-        );
+	/**
+	 * Whether a domain depends upon eventEditor domain.
+	 *
+	 * @param string $entry_point
+	 * @return bool
+	 */
+	private function dependsUponEdtr(string $entry_point): bool
+	{
+		return in_array($entry_point, $this->edtr_domains, true);
+	}
 
-        wp_add_inline_script(
-            'eventespresso-i18n',
-            sprintf('var baristaAssetsUrl = "%s";', $this->url('build/')),
-            'before'
-        );
-    }
+
+	/**
+	 * Registers all the WordPress packages scripts that are in the standardized
+	 * `build/` location.
+	 *
+	 * @param WP_Scripts $scripts WP_Scripts instance.
+	 * @since 0.0.1
+	 */
+	public function registerScripts(WP_Scripts $scripts)
+	{
+		$asset_files  = $this->getManifest();
+		$entry_points = $this->getEntryPoints();
+
+		foreach ($entry_points as $entry_point) {
+			$handle = 'eventespresso-' . $entry_point;
+
+			// Get the path from root directory as expected by `$this->url`.
+			$package_path = 'build' . $asset_files[ $entry_point . '.js' ];
+
+			$dependencies = [];
+
+			if (! empty($asset_files[ $entry_point . '.php' ])) {
+				$asset_file   = EE_BARISTA_DIR . 'build' . $asset_files[ $entry_point . '.php' ];
+				$asset        = file_exists($asset_file) ? require($asset_file) : null;
+				$dependencies = $asset['dependencies'] ?? $dependencies;
+			}
+
+			// remove cyclical dependencies, if any
+			if (($key = array_search($handle, $dependencies, true)) !== false) {
+				unset($dependencies[ $key ]);
+			}
+			if ($this->dependsUponEdtr($entry_point)) {
+				$dependencies[] = 'eventespresso-eventEditor';
+			}
+
+			$version = $asset['version'] ?? '';
+			$version = $version === '' && file_exists(EE_BARISTA_DIR . $package_path)
+				? filemtime(EE_BARISTA_DIR . $package_path)
+				: espresso_version();
+
+			$this->overrideScript(
+				$scripts,
+				$handle,
+				$this->url($package_path),
+				$dependencies,
+				$version,
+				true
+			);
+		}
+	}
+
+
+	/**
+	 * Registers all the packages and domain styles that are in the build folder.
+	 *
+	 * @param WP_Styles $styles WP_Styles instance.
+	 * @since 0.0.1
+	 */
+	public function registerPackagesStyles(WP_Styles $styles)
+	{
+		$asset_files  = $this->getManifest();
+		$entry_points = $this->getEntryPoints();
+
+		foreach ($entry_points as $entry_point) {
+			$handle = 'eventespresso-' . $entry_point;
+
+			$dependencies = []; // May be we need it some day ¯\_(ツ)_/¯
+
+			if (! empty($asset_files[ $entry_point . '.css' ])) {
+				$css_relative_path = 'build' . $asset_files[ $entry_point . '.css' ];
+				$css_absolute_path = EE_BARISTA_DIR . $css_relative_path;
+
+				if (file_exists($css_absolute_path)) {
+					$version = filemtime($css_absolute_path);
+					$this->overrideStyle(
+						$styles,
+						$handle,
+						$this->url($css_relative_path),
+						$dependencies,
+						$version
+					);
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Enqueues assets that are loaded by exernal plugins/services.
+	 */
+	public function enqueueScripts($hook)
+	{
+		global $post;
+
+		$is_edtr_page = $post && $post->post_type === 'espresso_events';
+		$is_edtr_page = $is_edtr_page && ($hook == 'post-new.php' || $hook == 'post.php');
+
+		if (! $is_edtr_page) {
+			return;
+		}
+
+		$scripts = ['esEdtrSlots'];
+
+		foreach ($scripts as $handle) {
+			$handle = 'eventespresso-' . $handle;
+			if (wp_script_is($handle, 'registered')) {
+				wp_enqueue_script($handle);
+			}
+		}
+	}
+
+
+	public function addAssets()
+	{
+		// Enqueue the empty style with all the barista styles as deps.
+		wp_enqueue_style(
+			'ee-barista',
+			plugins_url('styles.css', __FILE__),
+			array_keys($this->styles)
+		);
+
+		wp_add_inline_script(
+			'eventespresso-i18n',
+			sprintf('var baristaAssetsUrl = "%s";', $this->url('build/')),
+			'before'
+		);
+	}
 }

--- a/lib/FeatureFlagsAdminPage.php
+++ b/lib/FeatureFlagsAdminPage.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace EventEspresso\Barista;
+
+use EE_Admin_Page;
+use EE_Error;
+use EE_Switch_Input;
+use EEH_URL;
+use EventEspresso\core\domain\services\capabilities\FeatureFlagsConfig;
+use EventEspresso\core\services\database\WordPressOption;
+use EventEspresso\core\services\loaders\LoaderFactory;
+use Maintenance_Admin_Page;
+
+/**
+ * Class FeatureFlagsConfig
+ * UI for managing Feature Flags configuration
+ *
+ * @since $VID:$
+ */
+class FeatureFlagsAdminPage
+{
+	public static function loadFeatureFlagsAdminPageConfig(array $page_config): array
+	{
+		$page_config['feature_flags_config'] = [
+			'nav'           => [
+				'label' => esc_html__('Feature Flags', 'event_espresso'),
+				'icon'  => 'dashicons-flag',
+				'order' => 100,
+			],
+			'require_nonce' => false,
+		];
+		return $page_config;
+	}
+
+
+	public static function loadFeatureFlagsAdminPageRoutes(array $page_routes): array
+	{
+		$page_routes['feature_flags_config']              = [
+			'func'       => [FeatureFlagsAdminPage::class, 'loadFeatureFlagsConfigForm'],
+			'capability' => 'manage_options',
+		];
+		$page_routes['process_feature_flags_config_form'] = [
+			'func'       => [FeatureFlagsAdminPage::class, 'processFeatureFlagsConfigForm'],
+			'capability' => 'manage_options',
+			'noheader'   => true,
+		];
+		return $page_routes;
+	}
+
+
+	/**
+	 * @param Maintenance_Admin_Page $admin_page
+	 * @return void
+	 * @throws EE_Error
+	 */
+	public static function loadFeatureFlagsConfigForm(Maintenance_Admin_Page $admin_page)
+	{
+		$form = new FeatureFlagsConfigForm(LoaderFactory::getShared(FeatureFlagsConfig::class));
+		$admin_page->setAdminPageTitle(esc_html__('Feature Flags Configuration', 'event_espresso'));
+		$admin_page->set_template_args(
+			[
+				'admin_page_content' => $form->form_open(
+						EE_Admin_Page::add_query_args_and_nonce(
+							['action' => 'process_feature_flags_config_form'],
+							EE_MAINTENANCE_ADMIN_URL
+						),
+						'post'
+					)
+					. $form->get_html_and_js()
+					. $form->form_close(),
+			]
+		);
+		$admin_page->display_admin_page_with_no_sidebar();
+	}
+
+
+	/**
+	 * @throws EE_Error
+	 */
+	public static function processFeatureFlagsConfigForm(Maintenance_Admin_Page $admin_page)
+	{
+		if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+			/** @var FeatureFlagsConfig $feature_flags_config */
+			$feature_flags_config = LoaderFactory::getShared(FeatureFlagsConfig::class);
+			$form                 = new FeatureFlagsConfigForm($feature_flags_config);
+			$form->receive_form_submission($_REQUEST);
+			if ($form->is_valid()) {
+				$feature_flags_form_options = $form->valid_data();
+
+				$feature_flags = $feature_flags_config->getFeatureFlags();
+				$success       = true;
+
+				foreach ($feature_flags_form_options as $feature_flag => $value) {
+					$result = WordPressOption::UPDATE_NONE;
+					if ($feature_flag && property_exists($feature_flags, $feature_flag)) {
+						$result = $value === EE_Switch_Input::OPTION_ON
+							? $feature_flags_config->enableFeatureFlag($feature_flag)
+							: $feature_flags_config->disableFeatureFlag($feature_flag);
+					}
+					$success = $result === WordPressOption::UPDATE_ERROR ? $result : $success;
+					if ($result === WordPressOption::UPDATE_ERROR) {
+						EE_Error::add_error(
+							sprintf(
+							/* translators: %1$s: feature flag name */
+								esc_html__(
+									'An error occurred while trying to update the %1$s feature flag.',
+									'event_espresso'
+								),
+								$feature_flag
+							),
+							__FILE__,
+							__FUNCTION__,
+							__LINE__
+						);
+						break;
+					}
+				}
+				if ($success) {
+					EE_Error::add_success(esc_html__('Feature Flags updated successfully.', 'event_espresso'));
+				}
+				EEH_URL::safeRedirectAndExit(
+					EE_Admin_Page::add_query_args_and_nonce(
+						[
+							'page'   => 'espresso_maintenance_settings',
+							'action' => 'feature_flags_config',
+						],
+						admin_url('admin.php')
+					)
+				);
+			}
+		}
+	}
+}

--- a/lib/FeatureFlagsAdminPage.php
+++ b/lib/FeatureFlagsAdminPage.php
@@ -86,10 +86,8 @@ class FeatureFlagsAdminPage
 			$form->receive_form_submission($_REQUEST);
 			if ($form->is_valid()) {
 				$feature_flags_form_options = $form->valid_data();
-
 				$feature_flags = $feature_flags_config->getFeatureFlags();
 				$success       = true;
-
 				foreach ($feature_flags_form_options as $feature_flag => $value) {
 					$result = WordPressOption::UPDATE_NONE;
 					if ($feature_flag && property_exists($feature_flags, $feature_flag)) {
@@ -101,7 +99,7 @@ class FeatureFlagsAdminPage
 					if ($result === WordPressOption::UPDATE_ERROR) {
 						EE_Error::add_error(
 							sprintf(
-							/* translators: %1$s: feature flag name */
+								/* translators: %1$s: feature flag name */
 								esc_html__(
 									'An error occurred while trying to update the %1$s feature flag.',
 									'event_espresso'

--- a/lib/FeatureFlagsConfigForm.php
+++ b/lib/FeatureFlagsConfigForm.php
@@ -24,9 +24,14 @@ class FeatureFlagsConfigForm extends EE_Form_Section_Proper
 			FeatureFlagsConfig::USE_EVENT_EDITOR_BULK_EDIT => [
 				'name' => esc_html__('Event Editor Bulk Edit','event_espresso'),
 				'html_label_text' => esc_html__('Use Event Editor Bulk Edit','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the Bulk Edit feature in the Advanced Event Editor (EDTR). default: Enabled for Caffeinated sites, disabled for Decaf or Multisite installs',
-					'event_espresso'
+				'help_text' => sprintf(
+					esc_html__(
+						'Whether to enable the Bulk Edit feature in the Advanced Event Editor (EDTR).%1$s%2$sPLEASE NOTE: Bulk Editing is ALWAYS enabled if the Recurring Events Manager add-on is active.%3$s%1$s default: Enabled for Caffeinated sites, disabled for Decaf or Multisite installs',
+						'event_espresso'
+					),
+					'<br/>',
+					'<strong>',
+					'</strong>'
 				)
 			],
 			FeatureFlagsConfig::USE_DEFAULT_TICKET_MANAGER => [

--- a/lib/FeatureFlagsConfigForm.php
+++ b/lib/FeatureFlagsConfigForm.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace EventEspresso\Barista;
+
+use EE_Admin_Two_Column_Layout;
+use EE_Form_Section_HTML;
+use EE_Form_Section_Proper;
+use EE_Submit_Input;
+use EE_Switch_Input;
+use EEH_HTML;
+use EventEspresso\core\domain\services\capabilities\FeatureFlagsConfig;
+
+/**
+ * Class FeatureFlagsConfigForm
+ *
+ * @since $VID:$
+ */
+class FeatureFlagsConfigForm extends EE_Form_Section_Proper
+{
+	public function __construct(FeatureFlagsConfig $feature_flags_config)
+	{
+		$feature_flags = $feature_flags_config->getFeatureFlags();
+		$feature_flags_form_options = [
+			FeatureFlagsConfig::USE_EVENT_EDITOR_BULK_EDIT => [
+				'name' => esc_html__('Event Editor Bulk Edit','event_espresso'),
+				'html_label_text' => esc_html__('Use Event Editor Bulk Edit','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the Bulk Edit feature in the Advanced Event Editor (EDTR). default: Enabled for Caffeinated sites, disabled for Decaf or Multisite installs',
+					'event_espresso'
+				)
+			],
+			FeatureFlagsConfig::USE_DEFAULT_TICKET_MANAGER => [
+				'name' => esc_html__('Default Ticket Manager','event_espresso'),
+				'html_label_text' => esc_html__('Use Default Ticket Manager','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the new Default Ticket Manager in the EDTR. default: Enabled',
+					'event_espresso'
+				)
+			],
+			FeatureFlagsConfig::USE_EVENT_DESCRIPTION_RTE => [
+				'name' => esc_html__('Event Description RTE','event_espresso'),
+				'html_label_text' => esc_html__('Use Rich Text Editor for Event Description','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the Rich Text Editor for the Event Description field in the EDTR or use tinymce. default: Disabled',
+					'event_espresso'
+				)
+			],
+			FeatureFlagsConfig::USE_EXPERIMENTAL_RTE => [
+				'name' => esc_html__('Rich Text Editor','event_espresso'),
+				'html_label_text' => esc_html__('Use Rich Text Editor for other RTE fields','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the Rich Text Editor for all other RTE fields in the EDTR. default: Disabled',
+					'event_espresso'
+				)
+			],
+			FeatureFlagsConfig::USE_REG_FORM_BUILDER => [
+				'name' => esc_html__('Registration Form Builder','event_espresso'),
+				'html_label_text' => esc_html__('Use Registration Form Builder','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the new Registration Form Builder in the EDTR or continue using the legacy Question Groups and Registration Form admin pages. default: Disabled',
+					'event_espresso'
+				)
+			],
+			FeatureFlagsConfig::USE_REG_OPTIONS_META_BOX => [
+				'name' => esc_html__('Registration Options','event_espresso'),
+				'html_label_text' => esc_html__('Use Registration Options','event_espresso'),
+				'help_text' => esc_html__(
+					'Whether to enable the new Registration Options meta box in the EDTR or continue using the legacy Event Registration Options. default: Disabled',
+					'event_espresso'
+				)
+			],
+		];
+
+		$subsections = [
+			'header' => new EE_Form_Section_HTML(EEH_HTML::h3(__('Feature Flags', 'event_espresso')))
+		];
+		foreach ($feature_flags_form_options as $id => $feature_flags_form_option) {
+			$subsections[$id] = new EE_Switch_Input(
+				[
+					'default'        => $feature_flags->{$id}
+						? EE_Switch_Input::OPTION_ON
+						: EE_Switch_Input::OPTION_OFF,
+					'html_name'       => $id,
+					'html_label_text' => $feature_flags_form_option['html_label_text'],
+					'html_help_text'  => $feature_flags_form_option['help_text'],
+				],
+				[
+					EE_Switch_Input::OPTION_OFF => sprintf(
+						esc_html__('%1$s is DISABLED', 'event_espresso'),
+						$feature_flags_form_option['name']
+					),
+					EE_Switch_Input::OPTION_ON  => sprintf(
+						esc_html__('%1$s is ENABLED', 'event_espresso'),
+						$feature_flags_form_option['name']
+					),
+				]
+			);
+		}
+		$subsections[''] = new EE_Submit_Input(
+			['default' => esc_html__('Update Feature Flags', 'event_espresso')]
+		);
+		parent::__construct(
+			[
+				'name'            => 'BaristaAdminPageConfig',
+				'layout_strategy' => new EE_Admin_Two_Column_Layout(),
+				'subsections'     => $subsections,
+			]
+		);
+	}
+}

--- a/packages/ee-components/src/EntityList/EntityList.tsx
+++ b/packages/ee-components/src/EntityList/EntityList.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@eventespresso/i18n';
-import { useCurrentUserCan, useStatus } from '@eventespresso/services';
+import { useStatus } from '@eventespresso/services';
 import { Slot } from '@eventespresso/slot-fill';
 import { CollapsibleLegend, EmptyState, Pagination, EntityList as EntityListUI } from '@eventespresso/ui-components';
 import type { EntityListFilterStateManager } from '@eventespresso/services';
@@ -23,8 +23,6 @@ const EntityList = <ELFS extends EntityListFilterStateManager<any>>({
 	const { isError, isLoading } = useStatus();
 	const error = isError(entityType);
 	const loading = isLoading(entityType);
-	const currentUserCan = useCurrentUserCan();
-	const showBulkActions = currentUserCan('ee_event_editor_bulk_edit');
 
 	let entityList: React.ReactNode;
 
@@ -36,14 +34,7 @@ const EntityList = <ELFS extends EntityListFilterStateManager<any>>({
 		entityList = renderList();
 	}
 
-	const filterBar = (
-		<EntityListFilterBar
-			domain={domain}
-			filterState={filterState}
-			listId={listId}
-			showBulkActionsToggle={showBulkActions}
-		/>
-	);
+	const filterBar = <EntityListFilterBar domain={domain} filterState={filterState} listId={listId} />;
 
 	const legend = <CollapsibleLegend direction='row' legendConfig={legendConfig} termWhiteBg />;
 

--- a/packages/ee-components/src/EntityList/EntityListFilterBar.tsx
+++ b/packages/ee-components/src/EntityList/EntityListFilterBar.tsx
@@ -4,7 +4,6 @@ import {
 	SearchInputWithLabel,
 	EntityListFilterBar as EntityListFilterBarUI,
 	EntityListViewButtonGroup,
-	ToggleBulkActionsButton,
 } from '@eventespresso/ui-components';
 
 import type { EntityListFilterStateManager as ELFSM } from '@eventespresso/services';
@@ -18,22 +17,15 @@ export const EntityListFilterBar = <FS extends ELFSM>({
 	domain,
 	filterState,
 	listId,
-	showBulkActionsToggle,
 }: EntityListFilterBarProps<FS>): JSX.Element => {
-	const { searchText, setCardView, setSearchText, setTableView, showBulkActions, toggleBulkActions, view } =
-		filterState;
+	const { searchText, setCardView, setSearchText, setTableView, view } = filterState;
 
 	const filerBarItems = useFilterBarUIElements({ domain, filterState, listId });
 
 	const searchId = `ee-search-input-${listId}`;
 
 	const mainButtons = (
-		<>
-			<EntityListViewButtonGroup id={listId} setCardView={setCardView} setTableView={setTableView} view={view} />
-			{showBulkActionsToggle && view === 'table' && (
-				<ToggleBulkActionsButton id={listId} onClick={toggleBulkActions} value={showBulkActions} />
-			)}
-		</>
+		<EntityListViewButtonGroup id={listId} setCardView={setCardView} setTableView={setTableView} view={view} />
 	);
 
 	const collapsibleButtons = (

--- a/packages/ee-components/src/EntityList/types.ts
+++ b/packages/ee-components/src/EntityList/types.ts
@@ -74,7 +74,6 @@ export interface EntityTableFilters<FS extends ELFSM> {
 export interface EntityListFilterBarProps<FS extends ELFSM> extends Partial<EntityListViewProps<FS>> {
 	domain: string;
 	listId?: string;
-	showBulkActionsToggle?: boolean;
 }
 
 export interface EntityType {

--- a/packages/ee-components/src/filterBar/SortByControl/index.tsx
+++ b/packages/ee-components/src/filterBar/SortByControl/index.tsx
@@ -23,9 +23,7 @@ export const SortByControl: React.FC<SortByControlProps> = ({
 	value,
 }) => {
 	const { isOpen, onOpen, onClose } = useDisclosure();
-	const text =
-		(entityType === 'datetimes' && __('set custom dates order')) ||
-		(entityType === 'tickets' && __('set custom tickets order'));
+	const text = __('set order');
 	const title =
 		(entityType === 'datetimes' && __('Set Custom Dates Order - this is how dates are ordered on the frontend')) ||
 		(entityType === 'tickets' && __('Set Custom Tickets Order - this is how tickets are ordered on the frontend'));
@@ -44,7 +42,14 @@ export const SortByControl: React.FC<SortByControlProps> = ({
 	return (
 		<>
 			<div className='ee-sort-by-control'>
-				<SelectWithLabel id={id} label={label} options={options} onChangeValue={onChangeValue} value={value} />
+				<SelectWithLabel
+					id={id}
+					label={label}
+					options={options}
+					onChangeValue={onChangeValue}
+					value={value}
+					width='small'
+				/>
 				{reorderButton}
 			</div>
 			<ModalWithAlert

--- a/packages/ee-components/src/filterBar/SortByControl/style.scss
+++ b/packages/ee-components/src/filterBar/SortByControl/style.scss
@@ -3,7 +3,8 @@
 .ee-sort-by-control {
 	align-items: flex-end;
 	display: flex;
-	padding-bottom: var(--ee-padding-tiny);
+	flex-direction: column;
+	padding-block-end: var(--ee-padding-tiny);
 
 	.ee-input-label__wrapper {
 		padding-bottom: 0;
@@ -11,6 +12,11 @@
 
 	.ee-btn-base.ee-btn {
 		margin-block-end: var(--ee-margin-micro);
+		margin-inline-end: var(--ee-margin-small);
+	}
+
+	@include min480px {
+		flex-direction: row;
 	}
 }
 

--- a/packages/services/src/filterState/types.ts
+++ b/packages/services/src/filterState/types.ts
@@ -7,7 +7,6 @@ export interface EntityListFilterState<SortBy = BasicSortBy> extends ListView {
 	pageNumber: number;
 	perPage: number;
 	searchText: string;
-	showBulkActions: boolean;
 	sortBy: SortBy;
 	total: number;
 }
@@ -34,7 +33,6 @@ export interface EntityListFilterStateManager<SortBy = BasicSortBy> extends Enti
 	setSortBy: (sortBy: SortBy) => void;
 	setTableView: VoidFunction;
 	setTotal: (total: number) => void;
-	toggleBulkActions: VoidFunction;
 }
 
 export type EntityListFilterStateReducer<SortBy = BasicSortBy> = (

--- a/packages/services/src/filterState/useEntityListFilterStateManager.ts
+++ b/packages/services/src/filterState/useEntityListFilterStateManager.ts
@@ -23,7 +23,6 @@ const useEntityListFilterStateManager = <SortBy = BasicSortBy>(
 			pageNumber: 1,
 			perPage,
 			searchText: '',
-			showBulkActions: false,
 			sortBy,
 			total: null,
 			view,
@@ -101,12 +100,6 @@ const useEntityListFilterStateManager = <SortBy = BasicSortBy>(
 		});
 	}, []);
 
-	const toggleBulkActions: FSM['toggleBulkActions'] = useCallback(() => {
-		dispatch({
-			type: 'TOGGLE_BULK_ACTIONS',
-		});
-	}, []);
-
 	const setSearchText: FSM['setSearchText'] = useCallback((searchText) => {
 		dispatch({
 			searchText,
@@ -125,7 +118,6 @@ const useEntityListFilterStateManager = <SortBy = BasicSortBy>(
 			setSortBy,
 			setTableView,
 			setTotal,
-			toggleBulkActions,
 		}),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[state]

--- a/packages/services/src/filterState/useStateReducer.ts
+++ b/packages/services/src/filterState/useStateReducer.ts
@@ -25,9 +25,6 @@ const useStateReducer = <SortBy = BasicSortBy>(): EntityListFilterStateReducer<S
 			case 'SET_VIEW':
 				return { ...state, view };
 
-			case 'TOGGLE_BULK_ACTIONS':
-				return { ...state, showBulkActions: !state.showBulkActions };
-
 			default:
 				throw new Error('Unexpected action');
 		}

--- a/packages/styles/src/mixins/_base-styles.scss
+++ b/packages/styles/src/mixins/_base-styles.scss
@@ -86,6 +86,53 @@
 	}
 }
 
+@mixin ee-base-input-widths {
+	&-width--auto {
+		min-width: unset;
+		width: auto;
+	}
+	&-width--nano {
+		min-width: calc(var(--ee-font-size-default) * 2);
+	}
+
+	&-width--micro {
+		min-width: calc(var(--ee-font-size-default) * 4);
+	}
+
+	&-width--tiny {
+		min-width: calc(var(--ee-font-size-default) * 6);
+	}
+
+	&-width--smaller {
+		min-width: calc(var(--ee-font-size-default) * 8);
+	}
+
+	&-width--small {
+		min-width: calc(var(--ee-font-size-default) * 12);
+	}
+
+
+	&-width--default {
+		min-width: calc(var(--ee-font-size-default) * 15);
+	}
+
+	&-width--big {
+		min-width: calc(var(--ee-font-size-default) * 18);
+	}
+
+	&-width--bigger {
+		min-width: calc(var(--ee-font-size-default) * 27);
+	}
+
+	&-width--huge {
+		min-width: calc(var(--ee-font-size-default) * 36);
+	}
+
+	&-width--extreme {
+		min-width: calc(var(--ee-font-size-default) * 48);
+	}
+}
+
 @mixin ee-base-inputs-styles {
 	background: var(--ee-background-color);
 	border-color: var(--ee-border-color);
@@ -103,15 +150,11 @@
 	padding: var(--ee-padding-micro) var(--ee-padding-tiny);
 
 	@include ee-base-input-sizes;
-
+	@include ee-base-input-widths;
 	@include transition(all ease 50ms);
-
 	@include ee-input-base-focus;
-
 	@include ee-input-base-hover;
-
 	@include ee-input-disabled-hover;
-
 	@include ee-input-error;
 }
 

--- a/packages/styles/src/mixins/_breakpoints.scss
+++ b/packages/styles/src/mixins/_breakpoints.scss
@@ -117,6 +117,12 @@ $breakpointsMapping: (
 }
 
 /* iPad Portrait */
+@mixin max767px {
+	@include breakpoint(767px, max) {
+		@content;
+	}
+}
+
 @mixin min767px {
 	@include breakpoint(767px, min) {
 		@content;

--- a/packages/ui-components/src/ActiveFilters/FilterTag/styles.scss
+++ b/packages/ui-components/src/ActiveFilters/FilterTag/styles.scss
@@ -10,9 +10,9 @@
 	display: flex;
 	flex-flow: row nowrap;
 	font-size: var(--ee-font-size-small);
-	height: var(--ee-icon-button-size-micro);
+	height: var(--ee-icon-button-size-tiny);
 	margin: 0 var(--ee-margin-smaller) var(--ee-margin-tiny) 0;
-	padding: 0 var(--ee-padding-nano) 0 var(--ee-padding-smaller);
+	padding: 0 var(--ee-padding-micro) 0 var(--ee-padding-smaller);
 	position: relative;
 
 	[dir='rtl'] & {

--- a/packages/ui-components/src/ActiveFilters/styles.scss
+++ b/packages/ui-components/src/ActiveFilters/styles.scss
@@ -4,7 +4,9 @@
 	&__wrapper {
 		align-items: center;
 		display: flex;
-		margin: 0 0 var(--ee-margin-default);
+		margin: 0;
+		margin-block: var(--ee-margin-small);
+		margin-inline-start: var(--ee-margin-tiny);
 
 		@include max600px {
 			align-items: flex-start;

--- a/packages/ui-components/src/EntityList/EntityList.tsx
+++ b/packages/ui-components/src/EntityList/EntityList.tsx
@@ -37,8 +37,8 @@ export const EntityList: React.FC<EntityListProps> = ({
 			{entityList}
 
 			<ButtonRow alignItems='start' justifyContent='space-between'>
-				{legend}
 				{pagination}
+				{legend}
 			</ButtonRow>
 
 			<div className={'ee-entity-list__footer'}>{footer}</div>

--- a/packages/ui-components/src/EntityList/filterBar/buttons/ToggleFiltersButton.tsx
+++ b/packages/ui-components/src/EntityList/filterBar/buttons/ToggleFiltersButton.tsx
@@ -1,16 +1,17 @@
 import { __ } from '@eventespresso/i18n';
 import { Filter } from '@eventespresso/icons';
-import { Button } from '../../../Button';
+import { Button, ButtonType } from '../../../Button';
 
 import type { ToggleFiltersButtonProps } from '../types';
 
 export const ToggleFiltersButton: React.FC<ToggleFiltersButtonProps> = ({ id, onClick, value, ...rest }) => {
 	const filterId = `ee-toggle-filters-btn-${id}`;
-	const tooltip = value ? __('hide filters') : __('show filters');
+	const buttonType = value ? ButtonType.PRIMARY : ButtonType.DEFAULT;
 
 	return (
 		<Button
 			active={value}
+			buttonType={buttonType}
 			className='ee-filter-bar__btn'
 			icon={Filter}
 			id={filterId}
@@ -19,7 +20,7 @@ export const ToggleFiltersButton: React.FC<ToggleFiltersButtonProps> = ({ id, on
 			size='small'
 			{...rest}
 		>
-			{tooltip}
+			{__('filters')}
 		</Button>
 	);
 };

--- a/packages/ui-components/src/EntityList/filterBar/style.scss
+++ b/packages/ui-components/src/EntityList/filterBar/style.scss
@@ -5,8 +5,10 @@ $filter-btn: '.ee-filter-bar__btn';
 .ee-filter-bar {
 	box-sizing: border-box;
 	color: var(--ee-default-text-color);
-	margin: 0 0 var(--ee-margin-tiny);
-	padding: var(--ee-padding-tiny) 0;
+	margin: 0;
+	margin-block-start:  var(--ee-margin-tiny);
+	padding: 0;
+	padding-block-start: var(--ee-padding-smaller);
 
 	&__main {
 		display: flex;
@@ -21,7 +23,7 @@ $filter-btn: '.ee-filter-bar__btn';
 	&__collapsible {
 		display: flex;
 		flex-flow: row wrap;
-		padding: 0 var(--ee-padding-small);
+		padding: 0;
 
 		@include max782px {
 			padding: 0 0 var(--ee-padding-small);
@@ -34,13 +36,13 @@ $filter-btn: '.ee-filter-bar__btn';
 		flex-flow: column nowrap;
 		height: auto;
 		justify-content: flex-end;
-		margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;
+		margin: 0;
 		max-width: 100%;
 		min-width: calc(var(--ee-font-size-default) * 12);
 		white-space: pre;
 		width: auto;
 
-		@include max850px {
+		@include max1024px {
 			min-width: calc(49.5% - var(--ee-margin-small));
 		}
 
@@ -71,31 +73,31 @@ $filter-btn: '.ee-filter-bar__btn';
 		}
 
 		&--micro {
-			min-width: calc(var(--ee-font-size-default) * 3);
-		}
-
-		&--tiny {
 			min-width: calc(var(--ee-font-size-default) * 4);
 		}
 
-		&--smaller {
+		&--tiny {
 			min-width: calc(var(--ee-font-size-default) * 6);
 		}
 
+		&--smaller {
+			min-width: calc(var(--ee-font-size-default) * 8);
+		}
+
 		&--small {
-			min-width: calc(var(--ee-font-size-default) * 9);
+			min-width: calc(var(--ee-font-size-default) * 12);
 		}
 
 		&--big {
-			min-width: calc(var(--ee-font-size-default) * 15);
+			min-width: calc(var(--ee-font-size-default) * 18);
 		}
 
 		&--bigger {
-			min-width: calc(var(--ee-font-size-default) * 21);
+			min-width: calc(var(--ee-font-size-default) * 27);
 		}
 
 		&--huge {
-			min-width: calc(var(--ee-font-size-default) * 32);
+			min-width: calc(var(--ee-font-size-default) * 36);
 		}
 
 		&--extreme {

--- a/packages/ui-components/src/EntityList/filterBar/style.scss
+++ b/packages/ui-components/src/EntityList/filterBar/style.scss
@@ -59,48 +59,56 @@ $filter-btn: '.ee-filter-bar__btn';
 			margin: 0 0 var(--ee-margin-smaller);
 		}
 
+		&:first-child > div {
+			padding-inline-start: 0;
+		}
+
+		&:last-child > div {
+			padding-inline-end: 0;
+		}
+
 		> div,
 		&--full-width {
 			width: 100%;
 		}
 
-		&--auto {
+		&-width--auto {
 			width: auto;
 		}
 
-		&--nano {
+		&-width--nano {
 			min-width: calc(var(--ee-font-size-default) * 2);
 		}
 
-		&--micro {
+		&-width--micro {
 			min-width: calc(var(--ee-font-size-default) * 4);
 		}
 
-		&--tiny {
+		&-width--tiny {
 			min-width: calc(var(--ee-font-size-default) * 6);
 		}
 
-		&--smaller {
+		&-width--smaller {
 			min-width: calc(var(--ee-font-size-default) * 8);
 		}
 
-		&--small {
+		&-width--small {
 			min-width: calc(var(--ee-font-size-default) * 12);
 		}
 
-		&--big {
+		&-width--big {
 			min-width: calc(var(--ee-font-size-default) * 18);
 		}
 
-		&--bigger {
+		&-width--bigger {
 			min-width: calc(var(--ee-font-size-default) * 27);
 		}
 
-		&--huge {
+		&-width--huge {
 			min-width: calc(var(--ee-font-size-default) * 36);
 		}
 
-		&--extreme {
+		&-width--extreme {
 			min-width: calc(var(--ee-font-size-default) * 48);
 		}
 	}
@@ -167,6 +175,8 @@ $filter-btn: '.ee-filter-bar__btn';
 
 	&__chain {
 		min-height: 40px;
+		position: relative;
+		inset-inline-start: var(--ee-margin-pico);
 
 		@include max850px {
 			width: calc(49.5% - var(--ee-margin-small));

--- a/packages/ui-components/src/EntityList/style.scss
+++ b/packages/ui-components/src/EntityList/style.scss
@@ -55,9 +55,13 @@
 	}
 
 	&__pagination {
-		&.ee-pagination {
-			margin: 0 0 0 auto;
-		}
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	> .ee-btn-row {
+		position: relative;
 	}
 
 	+ .ee-entity-list {

--- a/packages/ui-components/src/FilterBarFilter/FilterBarFilter.tsx
+++ b/packages/ui-components/src/FilterBarFilter/FilterBarFilter.tsx
@@ -1,11 +1,14 @@
 import classNames from 'classnames';
 
-type FilterBarFilterProps = {
-	className?: string;
-};
+import type { Size } from '../types';
 
-const FilterBarFilter: React.FC<FilterBarFilterProps> = ({ children, className }) => {
-	return <div className={classNames('ee-filter-bar__filter', className)}>{children}</div>;
+interface FilterBarFilterProps extends Size {
+	className?: string;
+}
+
+const FilterBarFilter: React.FC<FilterBarFilterProps> = ({ children, className, size }) => {
+	const filterClasses = classNames('ee-filter-bar__filter', size && `ee-filter-bar__filter--${size}`, className);
+	return <div className={filterClasses}>{children}</div>;
 };
 
 export default FilterBarFilter;

--- a/packages/ui-components/src/FilterBarFilter/FilterBarFilter.tsx
+++ b/packages/ui-components/src/FilterBarFilter/FilterBarFilter.tsx
@@ -1,13 +1,17 @@
 import classNames from 'classnames';
 
-import type { Size } from '../types';
+import type { Width } from '../types';
 
-interface FilterBarFilterProps extends Size {
+interface FilterBarFilterProps extends Width {
 	className?: string;
 }
 
-const FilterBarFilter: React.FC<FilterBarFilterProps> = ({ children, className, size }) => {
-	const filterClasses = classNames('ee-filter-bar__filter', size && `ee-filter-bar__filter--${size}`, className);
+const FilterBarFilter: React.FC<FilterBarFilterProps> = ({ children, className, width }) => {
+	const filterClasses = classNames(
+		'ee-filter-bar__filter',
+		width && `ee-filter-bar__filter-width--${width}`,
+		className
+	);
 	return <div className={filterClasses}>{children}</div>;
 };
 

--- a/packages/ui-components/src/Legend/ToggleLegendButton.tsx
+++ b/packages/ui-components/src/Legend/ToggleLegendButton.tsx
@@ -1,8 +1,8 @@
 import { useSpring, animated } from 'react-spring';
-import { __ } from '@eventespresso/i18n';
 
+import { __ } from '@eventespresso/i18n';
 import { CompassFilled } from '@eventespresso/icons';
-import { Button } from '../Button';
+import { Button, ButtonType } from '../Button';
 import type { ToggleLegendButtonProps } from './types';
 
 const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({
@@ -23,18 +23,19 @@ const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({
 		</animated.div>
 	);
 
-	const tooltip = showLegend ? __('hide legend') : __('show legend');
+	const buttonType = showLegend ? ButtonType.PRIMARY : ButtonType.DEFAULT;
 
 	return (
 		<Button
 			active={showLegend}
+			buttonType={buttonType}
 			className={className}
 			icon={icon}
 			noHorizontalMargin={noHorizontalMargin}
 			onClick={toggleLegend}
 			size='tiny'
 		>
-			{tooltip}
+			{__('legend')}
 		</Button>
 	);
 };

--- a/packages/ui-components/src/Pagination/style.scss
+++ b/packages/ui-components/src/Pagination/style.scss
@@ -8,8 +8,7 @@ $border-radius: var(--ee-border-radius-tiny);
 	display: flex;
 	flex-flow: row wrap;
 	justify-content: flex-end;
-	margin: var(--ee-margin-small) 0;
-	padding: var(--ee-padding-smaller);
+	padding: var(--ee-padding-tiny);
 
 	&--align {
 		&-center {

--- a/packages/ui-components/src/Select/Select.tsx
+++ b/packages/ui-components/src/Select/Select.tsx
@@ -11,12 +11,13 @@ import type { SelectProps } from './types';
 import './style.scss';
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps & React.ComponentProps<typeof InlineSelect>>(
-	({ fitContainer, flow, id, noBorderColor, onChangeInstantValue, size, wrapperClassName, ...props }, ref) => {
+	({ fitContainer, flow, id, noBorderColor, onChangeInstantValue, size, width, wrapperClassName, ...props }, ref) => {
 		const className = classNames(
 			'ee-select ee-input-base',
 			noBorderColor && 'ee-select--no-border-color',
 			props.className,
-			size && size !== 'default' && [`ee-select--${size}`]
+			size && size !== 'default' && [`ee-select--${size}`],
+			width && [`ee-select-width--${width}`]
 		);
 		const wrapperClass = classNames(
 			wrapperClassName,

--- a/packages/ui-components/src/Select/types.ts
+++ b/packages/ui-components/src/Select/types.ts
@@ -1,6 +1,7 @@
 import type { SelectProps as AdapterSelectProps } from '@eventespresso/adapters';
+import type { Size, Width } from '../types';
 
-export interface SelectProps extends AdapterSelectProps {
+export interface SelectProps extends Omit<AdapterSelectProps, 'size' | 'width'>, Size, Width {
 	fitContainer?: boolean;
 	flow?: 'inline';
 	noBorderColor?: boolean;

--- a/packages/ui-components/src/bulkEdit/styles.scss
+++ b/packages/ui-components/src/bulkEdit/styles.scss
@@ -3,43 +3,56 @@
 .ee-bulk-edit-actions {
 	&__wrapper {
 		align-items: flex-end;
+		box-sizing: border-box;
 		display: flex;
-		padding-bottom: var(--ee-padding-smaller);
+		margin-block-start: var(--ee-margin-tiny);
+		margin-block-end: var(--ee-margin-smaller);
+		max-width: 100%;
+		min-width: fit-content;
 		width: 100%;
 
-		@include max782px {
-			align-items: center;
+		@include max767px {
 			flex-direction: column;
 		}
 
 		.ee-input-label__wrapper {
-			display: inline-grid;
+			display: inline-flex;
 			padding-bottom: 0;
 			padding-left: 0;
+			width: auto;
+		}
 
-			label {
-				@include max782px {
-					text-align: center;
-				}
-			}
+		.ee-btn-base.ee-btn {
+			margin-block: var(--ee-margin-micro);
+			margin-inline-start: 0;
 		}
 	}
 
 	&__select {
 		&-wrapper {
 			display: contents;
-			max-width: fit-content;
+			max-width: 32rem;
+			width: fit-content;
 		}
 
 		&.ee-input-base.ee-select {
-			max-width: fit-content;
+			min-width: 16rem !important;
+			width: fit-content !important;
 		}
 	}
 
 	&__mobile-checkbox {
 		display: none;
-		@include max782px {
+		@include max1280px {
 			display: block;
+			padding: 0 1.5rem 0.85rem 0.5rem;
 		}
+	}
+}
+
+th .ee-bulk-edit-actions__checkbox {
+		margin-block-end: var(--ee-margin-micro) !important;
+	@include min1600px {
+		margin-inline-start: var(--ee-margin-small) !important;
 	}
 }

--- a/packages/ui-components/src/types.ts
+++ b/packages/ui-components/src/types.ts
@@ -33,6 +33,22 @@ export interface EditButtonProps {
 
 export type ForwardRefComponent<P, C> = ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<C>>;
 
+export type Sizes =
+	| 'auto'
+	| 'nano'
+	| 'micro'
+	| 'tiny'
+	| 'smaller'
+	| 'small'
+	| 'default'
+	| 'big'
+	| 'bigger'
+	| 'huge'
+	| 'extreme';
+
 export interface Size {
-	size?: 'nano' | 'micro' | 'tiny' | 'smaller' | 'small' | 'default' | 'big' | 'bigger' | 'huge';
+	size?: Sizes;
+}
+export interface Width {
+	width?: Sizes;
 }


### PR DESCRIPTION
For the E2E tests that @alexkuc is developing, we needed to remove the feature flags filter that was in the "Barista for Event Espresso" add-on, that essentially turned ALL of the flags on (for development purposes), because he needs manual control over them which he will do via WP-CLI. 

This of course meant that there was no longer a way to turn those filters on for anyone that doesn't use WP-CLI. 

This PR:

- adds a new tab to the EE Maintenance admin page named "Feature Flags"
- adds a series of switches for enabling or disabling individual feature flags
- refactors some of the logic in the EDTR (specifically the bulk edit feature) so that things can be modified directly via the new feature flags admin.
- removed the show/hide button for the bulk edit functionality
- the bulk edit UI will now always show when using the Entity List table view in the EDTR
- fixes some other style issues I noticed


Here's what the new admin page looks like:
![image](https://github.com/eventespresso/barista/assets/1751030/c7493f44-5933-4663-984e-16a6c22d1865)

And here's what the Event Dates List and filters look like in table view after the changes:
![image](https://github.com/eventespresso/barista/assets/1751030/f227dd23-a8e6-4659-b931-2be20890ee27)

### testing notes

- log into the admin and go to the WP Plugins admin page
- activate the "Barista for Event Espresso" plugin
- go to EE Maintenance admin page and click on the "Features Flag" tab
- toggle ALL switches off and click update
- [x] confirm that changes update correctly
- try toggling one or more feature flag switches ON and click update
- [x] confirm that changes update correctly
- [x] confirm that navigating away and returning to page still shows same settings
- turn ALL feature flags off again and click update
- in another browser tab, go the the Events admin page and add/edit an event
- toggle one of the feature flags to ON and click update
- refresh the event editor and look for the new feature / functionality
- [ ] confirm that toggling the feature flag switch affects the UI accordingly
- continue toggling each feature flag switch in the new UI and checking that the corresponding feature/functionality has changed in the EDTR
- [ ] confirm that everything works as expected
