### PR TITLE
Fix Datetime TBD Status Predicates

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -83,7 +83,7 @@ function getClientEnvironment(publicUrl) {
 				// and `sockPort` options in webpack-dev-server.
 				WDS_SOCKET_HOST: process.env.WDS_SOCKET_HOST,
 				WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
-				WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
+				WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT || 0,
 				// Whether or not react-refresh is enabled.
 				// react-refresh is not 100% stable at this time,
 				// which is why it's disabled by default.

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -10,7 +10,7 @@ const getHttpsConfig = require('./getHttpsConfig');
 const host = process.env.HOST || '0.0.0.0';
 const sockHost = process.env.WDS_SOCKET_HOST;
 const sockPath = process.env.WDS_SOCKET_PATH; // default: '/sockjs-node'
-const sockPort = process.env.WDS_SOCKET_PORT;
+const sockPort = process.env.WDS_SOCKET_PORT || 0;
 
 module.exports = function (proxy, allowedHost) {
 	return {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -20,7 +20,6 @@
 		"@chakra-ui/icons": "^1.0.17",
 		"@chakra-ui/react": "^1.6.12",
 		"@emotion/react": "^11.5.0",
-		"@emotion/styled": "^11.3.0",
 		"downshift": "6.1.7",
 		"framer-motion": "^4.1.17",
 		"rc-pagination": "^3.1.9",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -19,7 +19,6 @@
 	"dependencies": {
 		"@chakra-ui/icons": "^1.0.17",
 		"@chakra-ui/react": "^1.6.12",
-		"@emotion/react": "^11.5.0",
 		"downshift": "6.1.7",
 		"framer-motion": "^4.1.17",
 		"rc-pagination": "^3.1.9",

--- a/packages/constants/src/datetime.ts
+++ b/packages/constants/src/datetime.ts
@@ -10,6 +10,7 @@ export const datetimeStatus = {
 	isPostponed: __('Postponed'),
 	isSoldOut: __('Sold Out'),
 	isUpcoming: __('Upcoming'),
+	isTBD: __('TBD'),
 };
 
 export const datetimeStatusLabels = {

--- a/packages/edtr-services/src/apollo/mutations/useReorderEntities.ts
+++ b/packages/edtr-services/src/apollo/mutations/useReorderEntities.ts
@@ -91,7 +91,7 @@ export const useReorderEntities = <E extends Entity>({
 				const [entity] = allEntities.splice(indexInAll, 1);
 
 				// reset the order property for all entities in filtered list
-				return { ...entity, order: index + 1 };
+				return { ...entity, order: index + 1, key: index };
 			});
 
 			// insert ordered entities at the beginning of the array
@@ -101,7 +101,7 @@ export const useReorderEntities = <E extends Entity>({
 			// but now we need to reset the order properties for ALL entities
 			allEntities.map((entity, index) => {
 				// add 1 so we don't end up with order: 0
-				return { ...entity, order: index + 1 };
+				return { ...entity, order: index + 1, key: index };
 			});
 
 			setAllOrderedEntities(entities);

--- a/packages/predicates/src/datetimes/filters/activeUpcoming/index.ts
+++ b/packages/predicates/src/datetimes/filters/activeUpcoming/index.ts
@@ -1,5 +1,4 @@
-import isActive from '../../isActive';
-import isUpcoming from '../../isUpcoming';
+import { isActive, isUpcoming } from '../../index';
 import type { DatetimeFilterFn } from '../types';
 
 const activeUpcoming: DatetimeFilterFn = (dates) => {

--- a/packages/predicates/src/datetimes/filters/soldOutOnly/index.ts
+++ b/packages/predicates/src/datetimes/filters/soldOutOnly/index.ts
@@ -2,8 +2,6 @@ import isSoldOut from '../../isSoldOut';
 
 import type { DatetimeFilterFn } from '../types';
 
-const soldOutOnly: DatetimeFilterFn = (dates) => {
-	return dates.filter(isSoldOut);
-};
+const soldOutOnly: DatetimeFilterFn = (dates) => dates.filter(isSoldOut);
 
 export default soldOutOnly;

--- a/packages/predicates/src/datetimes/filters/upcomingOnly/index.ts
+++ b/packages/predicates/src/datetimes/filters/upcomingOnly/index.ts
@@ -1,4 +1,4 @@
-import {isTBD, isUpcoming} from '../../index';
+import { isTBD, isUpcoming } from '../../index';
 import type { DatetimeFilterFn } from '../types';
 
 const upcomingOnly: DatetimeFilterFn = (dates) => dates.filter((date) => isUpcoming(date) || isTBD(date));

--- a/packages/predicates/src/datetimes/filters/upcomingOnly/index.ts
+++ b/packages/predicates/src/datetimes/filters/upcomingOnly/index.ts
@@ -1,5 +1,6 @@
+import {isTBD, isUpcoming} from '../../index';
 import type { DatetimeFilterFn } from '../types';
 
-const upcomingOnly: DatetimeFilterFn = (dates) => dates.filter(({ isUpcoming }) => isUpcoming);
+const upcomingOnly: DatetimeFilterFn = (dates) => dates.filter((date) => isUpcoming(date) || isTBD(date));
 
 export default upcomingOnly;

--- a/packages/predicates/src/datetimes/index.ts
+++ b/packages/predicates/src/datetimes/index.ts
@@ -12,6 +12,7 @@ export { default as sortDates } from './sorters';
 export { default as validFiniteCapacityLimit } from './validFiniteCapacityLimit';
 export { default as validSold } from './validSold';
 export { default as validStatus } from './validStatus';
+export { isTBD, isNotTBD } from './isTBD';
 
 export * from './constants';
 export * from './datetimeFields';

--- a/packages/predicates/src/datetimes/isCancelled/index.ts
+++ b/packages/predicates/src/datetimes/isCancelled/index.ts
@@ -10,6 +10,6 @@ import type { EntityFieldPred as EFP } from '@eventespresso/utils';
  */
 export const isCancelled = (date: Datetime): boolean => {
 	return R.propEq('isCancelled', true, date) || R.propEq('status', 'CANCELLED', date);
-}
+};
 
 export const isNotCancelled: EFP<'isCancelled', boolean> = R.complement(isCancelled);

--- a/packages/predicates/src/datetimes/isCancelled/index.ts
+++ b/packages/predicates/src/datetimes/isCancelled/index.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 
+import type { Datetime } from '@eventespresso/edtr-services';
 import type { EntityFieldPred as EFP } from '@eventespresso/utils';
 
 /**
@@ -7,6 +8,8 @@ import type { EntityFieldPred as EFP } from '@eventespresso/utils';
  * @param {Object} entity object
  * @return {boolean} true if datetime is cancelled
  */
-export const isCancelled: EFP<'isCancelled', boolean> = R.propEq('isCancelled', true);
+export const isCancelled = (date: Datetime): boolean => {
+	return R.propEq('isCancelled', true, date) || R.propEq('status', 'CANCELLED', date);
+}
 
 export const isNotCancelled: EFP<'isCancelled', boolean> = R.complement(isCancelled);

--- a/packages/predicates/src/datetimes/isPostponed/index.ts
+++ b/packages/predicates/src/datetimes/isPostponed/index.ts
@@ -10,6 +10,6 @@ import type { EntityFieldPred as EFP } from '@eventespresso/utils';
  */
 export const isPostponed = (date: Datetime): boolean => {
 	return R.propEq('isPostponed', true, date) || R.propEq('status', 'POSTPONED', date);
-}
+};
 
 export const isNotPostponed: EFP<'isPostponed', boolean> = R.complement(isPostponed);

--- a/packages/predicates/src/datetimes/isPostponed/index.ts
+++ b/packages/predicates/src/datetimes/isPostponed/index.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 
+import type { Datetime } from '@eventespresso/edtr-services';
 import type { EntityFieldPred as EFP } from '@eventespresso/utils';
 
 /**
@@ -7,6 +8,8 @@ import type { EntityFieldPred as EFP } from '@eventespresso/utils';
  * @param {Object} entity object
  * @return {boolean} true if datetime is postponed
  */
-export const isPostponed: EFP<'isPostponed', boolean> = R.propEq('isPostponed', true);
+export const isPostponed = (date: Datetime): boolean => {
+	return R.propEq('isPostponed', true, date) || R.propEq('status', 'POSTPONED', date);
+}
 
 export const isNotPostponed: EFP<'isPostponed', boolean> = R.complement(isPostponed);

--- a/packages/predicates/src/datetimes/isTBD/index.ts
+++ b/packages/predicates/src/datetimes/isTBD/index.ts
@@ -1,0 +1,12 @@
+import * as R from 'ramda';
+
+import type { Datetime } from '@eventespresso/edtr-services';
+
+/**
+ * @function
+ * @param {Object} entity object
+ * @return {boolean} true if datetime has a status of DTB (TDB: to be determined)
+ */
+export const isTBD = (date: Datetime): boolean => R.propEq('status', 'TO_BE_DETERMINED', date);
+
+export const isNotTBD = (date: Datetime): boolean => R.complement(isTBD)(date);

--- a/packages/predicates/src/datetimes/isUpcoming/index.ts
+++ b/packages/predicates/src/datetimes/isUpcoming/index.ts
@@ -17,7 +17,7 @@ const isUpcoming = (date: Datetime, ignoreFlag = false): boolean => {
 		return diff('seconds', parseISO(date.startDate), now) > 0;
 	}
 	return (
-		R.propEq('isPostponed', true, date) ||
+		R.propEq('isUpcoming', true, date) ||
 		R.propEq('status', 'UPCOMING', date) ||
 		isPostponed(date) || // date is posptponed to a future date which means it is upcoming
 		isTBD(date) // date is TBD which most likely means it is upcoming

--- a/packages/predicates/src/datetimes/isUpcoming/index.ts
+++ b/packages/predicates/src/datetimes/isUpcoming/index.ts
@@ -1,9 +1,10 @@
+import * as R from 'ramda';
 import { parseISO } from 'date-fns';
 
 import type { Datetime } from '@eventespresso/edtr-services';
-import { isBooleanTrue } from '@eventespresso/utils';
 import { diff } from '@eventespresso/dates';
 import { NOW as now } from '@eventespresso/constants';
+import { isPostponed, isTBD } from '../index';
 
 /**
  * Whether a datetime is upcoming, based on its start date
@@ -12,9 +13,14 @@ import { NOW as now } from '@eventespresso/constants';
  * @param ignoreFlag Whether to ignore the boolean flag from the object and recalculate the value
  */
 const isUpcoming = (date: Datetime, ignoreFlag = false): boolean => {
+	if (ignoreFlag) {
+		return diff('seconds', parseISO(date.startDate), now) > 0;
+	}
 	return (
-		(!ignoreFlag && isBooleanTrue(date.isUpcoming)) ||
-		(ignoreFlag && diff('seconds', parseISO(date.startDate), now) > 0)
+		R.propEq('isPostponed', true, date) ||
+		R.propEq('status', 'UPCOMING', date) ||
+		isPostponed(date) || // date is posptponed to a future date which means it is upcoming
+		isTBD(date) // date is TBD which most likely means it is upcoming
 	);
 };
 

--- a/packages/ui-components/src/dnd/DragAndDrop.tsx
+++ b/packages/ui-components/src/dnd/DragAndDrop.tsx
@@ -17,11 +17,12 @@ export const DragAndDrop = <E extends any>({
 	onDragUpdate,
 	renderDraggableItem,
 }: DragAndDropProps<E>) => {
-	const draggableItems = items
-		.map(renderDraggableItem)
-		.map((item, index) => (
-			<Draggable asItem={asItem} content={item.content} id={item.id} index={index} key={item?.id} />
-		));
+	const draggableItems = items.map(renderDraggableItem).map((item, index) => {
+		if (!item.hasOwnProperty('id')) {
+			console.error('Entity is missing the "id" property', item);
+		}
+		return <Draggable asItem={asItem} content={item.content} id={item?.id} index={index} key={item?.id} />;
+	});
 
 	return (
 		<DragDropContext


### PR DESCRIPTION
from chat:

> Alex
> It seems by default datetime defaults to TBD or To Be Decided
> If there is a datetime filter all activate and upcoming, after creating datetime it won't show up in the list unless filter is removed
> The same applies for the ticket list if linked filter is on

This PR:

- fixes the above issue
- adds a new `isTBD()` datetime predicate
- updates the `isUpcoming()` predicate to include Postponed && TDB datetimes
- does some other code cleanup
- removes `@emotion` dependencies from the adapters package because they don't appear to be used anywhere and are already imported by Chakra which causes console warnings
- attempted to fix WebSocket concolse errors