### PR TITLE
Fix Feature Flags Admin

### DIFF
--- a/ee-barista.php
+++ b/ee-barista.php
@@ -30,7 +30,7 @@ define('EE_BARISTA_DIR', trailingslashit(plugin_dir_path(__FILE__)));
 define('EE_BARISTA_URL', trailingslashit(plugins_url('', __FILE__)));
 
 add_action(
-    'AHEE__EE_System__load_espresso_addons',
+    'AHEE__EventEspresso_core_services_bootstrap_BootstrapCore___construct',
     function () {
 		EE_Psr4AutoloaderInit::psr4_loader()->addNamespace('EventEspresso\Barista', __DIR__. '/lib');
         $barista = new EventEspresso\Barista\Barista();

--- a/lib/FeatureFlagsAdminPage.php
+++ b/lib/FeatureFlagsAdminPage.php
@@ -86,16 +86,13 @@ class FeatureFlagsAdminPage
 			$form->receive_form_submission($_REQUEST);
 			if ($form->is_valid()) {
 				$feature_flags_form_options = $form->valid_data();
-				// $feature_flags = $feature_flags_config->getFeatureFlags();
-				$success       = true;
 				foreach ($feature_flags_form_options as $feature_flag => $value) {
 					$result = WordPressOption::UPDATE_NONE;
 					if ($feature_flag) {
 						$result = $value === EE_Switch_Input::OPTION_ON
-							? $feature_flags_config->enableFeatureFlag($feature_flag, true)
-							: $feature_flags_config->disableFeatureFlag($feature_flag);
+							? $feature_flags_config->enableFeatureFlag($feature_flag, true, false)
+							: $feature_flags_config->disableFeatureFlag($feature_flag, false);
 					}
-					$success = $result === WordPressOption::UPDATE_ERROR ? $result : $success;
 					if ($result === WordPressOption::UPDATE_ERROR) {
 						EE_Error::add_error(
 							sprintf(
@@ -113,7 +110,7 @@ class FeatureFlagsAdminPage
 						break;
 					}
 				}
-				if ($success) {
+				if ($feature_flags_config->saveFeatureFlagsConfig()) {
 					EE_Error::add_success(esc_html__('Feature Flags updated successfully.', 'event_espresso'));
 				}
 				EEH_URL::safeRedirectAndExit(

--- a/lib/FeatureFlagsConfigForm.php
+++ b/lib/FeatureFlagsConfigForm.php
@@ -33,7 +33,8 @@ class FeatureFlagsConfigForm extends EE_Form_Section_Proper
 						: EE_Switch_Input::OPTION_OFF,
 					'html_name'       => $id,
 					'html_label_text' => $feature_flags_form_option['html_label_text'],
-					'html_help_text'  => $feature_flags_form_option['help_text'],
+					'html_help_text'  => $feature_flags_form_option['help_text'] . $feature_flags_form_option['overridden_by'],
+					'disabled'        => $feature_flags_form_option['overridden'],
 				],
 				[
 					EE_Switch_Input::OPTION_OFF => sprintf(

--- a/lib/FeatureFlagsConfigForm.php
+++ b/lib/FeatureFlagsConfigForm.php
@@ -19,22 +19,23 @@ class FeatureFlagsConfigForm extends EE_Form_Section_Proper
 {
 	public function __construct(FeatureFlagsConfig $feature_flags_config)
 	{
-		$feature_flags = $feature_flags_config->getFeatureFlags();
+		$feature_flags              = $feature_flags_config->getFeatureFlags();
 		$feature_flags_form_options = $feature_flags_config->getFeatureFlagsFormOptions();
 
 		$subsections = [
-			'header' => new EE_Form_Section_HTML(EEH_HTML::h3(__('Feature Flags', 'event_espresso')))
+			'header' => new EE_Form_Section_HTML(EEH_HTML::h3(__('Feature Flags', 'event_espresso'))),
 		];
 		foreach ($feature_flags_form_options as $id => $feature_flags_form_option) {
-			$subsections[$id] = new EE_Switch_Input(
+			$subsections[ $id ] = new EE_Switch_Input(
 				[
-					'default'        => $feature_flags->{$id}
+					'default'         => $feature_flags->{$id}
 						? EE_Switch_Input::OPTION_ON
 						: EE_Switch_Input::OPTION_OFF,
 					'html_name'       => $id,
 					'html_label_text' => $feature_flags_form_option['html_label_text'],
-					'html_help_text'  => $feature_flags_form_option['help_text'] . $feature_flags_form_option['overridden_by'],
-					'disabled'        => $feature_flags_form_option['overridden'],
+					'html_help_text'  => $feature_flags_form_option['help_text']
+						. ($feature_flags_form_option['overridden_by'] ?? ''),
+					'disabled'        => $feature_flags_form_option['overridden'] ?? false,
 				],
 				[
 					EE_Switch_Input::OPTION_OFF => sprintf(


### PR DESCRIPTION
Discovered that the Feature Flags admin was not working properly because the Barista add-on was being initialized too late in the core loading process. This prevented the ability to manage feature flags properly.

### This PR:

- loads and initializes the Barista add-on during the Core bootstrapping process
- adds override notice to admin form inputs and disables FF switches if overridden
- only updates FF config once after making all changes

> [!IMPORTANT]
> ~This PR requires Cafe branch: `NEW/CORE/easy-digital-downloads`~
> This PR now works with Cafe `DEV` branch