### PR TITLE
Add ItemCount to Datetime Registrations Link

### DIFF
--- a/domains/core/admin/eventEditor/src/ui/datetimes/datesList/DateRegistrationsLink.tsx
+++ b/domains/core/admin/eventEditor/src/ui/datetimes/datesList/DateRegistrationsLink.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@eventespresso/i18n';
-import { RegistrationsLink } from '@eventespresso/ui-components';
-import { useRegistrationsLink } from '@eventespresso/edtr-services';
+import { RegistrationsLink, ItemCount } from '@eventespresso/ui-components';
+import { useRegistrationsLink, useRelatedTickets } from '@eventespresso/edtr-services';
 import type { Datetime } from '@eventespresso/edtr-services';
 
 interface Props {
@@ -8,9 +8,26 @@ interface Props {
 }
 
 export const DateRegistrationsLink: React.FC<Props> = ({ datetime }) => {
+	const getRelatedTickets = useRelatedTickets();
+
+	const tickets = getRelatedTickets({
+		entity: 'datetimes',
+		entityId: datetime.id,
+	});
+
+	let count = 0;
+	for (const ticket of tickets) {
+		count += ticket.registrationCount;
+	}
+
 	const regListUrl = useRegistrationsLink({ datetime_id: datetime.dbId });
 
+	const countTitle = __('total registrations.');
 	const tooltip = __('view ALL registrations for this date.');
 
-	return <RegistrationsLink href={regListUrl} tooltip={tooltip} />;
+	return (
+		<ItemCount count={count} emphasizeZero={false} title={countTitle}>
+			<RegistrationsLink href={regListUrl} tooltip={tooltip} />
+		</ItemCount>
+	);
 };


### PR DESCRIPTION
### this PR:

- closes https://github.com/eventespresso/cafe/issues/1233
- adds item count to the datetimes reg link
  ![image](https://github.com/eventespresso/barista/assets/1751030/e72aa846-f238-4493-9583-91714f41d42b)


### testing notes

- load up an event that has multiple registrations
- [ ] confirm that the "Reg List" link in the datedetails panel now shows an item count
- click on link to visit reg list for that datetime
- [ ] confirm that items count at reg list table matches that displayed on datetimes reg link