### PR TITLE
Extract Feature Flag Details

### DIFF
--- a/lib/FeatureFlagsConfigForm.php
+++ b/lib/FeatureFlagsConfigForm.php
@@ -20,69 +20,7 @@ class FeatureFlagsConfigForm extends EE_Form_Section_Proper
 	public function __construct(FeatureFlagsConfig $feature_flags_config)
 	{
 		$feature_flags = $feature_flags_config->getFeatureFlags();
-		$feature_flags_form_options = [
-			FeatureFlagsConfig::USE_EVENT_EDITOR_BULK_EDIT => [
-				'name' => esc_html__('Event Editor Bulk Edit','event_espresso'),
-				'html_label_text' => esc_html__('Use Event Editor Bulk Edit','event_espresso'),
-				'help_text' => sprintf(
-					esc_html__(
-						'Whether to enable the Bulk Edit feature in the Advanced Event Editor (EDTR).%1$s%2$sPLEASE NOTE: Bulk Editing is ALWAYS enabled if the Recurring Events Manager add-on is active.%3$s%1$s default: Enabled for Caffeinated sites, disabled for Decaf or Multisite installs',
-						'event_espresso'
-					),
-					'<br/>',
-					'<strong>',
-					'</strong>'
-				)
-			],
-			FeatureFlagsConfig::USE_DEFAULT_TICKET_MANAGER => [
-				'name' => esc_html__('Default Ticket Manager','event_espresso'),
-				'html_label_text' => esc_html__('Use Default Ticket Manager','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the new Default Ticket Manager in the EDTR. default: Enabled',
-					'event_espresso'
-				)
-			],
-			FeatureFlagsConfig::USE_EVENT_DESCRIPTION_RTE => [
-				'name' => esc_html__('Event Description RTE','event_espresso'),
-				'html_label_text' => esc_html__('Use Rich Text Editor for Event Description','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the Rich Text Editor for the Event Description field in the EDTR or use tinymce. default: Disabled',
-					'event_espresso'
-				)
-			],
-			FeatureFlagsConfig::USE_EXPERIMENTAL_RTE => [
-				'name' => esc_html__('Rich Text Editor','event_espresso'),
-				'html_label_text' => esc_html__('Use Rich Text Editor for other RTE fields','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the Rich Text Editor for all other RTE fields in the EDTR. default: Disabled',
-					'event_espresso'
-				)
-			],
-			FeatureFlagsConfig::USE_REG_FORM_BUILDER => [
-				'name' => esc_html__('Registration Form Builder','event_espresso'),
-				'html_label_text' => esc_html__('Use Registration Form Builder','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the new Registration Form Builder in the EDTR or continue using the legacy Question Groups and Registration Form admin pages. default: Disabled',
-					'event_espresso'
-				)
-			],
-			FeatureFlagsConfig::USE_REG_OPTIONS_META_BOX => [
-				'name' => esc_html__('Registration Options','event_espresso'),
-				'html_label_text' => esc_html__('Use Registration Options','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to enable the new Registration Options meta box in the EDTR or continue using the legacy Event Registration Options. default: Disabled',
-					'event_espresso'
-				)
-			],
-			FeatureFlagsConfig::USE_EDD_PLUGIN_LICENSING => [
-				'name' => esc_html__('EDD Plugin Licensing','event_espresso'),
-				'html_label_text' => esc_html__('Use EDD Plugin Licensing','event_espresso'),
-				'help_text' => esc_html__(
-					'Whether to use the EDD Plugin Licensing system to manage licenses for the EE plugins. default: Disabled',
-					'event_espresso'
-				)
-			],
-		];
+		$feature_flags_form_options = $feature_flags_config->getFeatureFlagsFormOptions();
 
 		$subsections = [
 			'header' => new EE_Form_Section_HTML(EEH_HTML::h3(__('Feature Flags', 'event_espresso')))


### PR DESCRIPTION
Currently, Feature Flags (FFs) are defined in Core, but the FF admin is part of the Barista EE plugin. The FF form options were also defined in the Barista plugin. This is awkward because whenever a new FF is added, you need to add the FF to core as well as update the Barista plugin to add the new FF to the FF admin page form. 

This PR:

- extracts the FF form options from the Barista plugin
- the Cafe branch `MOD/CORE/feature-flags-form-options` adds the FF form options to a new FeatureFlag class

So now, we only need to add new FFs to core, and the FF admin will just work without any further modifications