### PR TITLE
Move Venue Sorting into useVenues() Hook

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/venue/VenueDetails.tsx
+++ b/domains/core/admin/eventEditor/src/ui/venue/VenueDetails.tsx
@@ -28,16 +28,8 @@ export const VenueDetails: React.FC = () => {
 	const [selectedVenueId, setSelectedVenueId] = useState(event?.venue || '');
 
 	const venues = useVenues();
-	// need to make a copy else we can't sort it
-	const sortedVenues = useMemo(() => [...venues], [venues]);
-	// create a collator to sort the venues by name using the current locale and natural sort order
-	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
-	sortedVenues.sort((a, b) => collator.compare(a.name, b.name));
 
-	const selectedVenue = useMemo(
-		() => findEntityByGuid(sortedVenues)(selectedVenueId),
-		[selectedVenueId, sortedVenues]
-	);
+	const selectedVenue = useMemo(() => findEntityByGuid(venues)(selectedVenueId), [selectedVenueId, venues]);
 
 	const createVenueLink = useVenueLink('create_new');
 	const editVenueLink = useVenueLink('edit', selectedVenue?.dbId);
@@ -130,7 +122,7 @@ export const VenueDetails: React.FC = () => {
 				onChangeInstantValue={onChangeInstantValue}
 				value={event?.venue}
 				venueName={selectedVenue?.name}
-				venues={sortedVenues}
+				venues={venues}
 			/>
 		</Container>
 	);

--- a/packages/edtr-services/src/apollo/queries/venues/useVenues.ts
+++ b/packages/edtr-services/src/apollo/queries/venues/useVenues.ts
@@ -13,9 +13,15 @@ export const useVenues = (): Venue[] => {
 
 	const { data } = useVenuesQuery<VenueEdge>(options);
 
-	const nodes = data?.espressoVenues?.nodes || [];
+	const venues = data?.espressoVenues?.nodes || [];
 
-	const cacheIds = getCacheIds(nodes);
+	// need to make a copy else we can't sort it
+	const sortedVenues = [...venues];
 
-	return useMemoStringify(nodes, cacheIds);
+	// create a collator to sort the venues by name using the current locale and natural sort order
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+	sortedVenues.sort((a, b) => collator.compare(a.name, b.name));
+
+	const cacheIds = getCacheIds(sortedVenues);
+	return useMemoStringify(sortedVenues, cacheIds);
 };


### PR DESCRIPTION
plz see: https://github.com/eventespresso/cafe/pull/969#issuecomment-1830554622

basically, the same VenueSelector component is used in two places, but only one of them was sorting the venues. This PR move sorting into the `useVenues()` hook so that they will always be sorted anywhere they are used. If another component wants/needs to change the sorting to something other than alphabetical, they can do that themselves.