### PR TITLE
Fix typo in e2e workflow

### DIFF
--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -20,7 +20,7 @@ on:
                 type: string
                 required: false
             ddev_version:
-                description: Which version of DDEV to use? (defaults to latest version)
+                description: Which version of DDEV to use? (defaults to version '1.22.6')
                 type: string
                 required: false
 


### PR DESCRIPTION
DDEV defaults to version `1.22.6`, _not_ latest version. This PR fixes typo when manually triggering e2e CI check.