### PR TITLE
Allow manual trigger for E2E job

### DIFF
--- a/.github/workflows/e2e-cache-warmup.yml
+++ b/.github/workflows/e2e-cache-warmup.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
     warmup-cache:
-        name: Warmup E2E Cache
+        name: Warmup E2E cache
         runs-on: ubuntu-22.04
         timeout-minutes: 60
         steps:

--- a/.github/workflows/e2e-cache-warmup.yml
+++ b/.github/workflows/e2e-cache-warmup.yml
@@ -26,7 +26,7 @@ jobs:
                   host: github.com
                   private-key: ${{ secrets.GH_ACTIONS_SSH_PRIVATE_KEY }}
 
-            - name: Run E2E Tests
+            - name: Run E2E tests
               uses: eventespresso/actions/packages/e2e-tests@main
               with:
                   cafe_repo_branch: DEV

--- a/.github/workflows/e2e-cache-warmup.yml
+++ b/.github/workflows/e2e-cache-warmup.yml
@@ -18,7 +18,7 @@ jobs:
     warmup-cache:
         name: Warmup E2E Cache
         runs-on: ubuntu-22.04
-        timeout-minutes: 20
+        timeout-minutes: 60
         steps:
             - name: Setup SSH
               uses: MrSquaare/ssh-setup-action@v2

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -56,6 +56,9 @@ jobs:
         timeout-minutes: 60
         needs: check
         if: needs.check.outputs.branch
+        concurrency:
+            group: ${{ github.workflow }}-${{ needs.check.outputs.branch }}
+            cancel-in-progress: ${{ github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch' }}
         steps:
             - name: Setup SSH for git
               uses: MrSquaare/ssh-setup-action@v2

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -12,7 +12,7 @@ on:
                 type: string
                 required: false
             barista_repo_branch:
-                description: Which branch to use for Barista repository? (default 'master')
+                description: Which branch to use for Barista repository? (defaults to workflow branch)
                 type: string
                 required: false
             e2e_tests_repo_branch:

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -8,71 +8,67 @@ on:
     workflow_dispatch:
         inputs:
             cafe_repo_branch:
-                description: 'Cafe branch to use? (default: DEV)'
+                description: Which branch to use for Cafe repository? (default 'DEV')
                 type: string
                 required: false
-            e2e_repo_branch:
-                description: 'E2E branch to use? (default: MAIN)'
+            barista_repo_branch:
+                description: Which branch to use for Barista repository? (default 'master')
+                type: string
+                required: false
+            e2e_tests_repo_branch:
+                description: Which branch to use for E2E Tests repository? (default 'MAIN')
                 type: string
                 required: false
 
 jobs:
-    run-tests:
-        name: Run E2E Tests
+    check:
+        name: Check conditions
         runs-on: ubuntu-22.04
-        # two conditions which trigger E2E checks
-        #   - PR is approved
-        #   - PR contains comment "/run-e2e" (manual trigger)
-        if: |
-            github.event.review.state == 'approved' ||
-            (
-                github.event.issue.pull_request &&
-                contains(github.event.comment.body, '/run-e2e')
-            ) ||
-            github.event_name == 'workflow_dispatch'
-        # avoid excessively high timeout values to avoid burning minutes
-        timeout-minutes: 60
+        outputs:
+            branch: |-
+                ${{ steps.pull_request_review.outputs.branch || steps.issue_comment.outputs.branch || steps.workflow_dispatch.outputs.branch }}
         steps:
-            - id: ssh
-              name: Setup SSH
+            - name: "Event: 'pull_request_review' Activity: 'submitted'"
+              id: pull_request_review
+              if: github.event_name == 'pull_request_review'
+              run: echo branch="${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+            - name: "Event: 'issue_comment' Activity: 'created'"
+              id: issue_comment
+              if: |
+                  github.event_name == 'issue_comment' &&
+                  github.event.issue.pull_request &&
+                  contains(github.event.comment.body, '/run-e2e')
+              run: |
+                  branch="$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')"
+                  echo branch="$branch" >> "$GITHUB_OUTPUT"
+              env:
+                  PR: ${{ github.event.issue.number }}
+                  REPO: ${{ github.repository }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: "Event: 'workflow_dispatch' Activity: 'not applicable'"
+              id: workflow_dispatch
+              if: github.event_name == 'workflow_dispatch'
+              run: echo branch="${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+    e2e:
+        name: Run E2E tests
+        runs-on: ubuntu-22.04
+        timeout-minutes: 60
+        needs: check
+        steps:
+            - name: Setup SSH for git
               uses: MrSquaare/ssh-setup-action@v2
               with:
                   host: github.com
                   private-key: ${{ secrets.GH_ACTIONS_SSH_PRIVATE_KEY }}
-            # In case of pull_request_review, we have access to HEAD REF of pull request. However, in case of issue_comment, we do not since event issue_comment always runs against default branch:
-            # Note: This event will only trigger a workflow run if the workflow file is on the default branch.
-            # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review
-            # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
-            - id: get-branch
-              name: Get Branch Ref of the Pull Request
-              run: |
-                  if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
-                      echo "Found branch name in \$GITHUB_REF_NAME: $GITHUB_REF_NAME"
-                      echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-                  # if condition earlier takes care of 'approved'-only PR submissions
-                  if [ $GITHUB_EVENT_NAME" == "pull_request_review" ]; then
-                      branch="$(gh pr view $GITHUB_PR --repo $GITHUB_REPO --json headRefName --jq '.headRefName')"
-                      echo "Found branch using gh cli: $branch"
-                      echo "branch=$branch" >> $GITHUB_OUTPUT
-                      exit 0
-                  fi
-                  echo "Could not obtain branch name!"
-                  exit 1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_REF: ${{ env.GITHUB_REF }}
-                  GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
-                  GITHUB_PR: ${{ github.event.issue.number }}
-                  GITHUB_REPO: ${{ github.repository }}
-            - id: run-e2e
-              name: Run tests
+            - name: Check branch ref
+              run: test "${{ needs.check.outputs.branch }}"
+            - name: Run tests
               uses: eventespresso/actions/packages/e2e-tests@main
               with:
                   cafe_repo_branch: ${{ inputs.cafe_repo_branch || 'DEV' }}
-                  barista_repo_branch: ${{ steps.get-branch.outputs.branch }}
-                  e2e_tests_repo_branch: ${{ inputs.e2e_repo_branch || 'MAIN' }}
+                  barista_repo_branch: ${{ inputs.barista_repo_branch || needs.check.outputs.branch }}
+                  e2e_tests_repo_branch: ${{ inputs.e2e_tests_repo_branch || 'MAIN' }}
                   gpg_password: ${{ secrets.E2E_GPG_PASSWORD }}
                   gpg_cipher: AES256
               env:

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -36,7 +36,7 @@ jobs:
               if: github.event_name == 'pull_request_review'
               run: |
                   count="$(gh pr view "$PR" --repo "$REPO" --json latestReviews --jq '.latestReviews | map(select(.state == "APPROVED")) | length')"
-                  echo "count=$count" >> "$GITHUB_OUTPUT"
+                  echo count="$count" >> "$GITHUB_OUTPUT"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   REPO: ${{ github.event.pull_request.head.repo.full_name }}
@@ -45,6 +45,8 @@ jobs:
     branch:
         name: Get branch ref
         runs-on: ubuntu-22.04
+        needs: check
+        if: github.event_name != 'pull_request_review' || needs.check.outputs.approvals == '1'
         outputs:
             ref: |-
                 ${{ steps.pull_request_review.outputs.branch || steps.issue_comment.outputs.branch || steps.workflow_dispatch.outputs.branch }}

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -5,6 +5,16 @@ on:
         types: [submitted]
     issue_comment:
         types: [created]
+    workflow_dispatch:
+        inputs:
+            cafe_repo_branch:
+                description: 'Cafe branch to use? (default: DEV)'
+                type: string
+                required: false
+            e2e_repo_branch:
+                description: 'E2E branch to use? (default: MAIN)'
+                type: string
+                required: false
 
 jobs:
     run-tests:
@@ -18,7 +28,8 @@ jobs:
             (
                 github.event.issue.pull_request &&
                 contains(github.event.comment.body, '/run-e2e')
-            )
+            ) ||
+            github.event_name == 'workflow_dispatch'
         # avoid excessively high timeout values to avoid burning minutes
         timeout-minutes: 60
         steps:
@@ -35,27 +46,33 @@ jobs:
             - id: get-branch
               name: Get Branch Ref of the Pull Request
               run: |
-                  if [ ! -z "${HEAD_REF}" ]
-                  then
-                    echo "Found branch name in github.event.pull_request.head.ref"
-                    echo branch="$HEAD_REF" >> $GITHUB_OUTPUT
-                  else
-                    branch=$(gh pr view $PR --repo $REPO --json headRefName --jq '.headRefName')
-                    echo "Found branch using gh cli: $branch"
-                    echo branch="$branch" >> $GITHUB_OUTPUT
+                  if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
+                      echo "Found branch name in \$GITHUB_REF_NAME: $GITHUB_REF_NAME"
+                      echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+                      exit 0
                   fi
+                  # if condition earlier takes care of 'approved'-only PR submissions
+                  if [ $GITHUB_EVENT_NAME" == "pull_request_review" ]; then
+                      branch="$(gh pr view $GITHUB_PR --repo $GITHUB_REPO --json headRefName --jq '.headRefName')"
+                      echo "Found branch using gh cli: $branch"
+                      echo "branch=$branch" >> $GITHUB_OUTPUT
+                      exit 0
+                  fi
+                  echo "Could not obtain branch name!"
+                  exit 1
               env:
-                  HEAD_REF: ${{ github.event.pull_request.head.ref }}
-                  PR: ${{ github.event.issue.number }}
-                  REPO: ${{ github.repository }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_REF: ${{ env.GITHUB_REF }}
+                  GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+                  GITHUB_PR: ${{ github.event.issue.number }}
+                  GITHUB_REPO: ${{ github.repository }}
             - id: run-e2e
               name: Run tests
               uses: eventespresso/actions/packages/e2e-tests@main
               with:
-                  cafe_repo_branch: DEV
+                  cafe_repo_branch: ${{ inputs.cafe_repo_branch || 'DEV' }}
                   barista_repo_branch: ${{ steps.get-branch.outputs.branch }}
-                  e2e_tests_repo_branch: MAIN
+                  e2e_tests_repo_branch: ${{ inputs.e2e_repo_branch || 'MAIN' }}
                   gpg_password: ${{ secrets.E2E_GPG_PASSWORD }}
                   gpg_cipher: AES256
               env:

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -28,11 +28,11 @@ jobs:
             branch: |-
                 ${{ steps.pull_request_review.outputs.branch || steps.issue_comment.outputs.branch || steps.workflow_dispatch.outputs.branch }}
         steps:
-            - name: "Event: 'pull_request_review' Activity: 'submitted'"
+            - name: "Event: 'pull_request_review' Activity: 'submitted' State: 'Approved'"
               id: pull_request_review
-              if: github.event_name == 'pull_request_review'
+              if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
               run: echo branch="${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
-            - name: "Event: 'issue_comment' Activity: 'created'"
+            - name: "Event: 'issue_comment' Activity: 'created' Type: 'Pull Request' Comment Body: '/run-e2e' (contains)"
               id: issue_comment
               if: |
                   github.event_name == 'issue_comment' &&
@@ -55,6 +55,7 @@ jobs:
         runs-on: ubuntu-22.04
         timeout-minutes: 60
         needs: check
+        if: needs.check.outputs.branch
         steps:
             - name: Setup SSH for git
               uses: MrSquaare/ssh-setup-action@v2

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -24,8 +24,29 @@ jobs:
     check:
         name: Check conditions
         runs-on: ubuntu-22.04
+        if: |
+            github.event.review.state == 'approved' ||
+            contains(github.event.comment.body, '/run-e2e') ||
+            github.event_name == 'workflow_dispatch'
         outputs:
-            branch: |-
+            approvals: ${{ steps.approvals.outputs.count }}
+        steps:
+            - name: Get PR approvals count (event 'pull_request_review' only!)
+              id: approvals
+              if: github.event_name == 'pull_request_review'
+              run: |
+                  count="$(gh pr view "$PR" --repo "$REPO" --json latestReviews --jq '.latestReviews | map(select(.state == "APPROVED")) | length')"
+                  echo "count=$count" >> "$GITHUB_OUTPUT"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.event.pull_request.head.repo.name }}
+                  PR: ${{ github.event.pull_request.number }}
+
+    branch:
+        name: Get branch ref
+        runs-on: ubuntu-22.04
+        outputs:
+            ref: |-
                 ${{ steps.pull_request_review.outputs.branch || steps.issue_comment.outputs.branch || steps.workflow_dispatch.outputs.branch }}
         steps:
             - name: "Event: 'pull_request_review' Activity: 'submitted' State: 'Approved'"
@@ -54,10 +75,10 @@ jobs:
         name: Run E2E tests
         runs-on: ubuntu-22.04
         timeout-minutes: 60
-        needs: check
-        if: needs.check.outputs.branch
+        needs: branch
+        if: needs.branch.outputs.ref
         concurrency:
-            group: ${{ github.workflow }}-${{ needs.check.outputs.branch }}
+            group: ${{ github.workflow }}-${{ needs.branch.outputs.ref }}
             cancel-in-progress: ${{ github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch' }}
         steps:
             - name: Setup SSH for git
@@ -66,12 +87,12 @@ jobs:
                   host: github.com
                   private-key: ${{ secrets.GH_ACTIONS_SSH_PRIVATE_KEY }}
             - name: Check branch ref
-              run: test "${{ needs.check.outputs.branch }}"
+              run: test "${{ needs.branch.outputs.ref }}"
             - name: Run tests
               uses: eventespresso/actions/packages/e2e-tests@main
               with:
                   cafe_repo_branch: ${{ inputs.cafe_repo_branch || 'DEV' }}
-                  barista_repo_branch: ${{ inputs.barista_repo_branch || needs.check.outputs.branch }}
+                  barista_repo_branch: ${{ inputs.barista_repo_branch || needs.branch.outputs.ref }}
                   e2e_tests_repo_branch: ${{ inputs.e2e_tests_repo_branch || 'MAIN' }}
                   gpg_password: ${{ secrets.E2E_GPG_PASSWORD }}
                   gpg_cipher: AES256

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -39,7 +39,7 @@ jobs:
                   echo "count=$count" >> "$GITHUB_OUTPUT"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  REPO: ${{ github.event.pull_request.head.repo.name }}
+                  REPO: ${{ github.event.pull_request.head.repo.full_name }}
                   PR: ${{ github.event.pull_request.number }}
 
     branch:


### PR DESCRIPTION
This PR will allow [manually triggering](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) E2E job with the option to override Cafe and E2E branches. As per GitHub's limitation, this will become enabled once it is merged:

> To trigger the `workflow_dispatch` event, your workflow must be in the default branch.

https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#configuring-a-workflow-to-run-manually