### PR TITLE
Fix E2E workflow failing to obtain head_ref from pull request

### DIFF
--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -40,9 +40,9 @@ jobs:
                     echo "Found branch name in github.event.pull_request.head.ref"
                     echo branch="$HEAD_REF" >> $GITHUB_OUTPUT
                   else
-                    echo "Using gh cli to get branch name"
-                    echo branch=$(gh pr view $PR --repo $REPO --json headRefName --jq '.
-                  headRefName') >> $GITHUB_OUTPUT
+                    branch=$(gh pr view $PR --repo $REPO --json headRefName --jq '.headRefName')
+                    echo "Found branch using gh cli: $branch"
+                    echo branch="$branch" >> $GITHUB_OUTPUT
                   fi
               env:
                   HEAD_REF: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Exactly the same fix as described in https://github.com/eventespresso/cafe/pull/914