### PR TITLE
Add support for decimals in Ticket Price Calculator

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -66,6 +66,9 @@ const config: Config.InitialOptions = {
 	moduleNameMapper: resolveTsconfigPathsToModuleNameMapper(),
 	moduleFileExtensions: ['web.js', 'js', 'web.ts', 'ts', 'web.tsx', 'tsx', 'json', 'web.jsx', 'jsx', 'node'],
 	watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+	// always show summary of unit tests
+	// https://jestjs.io/docs/configuration#summary-reporter
+	reporters: [['default', { summaryThreshold: 1 }]],
 };
 
 export default config;

--- a/packages/adapters/src/NumberInput/NumberInput.tsx
+++ b/packages/adapters/src/NumberInput/NumberInput.tsx
@@ -38,7 +38,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 			(valueAsString, valueAsNumber) => {
 				if (!isDisabled) {
 					onChange?.(valueAsString, valueAsNumber);
-					onChangeValue?.(valueAsNumber);
+					onChangeValue?.(valueAsString);
 				}
 			},
 			[isDisabled, onChange, onChangeValue]

--- a/packages/adapters/src/NumberInput/types.ts
+++ b/packages/adapters/src/NumberInput/types.ts
@@ -21,7 +21,9 @@ type Picked =
 	| 'step'
 	| 'value';
 
-export interface NumberInputProps extends Pick<ChakraNumberInputProps, Picked>, CommonInputProps<HTMLInputElement> {
+export interface NumberInputProps
+	extends Pick<ChakraNumberInputProps, Picked>,
+		CommonInputProps<HTMLInputElement, 'onChange'> {
 	decrementStepperProps?: ChakraBoxProps;
 	inputFieldProps?: ChakraInputProps;
 	inputStepperProps?: ChakraFlexProps;

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -2,5 +2,10 @@ export type CommonInputEvent<T = Element> = React.ChangeEvent<T> | React.FormEve
 
 export interface CommonInputProps<T = Element, V = React.ReactText> {
 	onChange?: (valueAsString: string, valueAsNumber: number) => void | React.ChangeEventHandler<T>;
-	onChangeValue?: (value: any) => void | ((value: V, event?: CommonInputEvent<T>) => void);
+	onChangeValue?: onChangeValueI<T, V>;
+}
+
+interface onChangeValueI<T = Element, V = React.ReactText> {
+	(value: any): void;
+	(value: V, event?: CommonInputEvent<T>): void;
 }

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,6 +1,6 @@
 export type CommonInputEvent<T = Element> = React.ChangeEvent<T> | React.FormEvent<T>;
 
 export interface CommonInputProps<T = Element, V = React.ReactText> {
-	onChange?: (valueAsString: string, valueAsNumber: number) => void | React.ChangeEventHandler<HTMLInputElement>;
-	onChangeValue?: ((value: V, event?: CommonInputEvent<T>) => void) | ((value: any) => void);
+	onChange?: (valueAsString: string, valueAsNumber: number) => void | React.ChangeEventHandler<T>;
+	onChangeValue?: (value: any) => void | ((value: V, event?: CommonInputEvent<T>) => void);
 }

--- a/packages/config/src/Factory.ts
+++ b/packages/config/src/Factory.ts
@@ -15,6 +15,14 @@ import {
 } from '.';
 
 export class Factory {
+	public static make(): Type.Config {
+		if (!window.eventEspressoData) {
+			return new Factory().get();
+		}
+		const { config, api } = window.eventEspressoData;
+		return new Factory(config, api).get();
+	}
+
 	constructor(
 		private readonly config?: EventEspressoData['config'],
 		private readonly api?: EventEspressoData['api']

--- a/packages/config/src/test/data.ts
+++ b/packages/config/src/test/data.ts
@@ -58,7 +58,7 @@ export const mockData: EventEspressoData = {
 			sign: 'Z',
 			signB4: true,
 			decimalPlaces: 3,
-			decimalMark: '::',
+			decimalMark: '.',
 			thousandsSeparator: ':',
 			subunits: 1000,
 		},

--- a/packages/tpc/src/data/test/data.calculations.test.ts
+++ b/packages/tpc/src/data/test/data.calculations.test.ts
@@ -68,7 +68,7 @@ describe('TPC:data.calculations', () => {
 		// Ticket total must have changed
 		expect(ticketTotalBefore).not.toEqual(ticketTotalAfter);
 
-		// calculate th expected ticket total
+		// calculate the expected ticket total
 		const calculatedTicketTotal = calculateTicketTotal(result.current.dataState.getData().prices);
 
 		expect(calculatedTicketTotal).toEqual(ticketTotalAfter);

--- a/packages/tpc/src/fields/BaseField.tsx
+++ b/packages/tpc/src/fields/BaseField.tsx
@@ -73,7 +73,6 @@ const BaseField: React.FC<BaseFieldProps> = ({
 				{...props}
 				inputClass={'ee-input'}
 				isDisabled={props.disabled}
-				onChangeValue={handlers?.onChangeValue}
 				showStepper={false}
 				value={fieldValue as string}
 				wrapperClass={props.className}

--- a/packages/tpc/src/fields/BaseField.tsx
+++ b/packages/tpc/src/fields/BaseField.tsx
@@ -68,7 +68,6 @@ const BaseField: React.FC<BaseFieldProps> = ({
 
 	if (type === 'number') {
 		return (
-			// @ts-ignore
 			<NumberInput
 				{...handlers}
 				{...props}

--- a/packages/tpc/src/fields/types.ts
+++ b/packages/tpc/src/fields/types.ts
@@ -1,6 +1,6 @@
 import { InputHTMLAttributes } from 'react';
 
-import type { CommonInputProps, NumberInputProps } from '@eventespresso/adapters';
+import type { NumberInputProps } from '@eventespresso/adapters';
 import type { SelectProps } from '@eventespresso/ui-components';
 
 import type { PriceModifierProps, TpcPriceModifier } from '../types';
@@ -8,8 +8,10 @@ import type { PriceModifierProps, TpcPriceModifier } from '../types';
 export type InputProps<E = HTMLInputElement> = Omit<
 	InputHTMLAttributes<E>,
 	'css' | 'max' | 'min' | 'step' | 'defaultValue' | 'onChange'
-> &
-	CommonInputProps<E>;
+> & {
+	onChange?: (value: any | EventTarget) => void;
+	onChangeValue?: (value: any) => void;
+};
 
 export type FieldValue = string | number | boolean;
 

--- a/packages/tpc/src/fields/types.ts
+++ b/packages/tpc/src/fields/types.ts
@@ -1,14 +1,16 @@
 import { InputHTMLAttributes } from 'react';
 
-import type { NumberInputProps } from '@eventespresso/adapters';
+import type { CommonInputProps, NumberInputProps } from '@eventespresso/adapters';
 import type { SelectProps } from '@eventespresso/ui-components';
 
 import type { PriceModifierProps, TpcPriceModifier } from '../types';
 
-// 'css' prop conflicts with Chakra UI component props
-export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'css' | 'max' | 'min' | 'step'> & {
-	onChangeValue?: (value: any) => void;
-};
+export type InputProps<E = HTMLInputElement> = Omit<
+	InputHTMLAttributes<E>,
+	'css' | 'max' | 'min' | 'step' | 'defaultValue' | 'onChange'
+> &
+	CommonInputProps<E>;
+
 export type FieldValue = string | number | boolean;
 
 type SupportedInputs = 'input' | 'select' | 'textarea';

--- a/packages/tpc/src/fields/useBaseField.tsx
+++ b/packages/tpc/src/fields/useBaseField.tsx
@@ -40,8 +40,9 @@ const useBaseField = ({
 					setValue(format(getValue(), name));
 				}
 			},
-			onChange: (valueAsString, valueAsNumber) => {
-				setValue(parse(valueAsString, name));
+			onChange: (event) => {
+				const value = event?.target?.value ? event.target.value : event;
+				setValue(parse(value, name));
 			},
 			onChangeValue: (value) => {
 				setValue(parse(value, name));

--- a/packages/tpc/src/fields/useBaseField.tsx
+++ b/packages/tpc/src/fields/useBaseField.tsx
@@ -40,9 +40,8 @@ const useBaseField = ({
 					setValue(format(getValue(), name));
 				}
 			},
-			onChange: (event) => {
-				const value = event?.target?.value;
-				setValue(parse(value, name));
+			onChange: (valueAsString, valueAsNumber) => {
+				setValue(parse(valueAsString, name));
 			},
 			onChangeValue: (value) => {
 				setValue(parse(value, name));

--- a/packages/tpc/src/fields/useBaseField.tsx
+++ b/packages/tpc/src/fields/useBaseField.tsx
@@ -23,7 +23,7 @@ const useBaseField = ({
 
 	if (formatOnBlur) {
 		if (component === 'input') {
-			fieldValue = defaultFormat(fieldValue, name);
+			fieldValue = format(fieldValue, name);
 		}
 	} else {
 		fieldValue = format(fieldValue, name);

--- a/packages/tpc/src/fields/usePriceAmount.tsx
+++ b/packages/tpc/src/fields/usePriceAmount.tsx
@@ -14,8 +14,9 @@ const usePriceAmount = ({ field, price }: UsePriceAmount): UsePrice => {
 
 	const setValue = useCallback<BFP['setValue']>(
 		(value) => {
-			const absValue = Math.abs(parsedAmount(value as number)) || 0;
-			updatePrice({ id: price.id, fieldValues: { [field]: absValue } });
+			const absValue = parsedAmount(value as number);
+			const positiveValue = absValue > 0 ? absValue : absValue * -1;
+			updatePrice({ id: price.id, fieldValues: { [field]: positiveValue } });
 		},
 		[updatePrice, price.id, field]
 	);

--- a/packages/tpc/src/fields/usePriceAmount.tsx
+++ b/packages/tpc/src/fields/usePriceAmount.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useMemo } from 'react';
 
-import { parsedAmount } from '@eventespresso/utils';
-
 import { useDataState } from '../data';
 import type { BaseFieldProps, UsePrice, UsePriceAmount } from './types';
 
@@ -10,13 +8,13 @@ type BFP = BaseFieldProps;
 const usePriceAmount = ({ field, price }: UsePriceAmount): UsePrice => {
 	const { updatePrice } = useDataState();
 
-	const getValue = useCallback<BFP['getValue']>(() => price[field], [field, price]);
+	const getValue = useCallback<BFP['getValue']>(() => {
+		return price[field];
+	}, [field, price]);
 
 	const setValue = useCallback<BFP['setValue']>(
 		(value) => {
-			const parsedValue = parsedAmount(value as number);
-			const positiveValue = parsedValue > 0 ? parsedValue : parsedValue * -1;
-			updatePrice({ id: price.id, fieldValues: { [field]: positiveValue } });
+			updatePrice({ id: price.id, fieldValues: { [field]: value } });
 		},
 		[updatePrice, price.id, field]
 	);

--- a/packages/tpc/src/fields/usePriceAmount.tsx
+++ b/packages/tpc/src/fields/usePriceAmount.tsx
@@ -14,8 +14,8 @@ const usePriceAmount = ({ field, price }: UsePriceAmount): UsePrice => {
 
 	const setValue = useCallback<BFP['setValue']>(
 		(value) => {
-			const absValue = parsedAmount(value as number);
-			const positiveValue = absValue > 0 ? absValue : absValue * -1;
+			const parsedValue = parsedAmount(value as number);
+			const positiveValue = parsedValue > 0 ? parsedValue : parsedValue * -1;
 			updatePrice({ id: price.id, fieldValues: { [field]: positiveValue } });
 		},
 		[updatePrice, price.id, field]

--- a/packages/tpc/src/inputs/PriceAmountInput.tsx
+++ b/packages/tpc/src/inputs/PriceAmountInput.tsx
@@ -1,18 +1,23 @@
 import classNames from 'classnames';
 import { __ } from '@eventespresso/i18n';
+import { useState, useCallback } from 'react';
 
 import { useMoneyDisplay } from '@eventespresso/services';
 import { parsedAmount } from '@eventespresso/utils';
 import { BaseField, MoneyInputWithConfig, usePriceAmount } from '../fields';
 import { useDataState } from '../data';
 import type { PriceModifierProps } from '../types';
+import type { BaseFieldProps, FieldValue } from '../fields/types';
 
 import './styles.scss';
 
+type Event = React.FocusEvent<HTMLInputElement>;
+
 const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
-	const { formatAmount } = useMoneyDisplay();
+	const { formatAmount: formatMoneyAmount } = useMoneyDisplay();
 	const { reverseCalculate, isDisabled } = useDataState();
 	const { getValue, setValue } = usePriceAmount({ field: 'amount', price });
+	const [format, setFormat] = useState(true);
 
 	const hasError = Number(price?.amount ?? 0) === 0;
 	const className = classNames(
@@ -20,6 +25,69 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 		hasError && 'ee-input__price-field--has-error',
 		price.isPercent
 	);
+
+	const getPrevValue = useCallback((): string | number => {
+		const value = getValue();
+		if (typeof value === 'boolean') {
+			return 0;
+		}
+		return value;
+	}, [getValue]);
+
+	const parseValue: BaseFieldProps['parse'] = useCallback(
+		(value) => {
+			// get previous value
+			const prevValue = getPrevValue();
+			// fallback to 0 if cannot parse previous amount
+			const prevAmount = parsedAmount(prevValue, 0);
+			// fallback to previous amount if cannot parse value
+			const newAmount = parsedAmount(value, prevAmount);
+			// return actual value
+			return newAmount;
+		},
+		[getPrevValue]
+	);
+
+	const formatValue: BaseFieldProps['format'] = useCallback(
+		(value) => {
+			const v = typeof value !== 'boolean' ? value : 0;
+			return formatMoneyAmount(v);
+		},
+		[formatMoneyAmount]
+	);
+
+	const makePositive = useCallback((input: number): number => {
+		return input > 0 ? input : input * -1;
+	}, []);
+
+	const onBlur: BaseFieldProps['onBlur'] = useCallback(
+		(event) => {
+			const rawValue = event.currentTarget.value;
+			const parsedValue = parseValue(rawValue, 'amount');
+			const formattedValue = formatValue(parsedValue, 'amount');
+			const positiveValue = makePositive(formattedValue);
+			setValue(positiveValue);
+			setFormat(true);
+		},
+		[parseValue, formatValue, makePositive, setValue, setFormat]
+	);
+
+	const onFocus = useCallback((event: Event): void => {
+		event.currentTarget.select();
+	}, []);
+
+	const onFocusCapture = useCallback((): void => {
+		setValue(formatValue(getValue(), 'amount'));
+		setFormat(false);
+	}, [formatValue, getValue, setValue, setFormat]);
+
+	const getFormattedValue = useCallback((): FieldValue => {
+		const raw = getValue();
+		if (format) {
+			return formatValue(raw, 'amount');
+		}
+		return raw;
+	}, [format, getValue, formatValue]);
 
 	const disabled = isDisabled || (reverseCalculate && price.isBasePrice) || price.isDefault;
 
@@ -29,18 +97,19 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 				aria-label={__('amount')}
 				className={className}
 				component='input'
+				type='number'
 				// because it can affect other tickets that have this price
 				// default price amount should not be changeable
 				disabled={disabled}
-				format={formatAmount}
-				formatOnBlur
-				getValue={getValue}
+				getValue={getFormattedValue}
+				setValue={setValue}
+				onBlur={onBlur}
+				onFocusCapture={onFocusCapture}
+				onChangeValue={setValue}
 				min={0}
 				name='amount'
-				parse={parsedAmount}
 				placeholder={__('amount…')}
-				setValue={setValue}
-				type='number'
+				onFocus={onFocus}
 			/>
 		</MoneyInputWithConfig>
 	);

--- a/packages/tpc/src/inputs/PriceAmountInput.tsx
+++ b/packages/tpc/src/inputs/PriceAmountInput.tsx
@@ -41,9 +41,7 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 			// fallback to 0 if cannot parse previous amount
 			const prevAmount = parsedAmount(prevValue, 0);
 			// fallback to previous amount if cannot parse value
-			const newAmount = parsedAmount(value, prevAmount);
-			// return actual value
-			return newAmount;
+			return parsedAmount(value, prevAmount);
 		},
 		[getPrevValue]
 	);

--- a/packages/tpc/src/inputs/PriceAmountInput.tsx
+++ b/packages/tpc/src/inputs/PriceAmountInput.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { __ } from '@eventespresso/i18n';
 
+import { useMoneyDisplay } from '@eventespresso/services';
 import { parsedAmount } from '@eventespresso/utils';
 import { BaseField, MoneyInputWithConfig, usePriceAmount } from '../fields';
 import { useDataState } from '../data';
@@ -9,6 +10,7 @@ import type { PriceModifierProps } from '../types';
 import './styles.scss';
 
 const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
+	const { formatAmount } = useMoneyDisplay();
 	const { reverseCalculate, isDisabled } = useDataState();
 	const { getValue, setValue } = usePriceAmount({ field: 'amount', price });
 
@@ -21,13 +23,6 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 
 	const disabled = isDisabled || (reverseCalculate && price.isBasePrice) || price.isDefault;
 
-	const formatParse =
-		(defaultValue = null) =>
-		(amount: any) => {
-			const parsedValue = parsedAmount(amount);
-			return isNaN(parsedValue) ? defaultValue : parsedValue;
-		};
-
 	return (
 		<MoneyInputWithConfig disabled={disabled} isPercent={price.isPercent}>
 			<BaseField
@@ -37,12 +32,12 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 				// because it can affect other tickets that have this price
 				// default price amount should not be changeable
 				disabled={disabled}
-				format={formatParse('')}
+				format={formatAmount}
 				formatOnBlur
 				getValue={getValue}
 				min={0}
 				name='amount'
-				parse={formatParse()}
+				parse={parsedAmount}
 				placeholder={__('amount…')}
 				setValue={setValue}
 				type='number'

--- a/packages/utils/src/money/ParsedAmount-class.ts
+++ b/packages/utils/src/money/ParsedAmount-class.ts
@@ -1,0 +1,59 @@
+import * as R from 'ramda';
+import { Factory as ConfigFactory } from '@eventespresso/config';
+import type { Amount } from './types';
+
+export class ParsedAmount {
+	/** decimal places */
+	private readonly dp: number;
+
+	/** decimal mark */
+	private readonly dm: string;
+
+	constructor() {
+		const {
+			currency: { decimalMark, decimalPlaces },
+		} = ConfigFactory.make();
+
+		this.dp = decimalPlaces;
+		this.dm = decimalMark;
+	}
+
+	public parse = (amount: Amount, fallback: number = 0): number => {
+		if (this.isNullOrUndefined(amount)) return fallback;
+		if (this.isNumber(amount)) return amount;
+		return this.parseString(amount, fallback);
+	};
+
+	private isNullOrUndefined = (amount: Amount): amount is null | undefined => {
+		if (amount === null) return true;
+		if (amount === undefined) return true;
+		return false;
+	};
+
+	private isNumber = (amount: Amount): amount is number => {
+		if (typeof amount === 'number') return true;
+		return false;
+	};
+
+	private parseString = (amount: string, fallback: number): number => {
+		const pipe = R.pipe(this.removeChars, this.removeExcessDecimals);
+		const string = pipe(amount);
+		const float = Number.parseFloat(string);
+		if (Number.isNaN(float)) return fallback;
+		return float;
+	};
+
+	private removeChars = (amount: string): string => {
+		const regex = new RegExp(String.raw`[^\d${this.dm}]`, 'g');
+		return amount.replaceAll(regex, '');
+	};
+
+	private removeExcessDecimals = (amount: string): string => {
+		if (!amount.includes(this.dm)) return amount;
+		const [integers, decimals] = amount.split(this.dm);
+		if (decimals.length > this.dp) {
+			return integers + this.dm + decimals.substring(0, this.dp);
+		}
+		return amount;
+	};
+}

--- a/packages/utils/src/money/ParsedAmount-class.ts
+++ b/packages/utils/src/money/ParsedAmount-class.ts
@@ -11,10 +11,10 @@ export class ParsedAmount {
 
 	constructor() {
 		const {
-			currency: { decimalMark, decimalPlaces },
+			currency: { decimalMark },
 		} = ConfigFactory.make();
 
-		this.dp = decimalPlaces;
+		this.dp = 6;
 		this.dm = decimalMark;
 	}
 

--- a/packages/utils/src/money/ParsedAmount-class.ts
+++ b/packages/utils/src/money/ParsedAmount-class.ts
@@ -44,7 +44,8 @@ export class ParsedAmount {
 	};
 
 	private removeChars = (amount: string): string => {
-		const regex = new RegExp(String.raw`[^\d${this.dm}]`, 'g');
+		const pattern = '[^\\d\\' + this.dm + ']';
+		const regex = new RegExp(pattern, 'g');
 		return amount.replaceAll(regex, '');
 	};
 

--- a/packages/utils/src/money/formatAmount.ts
+++ b/packages/utils/src/money/formatAmount.ts
@@ -16,5 +16,8 @@ export const formatAmount =
 	(amount: Amount): string => {
 		const newParsedAmount = parsedAmount(amount);
 		// newParsedAmount may be NaN
-		return isNaN(newParsedAmount) ? '' : newParsedAmount.toFixed(decimalPlaces);
+		const stringAmount = Number.isNaN(newParsedAmount) ? '' : newParsedAmount + '';
+		// lame, but we have to convert to string in order to use parseFloat
+		const floatAmount = Number.parseFloat(stringAmount);
+		return floatAmount.toFixed(decimalPlaces);
 	};

--- a/packages/utils/src/money/formatAmount.ts
+++ b/packages/utils/src/money/formatAmount.ts
@@ -16,7 +16,7 @@ export const formatAmount =
 	(amount: Amount): string => {
 		const newParsedAmount = parsedAmount(amount);
 		// newParsedAmount may be NaN
-		const stringAmount = Number.isNaN(newParsedAmount) ? '' : newParsedAmount + '';
+		const stringAmount = Number.isNaN(newParsedAmount) ? '0' : newParsedAmount + '';
 		// lame, but we have to convert to string in order to use parseFloat
 		const floatAmount = Number.parseFloat(stringAmount);
 		return floatAmount.toFixed(decimalPlaces);

--- a/packages/utils/src/money/index.ts
+++ b/packages/utils/src/money/index.ts
@@ -2,3 +2,4 @@ export * from './amountsMatch';
 export * from './currencySignClassName';
 export * from './formatAmount';
 export * from './parsedAmount';
+export * from './ParsedAmount-class';

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -6,15 +6,16 @@ const NON_NUMERIC_REGEX = /[^\d.-]+/g;
  * returns amount parsed as a float (if not already a number)
  *
  * @param {number|string} amount
+ * @param {boolean} what value to return if number cannot be parsed i.e. NaN condition
  * @return {number}
  */
-export const parsedAmount = (amount: Amount): number => {
+export const parsedAmount = (amount: Amount, fallback: number = 0): number => {
 	if (typeof amount === 'number') {
 		return amount;
 	}
-	const float = amount.replace(NON_NUMERIC_REGEX, '') as unknown;
-	if (Number.isNaN(float)) {
-		 return 0;
+	const parsedStr = amount.replace(NON_NUMERIC_REGEX, '');
+	if (Number.isNaN(parsedStr)) {
+		return fallback;
 	}
-	return float as number;
+	return Number.parseFloat(parsedStr);
 };

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -1,6 +1,5 @@
+import { ParsedAmount } from '.';
 import type { Amount } from './types';
-
-const NON_NUMERIC_REGEX = /[^\d.-]+/g;
 
 /**
  * returns amount parsed as a float (if not already a number)
@@ -10,16 +9,5 @@ const NON_NUMERIC_REGEX = /[^\d.-]+/g;
  * @return {number}
  */
 export const parsedAmount = (amount: Amount, fallback: number = 0): number => {
-	if (amount === null || amount === undefined) {
-		return fallback;
-	}
-	if (typeof amount === 'number') {
-		return amount;
-	}
-	const parsedStr = amount.replace(NON_NUMERIC_REGEX, '');
-	const float = Number.parseFloat(parsedStr);
-	if (Number.isNaN(float)) {
-		return fallback;
-	}
-	return float;
+	return new ParsedAmount().parse(amount, fallback);
 };

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -10,6 +10,9 @@ const NON_NUMERIC_REGEX = /[^\d.-]+/g;
  * @return {number}
  */
 export const parsedAmount = (amount: Amount, fallback: number = 0): number => {
+	if (amount === null) {
+		return fallback;
+	}
 	if (typeof amount === 'number') {
 		return amount;
 	}

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -1,5 +1,7 @@
 import type { Amount } from './types';
 
+const NON_NUMERIC_REGEX = /[^\d.-]+/g;
+
 /**
  * returns amount parsed as a float (if not already a number)
  *
@@ -7,8 +9,12 @@ import type { Amount } from './types';
  * @return {number}
  */
 export const parsedAmount = (amount: Amount): number => {
-	if (typeof amount === 'number') return amount;
-	const float = Number.parseFloat(amount);
-	if (Number.isNaN(float)) return 0;
-	return float;
+	if (typeof amount === 'number') {
+		return amount;
+	}
+	const float = amount.replace(NON_NUMERIC_REGEX, '') as unknown;
+	if (Number.isNaN(float)) {
+		 return 0;
+	}
+	return float as number;
 };

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -17,8 +17,9 @@ export const parsedAmount = (amount: Amount, fallback: number = 0): number => {
 		return amount;
 	}
 	const parsedStr = amount.replace(NON_NUMERIC_REGEX, '');
-	if (Number.isNaN(parsedStr)) {
+	const float = Number.parseFloat(parsedStr);
+	if (Number.isNaN(float)) {
 		return fallback;
 	}
-	return Number.parseFloat(parsedStr);
+	return float;
 };

--- a/packages/utils/src/money/parsedAmount.ts
+++ b/packages/utils/src/money/parsedAmount.ts
@@ -10,7 +10,7 @@ const NON_NUMERIC_REGEX = /[^\d.-]+/g;
  * @return {number}
  */
 export const parsedAmount = (amount: Amount, fallback: number = 0): number => {
-	if (amount === null) {
+	if (amount === null || amount === undefined) {
 		return fallback;
 	}
 	if (typeof amount === 'number') {

--- a/packages/utils/src/money/test/amountsMatch.test.ts
+++ b/packages/utils/src/money/test/amountsMatch.test.ts
@@ -1,3 +1,4 @@
+import { test } from '@eventespresso/config';
 import { amountsMatch } from '../';
 
 const testCases = [
@@ -64,6 +65,9 @@ const testCases = [
 ];
 
 describe('amountsMatch', () => {
+	beforeAll(() => {
+		window.eventEspressoData = test.mockData;
+	});
 	for (const testCase of testCases) {
 		it(testCase.desc, () => {
 			const result = amountsMatch(testCase.amount1, testCase.amount2);

--- a/packages/utils/src/money/test/amountsMatch.test.ts
+++ b/packages/utils/src/money/test/amountsMatch.test.ts
@@ -67,7 +67,7 @@ describe('amountsMatch', () => {
 	for (const testCase of testCases) {
 		it(testCase.desc, () => {
 			const result = amountsMatch(testCase.amount1, testCase.amount2);
-			expect(result).toBe(testCase.result);
+			expect(testCase.result).toBe(result);
 		});
 	}
 });

--- a/packages/utils/src/money/test/parsedAmount.test.ts
+++ b/packages/utils/src/money/test/parsedAmount.test.ts
@@ -2,7 +2,7 @@ import { parsedAmount } from '../';
 
 const testCases = [
 	{
-		desc: 'checks for parsed amount to be a number',
+		desc: 'returns a number for a number',
 		amount: 5,
 		result: 5,
 	},

--- a/packages/utils/src/money/test/parsedAmount.test.ts
+++ b/packages/utils/src/money/test/parsedAmount.test.ts
@@ -1,3 +1,4 @@
+import { test } from '@eventespresso/config';
 import { parsedAmount } from '../';
 
 const testCases = [
@@ -39,6 +40,9 @@ const testCases = [
 ];
 
 describe('formatAmount', () => {
+	beforeAll(() => {
+		window.eventEspressoData = test.mockData;
+	});
 	for (const testCase of testCases) {
 		it(testCase.desc, () => {
 			const result = parsedAmount(testCase.amount);

--- a/packages/utils/src/money/types.ts
+++ b/packages/utils/src/money/types.ts
@@ -1,1 +1,1 @@
-export type Amount = number | string;
+export type Amount = number | string | null;

--- a/packages/utils/src/money/types.ts
+++ b/packages/utils/src/money/types.ts
@@ -1,1 +1,1 @@
-export type Amount = number | string | null;
+export type Amount = number | string | null | undefined;


### PR DESCRIPTION
### TODOs

- [ ] other price fields: use 6 decimal points to retain accuracy, for more decimal points, truncate the value 
- [ ] final price field: format according to decimal places as defined in global settings
- [ ] update unit tests: make sure TPC uses 6 decimal places
- [ ] update e2e tests: make sure TPC uses 6 decimal places

---

### Scope

Fixes #1184
Fixes https://github.com/eventespresso/cafe/issues/619

---

### Testing Instructions

This PR changes formatting for Ticket Price Calculator:

![image](https://github.com/eventespresso/barista/assets/3331946/06e7fac4-4df3-4aed-8b03-aefc72850fb1)

![image](https://github.com/eventespresso/barista/assets/3331946/f462f0a1-8252-443c-8f4e-0fbdfbe15bc9)

You should now be able to enter _decimals_ in addition to integers.

For full description of original issue, please refer to [here](https://github.com/eventespresso/barista/issues/1184#issue-1692817204).

> [!IMPORTANT]
> If you enter more points than support in settings, the code will truncate _according to admin options_
> ![image](https://github.com/eventespresso/barista/assets/3331946/fba2c0b6-7887-4926-be00-f69a7afec152)
> ![image](https://github.com/eventespresso/barista/assets/3331946/1adfc14f-70ed-4b39-892a-2d2321e54339)

