### PR TITLE
Add credit card parameter for E2E tests for PayPal Commerce

### DIFF
--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -56,3 +56,6 @@ jobs:
                   cafe_repo_branch: DEV
                   barista_repo_branch: ${{ steps.get-branch.outputs.branch }}
                   e2e_tests_repo_branch: MAIN
+              env:
+                  E2E_TEST_CARD_PAYPAL_COMMERCE: ${{ secrets.E2E_TEST_CARD_PAYPAL_COMMERCE }}
+                  E2E_TEST_CREDS_PPC_SANDBOX_CONNECT: ${{ secrets.E2E_TEST_CREDS_PPC_SANDBOX_CONNECT }}


### PR DESCRIPTION
### this pull request:

Add credit card as a secure parameter to allow testing payment method PayPal Commerce

### testing notes

Unfortunately, due to how GH workflow works, to test this change, it needs to be merged first and then E2E tests can be re-run. Expectation is that tests continue to pass without any issues whatsoever.