### PR TITLE
Fix FormattedPrice component not being editable

### DIFF
--- a/packages/adapters/src/NumberInput/types.ts
+++ b/packages/adapters/src/NumberInput/types.ts
@@ -2,7 +2,7 @@ import type * as Chakra from '@chakra-ui/react';
 
 import type { CommonInputProps } from '../types';
 
-type CharaProps = Pick<
+type ChakraProps = Pick<
 	Chakra.NumberInputProps,
 	| 'aria-valuenow'
 	| 'clampValueOnBlur'
@@ -19,7 +19,7 @@ type CharaProps = Pick<
 	| 'onBlur'
 >;
 
-export interface NumberInputProps extends CharaProps, CommonInputProps<HTMLInputElement> {
+export interface NumberInputProps extends ChakraProps, CommonInputProps<HTMLInputElement> {
 	decrementStepperProps?: Chakra.BoxProps;
 	disabled?: boolean;
 	incrementStepperProps?: Chakra.BoxProps;

--- a/packages/adapters/src/NumberInput/types.ts
+++ b/packages/adapters/src/NumberInput/types.ts
@@ -1,13 +1,9 @@
-import type {
-	FlexProps as ChakraFlexProps,
-	InputProps as ChakraInputProps,
-	NumberInputProps as ChakraNumberInputProps,
-	BoxProps as ChakraBoxProps,
-} from '@chakra-ui/react';
+import type * as Chakra from '@chakra-ui/react';
 
 import type { CommonInputProps } from '../types';
 
-type Picked =
+type CharaProps = Pick<
+	Chakra.NumberInputProps,
 	| 'aria-valuenow'
 	| 'clampValueOnBlur'
 	| 'className'
@@ -19,14 +15,15 @@ type Picked =
 	| 'min'
 	| 'precision'
 	| 'step'
-	| 'value';
+	| 'value'
+>;
 
-export interface NumberInputProps extends Pick<ChakraNumberInputProps, Picked>, CommonInputProps<HTMLInputElement> {
-	decrementStepperProps?: ChakraBoxProps;
+export interface NumberInputProps extends CharaProps, CommonInputProps<HTMLInputElement> {
+	decrementStepperProps?: Chakra.BoxProps;
 	disabled?: boolean;
-	incrementStepperProps?: ChakraBoxProps;
-	inputFieldProps?: ChakraInputProps;
-	inputStepperProps?: ChakraFlexProps;
+	incrementStepperProps?: Chakra.BoxProps;
+	inputFieldProps?: Chakra.InputProps;
+	inputStepperProps?: Chakra.FlexProps;
 	name?: string;
 	/**
 	 * The pattern used to check the <input> element's value against on form submission.

--- a/packages/adapters/src/NumberInput/types.ts
+++ b/packages/adapters/src/NumberInput/types.ts
@@ -16,6 +16,7 @@ type CharaProps = Pick<
 	| 'precision'
 	| 'step'
 	| 'value'
+	| 'onBlur'
 >;
 
 export interface NumberInputProps extends CharaProps, CommonInputProps<HTMLInputElement> {

--- a/packages/services/src/hooks/useMoneyDisplay.ts
+++ b/packages/services/src/hooks/useMoneyDisplay.ts
@@ -6,13 +6,13 @@ import type { FormatAmountFunction } from '@eventespresso/utils';
 import type { Type as ConfigType } from '@eventespresso/config';
 
 export interface MoneyDisplay {
-	// the currency sign if the currency displays it before the amount (or '')
+	/** the currency sign if the currency displays it before the amount (or '') */
 	afterAmount: string;
-	// the currency sign if the currency displays it before the amount (or '')
+	/** the currency sign if the currency displays it before the amount (or '') */
 	beforeAmount: string;
-	// the full currency config object
+	/** the full currency config object */
 	currency: ConfigType.Currency;
-	// function for formatting the amount using the correct number of decimal places for the currency
+	/** function for formatting the amount using the correct number of decimal places for the currency */
 	formatAmount: FormatAmountFunction;
 }
 

--- a/packages/tpc/src/components/price/factory/IsPropsType.ts
+++ b/packages/tpc/src/components/price/factory/IsPropsType.ts
@@ -1,4 +1,4 @@
-import type { Type, Props } from '.';
+import type { Type } from '.';
 
 export const IsPropsType = {
 	Component: {

--- a/packages/tpc/src/components/price/factory/IsPropsType.ts
+++ b/packages/tpc/src/components/price/factory/IsPropsType.ts
@@ -8,13 +8,6 @@ export const IsPropsType = {
 			Number: ComponentNumberInput,
 		},
 	},
-	Hook: {
-		Select: HookSelect,
-		Input: {
-			Text: HookTextInput,
-			Number: HookNumberInput,
-		},
-	},
 };
 
 type Key = Type.Factory.Key; // alias
@@ -37,26 +30,5 @@ function ComponentTextInput(props: C.Props.Any): props is C.Props.G<'Text'> {
 }
 
 function ComponentNumberInput(props: C.Props.Any): props is C.Props.G<'Number'> {
-	return props._type === 'Number';
-}
-
-// H = hook, alias
-module H {
-	export module Props {
-		export type Any = Type.Factory.Hook.Props<Key>;
-		// G = generic, alias
-		export type G<K extends Key> = Type.Factory.Hook.Props<K>;
-	}
-}
-
-function HookSelect(props: H.Props.Any): props is Props.Type & { _type: 'Select' } {
-	return props._type === 'Select';
-}
-
-function HookTextInput(props: H.Props.Any): props is H.Props.G<'Text'> {
-	return props._type === 'Text';
-}
-
-function HookNumberInput(props: H.Props.Any): props is H.Props.G<'Number'> {
 	return props._type === 'Number';
 }

--- a/packages/tpc/src/components/price/factory/types.ts
+++ b/packages/tpc/src/components/price/factory/types.ts
@@ -12,14 +12,6 @@ export module Type {
 
 			// LATER: skip type 'Type' for now
 		}
-
-		export module Hook {
-			export type Props<K extends Key> = Type.Inputs.Map[K]['Hook']['Props'] & {
-				_type: K; // internal prop hence underscore
-			};
-
-			export type Type<K extends Key> = Type.Inputs.Map[K]['Hook']['Type'];
-		}
 	}
 
 	export module Inputs {
@@ -39,27 +31,11 @@ export module Type {
 		Component: {
 			Props: Component.Props<A>;
 		};
-		Hook: {
-			Props: Hook.Props;
-			Type: Hook.Type<A, V>;
-		};
 	};
 }
 
 module Component {
 	export type Props<H extends Attribute.Html> = Props.Type & H & AriaLabel;
-}
-
-module Hook {
-	export type Props = Props.Type;
-	export type Type<A extends Attribute.Html, V extends Value> = {
-		name: Name;
-		value: V;
-		handlers: {
-			onChange: A['onChange'];
-			onBlur?: A['onBlur'];
-		};
-	};
 }
 
 module Attribute {

--- a/packages/tpc/src/components/price/factory/types.ts
+++ b/packages/tpc/src/components/price/factory/types.ts
@@ -35,7 +35,10 @@ export module Type {
 }
 
 module Component {
-	export type Props<H extends Attribute.Html> = Props.Type & H & AriaLabel;
+	export type Props<H extends Attribute.Html> = H &
+		AriaLabel & {
+			name: string;
+		};
 }
 
 module Attribute {
@@ -49,13 +52,5 @@ module Element {
 	export type Input = HTMLInputElement;
 	export type Select = HTMLSelectElement;
 }
-
-module Props {
-	export type Type = {
-		name: Name;
-	};
-}
-
-type Name = string;
 
 type AriaLabel = Required<Pick<AriaAttributes, 'aria-label'>>;

--- a/packages/tpc/src/components/price/factory/types.ts
+++ b/packages/tpc/src/components/price/factory/types.ts
@@ -23,11 +23,11 @@ export module Type {
 		};
 	}
 
-	type Select = Make<SelectProps, string>;
-	type InputText = Make<TextInputWithLabelProps, string>;
-	type InputNumber = Make<NumberProps, number>;
+	type Select = Make<SelectProps>;
+	type InputText = Make<TextInputWithLabelProps>;
+	type InputNumber = Make<NumberProps>;
 
-	type Make<A extends object, V extends Value> = {
+	type Make<A extends object> = {
 		Component: {
 			Props: Component.Props<A>;
 		};
@@ -57,7 +57,5 @@ export module Props {
 }
 
 type Name = string;
-
-type Value = string | number | boolean;
 
 type AriaLabel = Required<Pick<AriaAttributes, 'aria-label'>>;

--- a/packages/tpc/src/components/price/factory/types.ts
+++ b/packages/tpc/src/components/price/factory/types.ts
@@ -3,24 +3,24 @@ import type { InputHTMLAttributes, SelectHTMLAttributes, AriaAttributes, HTMLAtt
 
 export module Type {
 	export module Factory {
-		export type Key = Type.Inputs.Key; // alias
+		export type Key = Inputs.Key; // alias
 
 		export module Component {
-			export type Props<K extends Key> = Type.Inputs.Map[K]['Component']['Props'] & {
+			export type Props<K extends Key> = Inputs.Map[K]['Component']['Props'] & {
 				_type: K; // underscore to avoid collission with html attribute
 			};
 
 			// LATER: skip type 'Type' for now
 		}
-	}
 
-	export module Inputs {
-		export type Key = keyof Map;
-		export type Map = {
-			Select: Select;
-			Text: InputText;
-			Number: InputNumber;
-		};
+		module Inputs {
+			export type Key = keyof Map;
+			export type Map = {
+				Select: Select;
+				Text: InputText;
+				Number: InputNumber;
+			};
+		}
 	}
 
 	type Select = Make<SelectProps>;
@@ -50,7 +50,7 @@ module Element {
 	export type Select = HTMLSelectElement;
 }
 
-export module Props {
+module Props {
 	export type Type = {
 		name: Name;
 	};


### PR DESCRIPTION
[jump to support testing instructions](#testing-instructions)

### Fixes

- https://github.com/eventespresso/barista/pull/1312#issuecomment-2135703002 <!-- issue ID or PR ID -->

### Smoke Test

- [x] does it build?
- [x] does it pass linter? <!-- check *all* packages  -->
- [x] does it pass unit tests? <!-- run *all* unit tests -->
- [x] does it pass end-to-end tests? <!-- run *all* e2e tests -->

### Assess Scope

- [x] make a list of the modified files <!-- section below -->
- [x] do testing instructions include all modified files?
- [x] ~are all consumer of modified files being tested tested?~ (only direct consumers)

### Modified Files

<!-- git diff -\-name-only HEAD..master -->

Types:
- packages/adapters/src/NumberInput/types.ts
- packages/tpc/src/components/price/factory/types.ts

Hooks and Functions:
- ~packages/services/src/hooks/useMoneyDisplay.ts~ (ignore, just comment change)
- packages/tpc/src/components/price/factory/IsPropsType.ts

Components:
- packages/tpc/src/components/price/input/FormattedPrice.tsx

### Testing Instructions (Developers)

#### types.ts (all files), IsPropsType.ts

Tested by @alexkuc locally as it is technical task

- confirmed that test files do not produce errors by opening them in Visual Studio Code
- performed the same step for consumers of the aforementioned files
- compiled assets locally to confirm types are okay

<h3 id="testing-instructions">Testing Instructions (Support)</h3>

#### FormattedPrice.tsx

- go to backend -> EE -> Events -> click `Add New Event`
- scroll down until you see section `Available Tickets`
- click `Add New Ticket`
- click `Set Ticket Prices`
- click `Add Default Prices`

- [ ] confirm that changes in price fields\* (red arrow) correctly reflects in total price (green arrow)
![image](https://github.com/eventespresso/barista/assets/3331946/7453ffb4-d31a-4bb6-bed0-3fb1487e3def)
- [ ] confirm that changes in total price field in bottom-up approach (green arrow) correctly updates price fields\* (red arrow)
![image](https://github.com/eventespresso/barista/assets/3331946/908ce036-ee82-494a-a9c5-6fefda9a2d6c)

\* please try different fields such as `Dollar Surcharge`, `Dollar Discount`, etc. Do NOT just try default field.

